### PR TITLE
test: Layer 1 + 2 regression harness (pure-logic + trait-level) and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: ci
+
+# Per-change regression gate. Unlike release.yml (tags only), this runs the
+# test suite on every push to main and on PRs, so a logic regression is caught
+# before it reaches a release rather than at tag time. Linux runs the
+# platform-independent tests fast and free; macOS runs the full suite including
+# the macOS-gated pure-logic tests.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+  CARGO_NET_RETRY: '10'
+  RUST_BACKTRACE: '1'
+
+jobs:
+  test-linux:
+    name: test (linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: '1.95.0'
+          components: rustfmt
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      # Cheap per-push format gate. release.yml only checks fmt at tag time, so a
+      # formatting slip used to surface as a failed release tag; catch it here.
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      # The platform-independent tests (pure logic + the non-macOS stub trait
+      # tests) run here. RUSTFLAGS is cleared because the macOS stubs leave some
+      # macOS-only items unused on Linux by design — same rationale as the
+      # release lint job's cross-compile check.
+      - name: Test (Linux stubs)
+        env:
+          RUSTFLAGS: ''
+        run: cargo test --locked
+
+  test-macos:
+    name: test (macos)
+    runs-on: macos-14   # Apple Silicon
+    timeout-minutes: 30
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit # macOS runners only support audit mode
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: '1.95.0'
+          target: aarch64-apple-darwin
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: aarch64-apple-darwin
+
+      # Full suite including the macOS-gated pure-logic tests (resolve_dest,
+      # keyboard-layout parsing, h264 NAL conversion, aac, etc.). These are
+      # pure-logic and headless — they do NOT require Screen Recording /
+      # Accessibility TCC grants (the capture/input/audio loops aren't unit
+      # tested). RUSTFLAGS keeps the default (-D warnings) so a warning in test
+      # code fails here too, matching the macOS clippy gate in release.yml.
+      - name: Test (macOS — full code paths)
+        env:
+          RUSTFLAGS: '-D warnings'
+        run: cargo test --locked --target aarch64-apple-darwin

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -188,26 +188,53 @@ struct MacRdpsndBackend {
     target_display_id: Option<u32>,
 }
 
+/// Negotiate the audio format to send the client.
+///
+/// Walks the `server` list (which is ordered by our preference — AAC ahead of
+/// PCM) and picks the first format the `client` also advertised. Returns
+/// `(server_idx, wFormatNo)` where `server_idx` indexes our list (so the caller
+/// knows what to encode) and `wFormatNo` is that format's position in the
+/// **client's** list — the value that goes on the wire.
+///
+/// `wFormatNo` MUST index the client's own Client Audio Formats list, NOT our
+/// server list: the client resolves each wave's codec as
+/// `ClientFormats[wFormatNo]`, and FreeRDP/Thincast hard-reject
+/// `wFormatNo >= NumberOfClientFormats` (verified in `rdpsnd_recv_wave2_pdu`).
+/// A PCM-only client (1 format) silently dropped every wave when we sent PCM's
+/// *server* index (1, once AAC took slot 0); mstsc tolerated the server index
+/// only because the lists coincided while we advertised a single format.
+///
+/// Pure (no platform deps, no shared state) so it's unit-tested on every
+/// target. Returns `None` when the client accepted none of our formats.
+fn choose_audio_format(server: &[AudioFormat], client: &[AudioFormat]) -> Option<(usize, u16)> {
+    let fmt_eq = |a: &AudioFormat, b: &AudioFormat| {
+        a.format == b.format
+            && a.n_channels == b.n_channels
+            && a.n_samples_per_sec == b.n_samples_per_sec
+            && a.bits_per_sample == b.bits_per_sample
+    };
+    let server_idx = server
+        .iter()
+        .position(|sf| client.iter().any(|cf| fmt_eq(cf, sf)))?;
+    let chosen = &server[server_idx];
+    // Can't fail in practice — `chosen` was matched from `client` above — but
+    // fold it into the Option rather than panicking on a hostile/odd list.
+    let format_no = client.iter().position(|cf| fmt_eq(cf, chosen))?;
+    let format_no = u16::try_from(format_no).ok()?;
+    Some((server_idx, format_no))
+}
+
 impl RdpsndServerHandler for MacRdpsndBackend {
     fn get_formats(&self) -> &[AudioFormat] {
         &self.formats
     }
 
     fn start(&mut self, client_format: &ClientAudioFormatPdu) -> Option<u16> {
-        let fmt_eq = |a: &AudioFormat, b: &AudioFormat| {
-            a.format == b.format
-                && a.n_channels == b.n_channels
-                && a.n_samples_per_sec == b.n_samples_per_sec
-                && a.bits_per_sample == b.bits_per_sample
-        };
-
-        // Choose which format to send: walk OUR list (AAC ahead of PCM) and
-        // take the first one the client also advertised. This drives the
-        // AAC-vs-PCM preference and tells the capture loop what to encode.
-        let Some(server_idx) = self
-            .formats
-            .iter()
-            .position(|sf| client_format.formats.iter().any(|cf| fmt_eq(cf, sf)))
+        // Negotiate which format to send (see `choose_audio_format`): server
+        // preference (AAC ahead of PCM), returning the wire `wFormatNo` indexed
+        // against the CLIENT's list. The capture loop then encodes `chosen`.
+        let Some((server_idx, format_no)) =
+            choose_audio_format(&self.formats, &client_format.formats)
         else {
             warn!(
                 client_formats = client_format.formats.len(),
@@ -217,26 +244,6 @@ impl RdpsndServerHandler for MacRdpsndBackend {
         };
         let chosen = &self.formats[server_idx];
         let use_aac = chosen.format == WaveFormat::AAC_MS;
-
-        // wFormatNo on the wire must index the CLIENT's own format list (the
-        // Client Audio Formats PDU it sent back), NOT our server list. The
-        // client resolves the wave's format as `ClientFormats[wFormatNo]` and
-        // FreeRDP/Thincast hard-reject `wFormatNo >= NumberOfClientFormats`
-        // (verified in rdpsnd_recv_wave2_pdu) — so a PCM-only client (1
-        // format) silently dropped every wave when we sent PCM's *server*
-        // index (1, once AAC took slot 0). mstsc tolerated the server index
-        // only because the lists coincided while we advertised a single
-        // format. Translate the chosen format to its position in the client's
-        // list. (Defensive None: can't actually fail — server_idx was found by
-        // matching against this very list.)
-        let Some(format_no) = client_format
-            .formats
-            .iter()
-            .position(|cf| fmt_eq(cf, chosen))
-        else {
-            warn!("negotiated format not found in client list; no audio");
-            return None;
-        };
         debug!(
             format_no,
             server_idx,
@@ -301,7 +308,7 @@ impl RdpsndServerHandler for MacRdpsndBackend {
                 });
             })
             .expect("spawn audio capture thread");
-        Some(format_no as u16)
+        Some(format_no)
     }
 
     fn stop(&mut self) {
@@ -866,4 +873,43 @@ fn planar_f32_to_interleaved_i16(planar: &[Vec<f32>]) -> Vec<u8> {
 fn float_to_i16(v: f32) -> i16 {
     let clamped = v.clamp(-1.0, 1.0);
     (clamped * 32767.0).round() as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_aac_when_client_supports_both() {
+        // Server advertises [AAC, PCM]; a client that takes both → AAC chosen.
+        let server = [aac_format(128_000), pcm_format()];
+        let client = [aac_format(128_000), pcm_format()];
+        let (server_idx, format_no) = choose_audio_format(&server, &client).unwrap();
+        assert_eq!(server_idx, 0, "AAC is our top preference");
+        assert_eq!(format_no, 0, "AAC is at client index 0 here");
+        assert_eq!(server[server_idx].format, WaveFormat::AAC_MS);
+    }
+
+    #[test]
+    fn pcm_only_client_gets_correct_client_list_index() {
+        // The regression that silenced PCM clients: server is [AAC, PCM] so PCM
+        // is at SERVER index 1, but a PCM-only client lists PCM at index 0. The
+        // wire wFormatNo must be the CLIENT index (0), not the server index (1).
+        let server = [aac_format(128_000), pcm_format()];
+        let client = [pcm_format()];
+        let (server_idx, format_no) = choose_audio_format(&server, &client).unwrap();
+        assert_eq!(server_idx, 1, "PCM is the second server format");
+        assert_eq!(format_no, 0, "but PCM is index 0 in the client's own list");
+        assert_eq!(server[server_idx].format, WaveFormat::PCM);
+    }
+
+    #[test]
+    fn no_common_format_returns_none() {
+        // Server only offers AAC; a PCM-only client shares nothing → no audio.
+        let server = [aac_format(128_000)];
+        let client = [pcm_format()];
+        assert!(choose_audio_format(&server, &client).is_none());
+        // Empty client list → also None.
+        assert!(choose_audio_format(&server, &[]).is_none());
+    }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -315,6 +315,35 @@ pub async fn primary_display_size() -> Result<Option<(u16, u16)>> {
     }
 }
 
+/// Decide whether the auto-size path should adopt the client's requested
+/// desktop size. Pure (no platform deps, no shared state) so it's unit-tested
+/// on every target.
+///
+/// With `auto_size` on, the vendored acceptor has already negotiated the
+/// client's requested size (from its Client Core Data) in Demand Active, and
+/// the `client` size here is the client's Confirm Active echo of that. We adopt
+/// it so capture, input scaling, and the H.264 pipeline all serve the
+/// negotiated resolution. The `200..=8192` band is the protocol-legal desktop
+/// range (MS-RDPBCGR); an echo outside it is garbage we refuse to adopt, and a
+/// no-op echo (already current) needs no change.
+///
+/// Returns `Some(adopted)` to switch, or `None` to keep the current size.
+fn adopt_client_size(
+    auto_size: bool,
+    current: (u16, u16),
+    client: DesktopSize,
+) -> Option<DesktopSize> {
+    if auto_size
+        && (client.width, client.height) != current
+        && (200..=8192).contains(&client.width)
+        && (200..=8192).contains(&client.height)
+    {
+        Some(client)
+    } else {
+        None
+    }
+}
+
 #[async_trait::async_trait]
 impl RdpServerDisplay for CaptureDisplay {
     async fn size(&mut self) -> DesktopSize {
@@ -324,28 +353,17 @@ impl RdpServerDisplay for CaptureDisplay {
 
     async fn request_initial_size(&mut self, client_size: DesktopSize) -> DesktopSize {
         let (width, height) = self.desktop_size.get();
-        // With auto_size on, the vendored acceptor has already negotiated
-        // the client's requested size (from its Client Core Data) in Demand
-        // Active, and `client_size` here is the client's Confirm Active echo
-        // of that. Adopt it into the shared size so capture, input scaling,
-        // and the H.264 pipeline all serve the negotiated resolution. The
-        // 200..=8192 band is the protocol-legal desktop range (MS-RDPBCGR);
-        // an echo outside it is garbage we refuse to adopt.
-        if self.auto_size
-            && (client_size.width, client_size.height) != (width, height)
-            && (200..=8192).contains(&client_size.width)
-            && (200..=8192).contains(&client_size.height)
-        {
+        if let Some(adopted) = adopt_client_size(self.auto_size, (width, height), client_size) {
             tracing::info!(
-                client_w = client_size.width,
-                client_h = client_size.height,
+                client_w = adopted.width,
+                client_h = adopted.height,
                 prev_w = width,
                 prev_h = height,
                 "serving client-requested desktop resolution \
                  (--no-client-resolution disables)"
             );
-            self.desktop_size.set(client_size.width, client_size.height);
-            return client_size;
+            self.desktop_size.set(adopted.width, adopted.height);
+            return adopted;
         }
         DesktopSize { width, height }
     }
@@ -381,6 +399,40 @@ impl RdpServerDisplay for CaptureDisplay {
             None => inner,
         })
     }
+}
+
+/// Max pixels per emitted legacy `BitmapUpdate`. The bitmap encoder packs a
+/// whole rect into one update PDU (one RLE rectangle per ~`65535/(w*4)`
+/// rows); mstsc renders a single ~1280×720 (≈0.9 MP) update but DROPS a
+/// 1920×1080 (≈2.1 MP) one — a per-update size/rectangle-count limit — so
+/// the big initial full-frame paint of a virtual display never shows
+/// (only the small ticking-clock dirty-rects render). Splitting tall rects
+/// into strips at or below this proven-good size keeps every update
+/// renderable. FreeRDP accepts either; it just sees more, smaller updates.
+///
+/// Pure rect math (no platform deps) — lives at file scope so it is
+/// unit-tested on every target; `mod macos` reaches it via `use super::*`.
+const MAX_BITMAP_UPDATE_PIXELS: u32 = 1280 * 720;
+
+/// Split a rect into horizontal strips each ≤ [`MAX_BITMAP_UPDATE_PIXELS`].
+/// Returns the rect unchanged when it already fits.
+fn split_strips(x: u16, y: u16, w: u16, h: u16) -> Vec<(u16, u16, u16, u16)> {
+    if w == 0 || h == 0 {
+        return Vec::new();
+    }
+    if u32::from(w) * u32::from(h) <= MAX_BITMAP_UPDATE_PIXELS {
+        return vec![(x, y, w, h)];
+    }
+    let strip_rows =
+        u16::try_from((MAX_BITMAP_UPDATE_PIXELS / u32::from(w)).max(1)).unwrap_or(u16::MAX);
+    let mut out = Vec::new();
+    let mut row = 0u16;
+    while row < h {
+        let sh = strip_rows.min(h - row);
+        out.push((x, y + row, w, sh));
+        row += sh;
+    }
+    out
 }
 
 #[cfg(target_os = "macos")]
@@ -717,37 +769,6 @@ mod macos {
         }))
     }
 
-    /// Max pixels per emitted legacy `BitmapUpdate`. The bitmap encoder packs a
-    /// whole rect into one update PDU (one RLE rectangle per ~`65535/(w*4)`
-    /// rows); mstsc renders a single ~1280×720 (≈0.9 MP) update but DROPS a
-    /// 1920×1080 (≈2.1 MP) one — a per-update size/rectangle-count limit — so
-    /// the big initial full-frame paint of a virtual display never shows
-    /// (only the small ticking-clock dirty-rects render). Splitting tall rects
-    /// into strips at or below this proven-good size keeps every update
-    /// renderable. FreeRDP accepts either; it just sees more, smaller updates.
-    const MAX_BITMAP_UPDATE_PIXELS: u32 = 1280 * 720;
-
-    /// Split a rect into horizontal strips each ≤ [`MAX_BITMAP_UPDATE_PIXELS`].
-    /// Returns the rect unchanged when it already fits.
-    fn split_strips(x: u16, y: u16, w: u16, h: u16) -> Vec<(u16, u16, u16, u16)> {
-        if w == 0 || h == 0 {
-            return Vec::new();
-        }
-        if u32::from(w) * u32::from(h) <= MAX_BITMAP_UPDATE_PIXELS {
-            return vec![(x, y, w, h)];
-        }
-        let strip_rows =
-            u16::try_from((MAX_BITMAP_UPDATE_PIXELS / u32::from(w)).max(1)).unwrap_or(u16::MAX);
-        let mut out = Vec::new();
-        let mut row = 0u16;
-        while row < h {
-            let sh = strip_rows.min(h - row);
-            out.push((x, y + row, w, sh));
-            row += sh;
-        }
-        out
-    }
-
     impl Drop for ScreenCaptureUpdates {
         fn drop(&mut self) {
             let _ = self.stream.stop_capture();
@@ -1074,9 +1095,16 @@ mod macos {
 mod stub {
     use super::*;
     use anyhow::Context;
+    use std::collections::VecDeque;
 
     pub struct StubUpdates {
-        pending: Option<DisplayUpdate>,
+        queue: VecDeque<DisplayUpdate>,
+        /// When true, `next_update` returns `Ok(None)` once `queue` drains
+        /// (ends the stream) instead of parking forever. Only the test
+        /// constructor sets this; production `new` keeps the park-forever
+        /// behavior so a real non-macOS build's update loop neither spins
+        /// nor exits after the single seed frame.
+        end_on_drain: bool,
     }
 
     impl StubUpdates {
@@ -1089,25 +1117,43 @@ mod stub {
             for _ in 0..pixel_count {
                 data.extend_from_slice(&[0xFF, 0x10, 0x80, 0x90]);
             }
+            let mut queue = VecDeque::new();
+            queue.push_back(DisplayUpdate::Bitmap(BitmapUpdate {
+                x: 0,
+                y: 0,
+                width: w,
+                height: h,
+                format: PixelFormat::ARgb32,
+                data: Bytes::from(data),
+                stride,
+            }));
             Ok(Self {
-                pending: Some(DisplayUpdate::Bitmap(BitmapUpdate {
-                    x: 0,
-                    y: 0,
-                    width: w,
-                    height: h,
-                    format: PixelFormat::ARgb32,
-                    data: Bytes::from(data),
-                    stride,
-                })),
+                queue,
+                end_on_drain: false,
             })
+        }
+
+        /// Test-only: drive an explicit sequence of updates through the
+        /// `RdpServerDisplayUpdates` trait, then end the stream. Lets the
+        /// protocol-layer tests assert the update plumbing without a real
+        /// ScreenCaptureKit backend.
+        #[cfg(test)]
+        pub fn with_updates(updates: impl IntoIterator<Item = DisplayUpdate>) -> Self {
+            Self {
+                queue: updates.into_iter().collect(),
+                end_on_drain: true,
+            }
         }
     }
 
     #[async_trait::async_trait]
     impl RdpServerDisplayUpdates for StubUpdates {
         async fn next_update(&mut self) -> Result<Option<DisplayUpdate>> {
-            if let Some(u) = self.pending.take() {
+            if let Some(u) = self.queue.pop_front() {
                 return Ok(Some(u));
+            }
+            if self.end_on_drain {
+                return Ok(None);
             }
             std::future::pending::<()>().await;
             Ok(None)
@@ -1129,5 +1175,156 @@ mod tests {
         let clone = size.clone();
         clone.set(u16::MAX, 1);
         assert_eq!(size.get(), (u16::MAX, 1));
+    }
+
+    #[test]
+    fn split_strips_passes_small_rects_through() {
+        // A rect already within the limit is returned unchanged (single strip).
+        assert_eq!(split_strips(0, 0, 1280, 720), vec![(0, 0, 1280, 720)]);
+        assert_eq!(split_strips(10, 20, 640, 480), vec![(10, 20, 640, 480)]);
+        // Zero-area rects produce nothing.
+        assert_eq!(split_strips(0, 0, 0, 100), Vec::new());
+        assert_eq!(split_strips(0, 0, 100, 0), Vec::new());
+    }
+
+    #[test]
+    fn split_strips_breaks_tall_rects_into_strips() {
+        // 1920×1080 (≈2.1 MP) exceeds the 1280×720 cap and must be split.
+        let strips = split_strips(0, 0, 1920, 1080);
+        assert!(strips.len() > 1, "oversized rect should split: {strips:?}");
+        // Each strip is within the per-update pixel budget.
+        for &(_, _, w, h) in &strips {
+            assert!(u32::from(w) * u32::from(h) <= MAX_BITMAP_UPDATE_PIXELS);
+            assert_eq!(w, 1920, "width is preserved; only rows are split");
+        }
+        // Strips tile the original rect contiguously with no gaps/overlap and
+        // cover the full height.
+        assert_eq!(strips.first().unwrap().1, 0);
+        let mut next_y = 0u16;
+        for &(x, y, _, h) in &strips {
+            assert_eq!(x, 0);
+            assert_eq!(y, next_y);
+            next_y += h;
+        }
+        assert_eq!(next_y, 1080, "strips cover the whole height");
+    }
+
+    #[test]
+    fn adopt_client_size_adopts_in_band_change_when_auto() {
+        // Auto-size on, a different in-band size → adopt it.
+        assert_eq!(
+            adopt_client_size(
+                true,
+                (1512, 982),
+                DesktopSize {
+                    width: 1920,
+                    height: 1080
+                }
+            ),
+            Some(DesktopSize {
+                width: 1920,
+                height: 1080
+            })
+        );
+    }
+
+    #[test]
+    fn adopt_client_size_refuses_when_disabled_or_unchanged_or_out_of_band() {
+        // auto_size off → never adopt.
+        assert_eq!(
+            adopt_client_size(
+                false,
+                (1512, 982),
+                DesktopSize {
+                    width: 1920,
+                    height: 1080
+                }
+            ),
+            None
+        );
+        // No-op echo (already current) → no change.
+        assert_eq!(
+            adopt_client_size(
+                true,
+                (1920, 1080),
+                DesktopSize {
+                    width: 1920,
+                    height: 1080
+                }
+            ),
+            None
+        );
+        // Below the 200..=8192 protocol band → refuse.
+        assert_eq!(
+            adopt_client_size(
+                true,
+                (1512, 982),
+                DesktopSize {
+                    width: 199,
+                    height: 1080
+                }
+            ),
+            None
+        );
+        // Above the band → refuse.
+        assert_eq!(
+            adopt_client_size(
+                true,
+                (1512, 982),
+                DesktopSize {
+                    width: 1920,
+                    height: 8193
+                }
+            ),
+            None
+        );
+        // Band edges are inclusive and adoptable.
+        assert_eq!(
+            adopt_client_size(
+                true,
+                (1512, 982),
+                DesktopSize {
+                    width: 200,
+                    height: 8192
+                }
+            ),
+            Some(DesktopSize {
+                width: 200,
+                height: 8192
+            })
+        );
+    }
+
+    // The programmable stub only exists on non-macOS builds (the Linux CI
+    // target); it backs the protocol-layer trait tests below.
+    #[cfg(not(target_os = "macos"))]
+    #[tokio::test]
+    async fn stub_updates_yields_injected_sequence_then_ends() {
+        use stub::StubUpdates;
+
+        let mk = |w: u16| {
+            DisplayUpdate::Bitmap(BitmapUpdate {
+                x: 0,
+                y: 0,
+                width: NonZeroU16::new(w).unwrap(),
+                height: NonZeroU16::new(1).unwrap(),
+                format: PixelFormat::ARgb32,
+                data: Bytes::from(vec![0u8; usize::from(w) * 4]),
+                stride: NonZeroUsize::new(usize::from(w) * 4).unwrap(),
+            })
+        };
+
+        let mut updates: Box<dyn RdpServerDisplayUpdates + Send> =
+            Box::new(StubUpdates::with_updates([mk(10), mk(20), mk(30)]));
+
+        // Driven through the trait, the injected updates come back in order...
+        for expected_w in [10u16, 20, 30] {
+            match updates.next_update().await.unwrap() {
+                Some(DisplayUpdate::Bitmap(b)) => assert_eq!(b.width.get(), expected_w),
+                other => panic!("expected bitmap width {expected_w}, got {other:?}"),
+            }
+        }
+        // ...and then the stream ends (the test constructor sets end_on_drain).
+        assert!(updates.next_update().await.unwrap().is_none());
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -135,12 +135,54 @@ fn map_client_to_display(
     }
 }
 
+/// macOS virtual keycodes whose `Ctrl+<key>` combo is remapped to `Cmd+<key>`
+/// under --map-ctrl-to-cmd: C V X A Z S F N T W O P R G (copy / paste / cut /
+/// select-all / undo / save / find / new / new-tab / close / open / print /
+/// reload / find-next). Deliberately EXCLUDES Q (`Cmd+Q` quits — a nasty
+/// surprise from `Ctrl+Q`) and all nav keys (Mac word-nav is Option+arrow, not
+/// Cmd+arrow). Windows redo (`Ctrl+Y`) is intentionally not here — Mac redo is
+/// `Cmd+Shift+Z`, reachable via `Ctrl+Shift+Z` through the Z mapping.
+///
+/// Pure (no platform deps) so it lives at file scope and is unit-tested on
+/// every target; `mod macos` reaches it via `use super::is_remappable_shortcut`.
+fn is_remappable_shortcut(vk: u16) -> bool {
+    matches!(
+        vk,
+        0x08 // C
+            | 0x09 // V
+            | 0x07 // X
+            | 0x00 // A
+            | 0x06 // Z
+            | 0x01 // S
+            | 0x03 // F
+            | 0x2D // N
+            | 0x11 // T
+            | 0x0D // W
+            | 0x1F // O
+            | 0x23 // P
+            | 0x0F // R
+            | 0x05 // G
+    )
+}
+
 #[cfg(test)]
 mod coord_tests {
-    use super::map_client_to_display;
+    use super::{is_remappable_shortcut, map_client_to_display};
 
     fn approx(a: f64, b: f64) -> bool {
         (a - b).abs() < 0.5
+    }
+
+    #[test]
+    fn curated_keys_remap_and_q_does_not() {
+        // Curated editing keys (C, V, X, A, Z, S) remap.
+        for vk in [0x08u16, 0x09, 0x07, 0x00, 0x06, 0x01] {
+            assert!(is_remappable_shortcut(vk), "vk {vk:#x} should remap");
+        }
+        // Q (0x0C) is deliberately excluded so Ctrl+Q can't become Cmd+Q.
+        assert!(!is_remappable_shortcut(0x0C));
+        // Arrows / nav keys are untouched (e.g. left arrow 0x7B).
+        assert!(!is_remappable_shortcut(0x7B));
     }
 
     #[test]
@@ -263,6 +305,7 @@ mod macos {
     use std::process::Command;
     use std::time::{Duration, Instant};
 
+    use super::is_remappable_shortcut;
     use super::scancodes::{is_numeric_pad_vk, scancode_to_cgkeycode};
 
     use anyhow::{anyhow, Result};
@@ -1468,33 +1511,6 @@ mod macos {
                 .map(|s| s.to_string())
                 .filter(|s| !s.is_empty())
         }
-    }
-
-    /// macOS virtual keycodes whose `Ctrl+<key>` combo is remapped to `Cmd+<key>`
-    /// under --map-ctrl-to-cmd: C V X A Z S F N T W O P R G (copy / paste / cut /
-    /// select-all / undo / save / find / new / new-tab / close / open / print /
-    /// reload / find-next). Deliberately EXCLUDES Q (`Cmd+Q` quits — a nasty
-    /// surprise from `Ctrl+Q`) and all nav keys (Mac word-nav is Option+arrow, not
-    /// Cmd+arrow). Windows redo (`Ctrl+Y`) is intentionally not here — Mac redo is
-    /// `Cmd+Shift+Z`, reachable via `Ctrl+Shift+Z` through the Z mapping.
-    fn is_remappable_shortcut(vk: u16) -> bool {
-        matches!(
-            vk,
-            0x08 // C
-                | 0x09 // V
-                | 0x07 // X
-                | 0x00 // A
-                | 0x06 // Z
-                | 0x01 // S
-                | 0x03 // F
-                | 0x2D // N
-                | 0x11 // T
-                | 0x0D // W
-                | 0x1F // O
-                | 0x23 // P
-                | 0x0F // R
-                | 0x05 // G
-        )
     }
 
     /// Standalone-terminal bundle ids where the Ctrl→Cmd remap is always
@@ -2956,23 +2972,6 @@ mod macos {
             tm.tm_min,
             tm.tm_sec
         )
-    }
-
-    #[cfg(test)]
-    mod remap_tests {
-        use super::is_remappable_shortcut;
-
-        #[test]
-        fn curated_keys_remap_and_q_does_not() {
-            // Curated editing keys (C, V, X, A, Z, S) remap.
-            for vk in [0x08u16, 0x09, 0x07, 0x00, 0x06, 0x01] {
-                assert!(is_remappable_shortcut(vk), "vk {vk:#x} should remap");
-            }
-            // Q (0x0C) is deliberately excluded so Ctrl+Q can't become Cmd+Q.
-            assert!(!is_remappable_shortcut(0x0C));
-            // Arrows / nav keys are untouched (e.g. left arrow 0x7B).
-            assert!(!is_remappable_shortcut(0x7B));
-        }
     }
 }
 

--- a/src/input/scancodes.rs
+++ b/src/input/scancodes.rs
@@ -165,3 +165,51 @@ pub(crate) fn is_numeric_pad_vk(vk: u16) -> bool {
             | 0x5C
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normal_letters_and_modifiers_map() {
+        // Spot-check the ANSI block: scancode → kVK_*.
+        assert_eq!(scancode_to_cgkeycode(0x1E, false), Some(0x00)); // A
+        assert_eq!(scancode_to_cgkeycode(0x10, false), Some(0x0C)); // Q
+        assert_eq!(scancode_to_cgkeycode(0x39, false), Some(0x31)); // Space
+        assert_eq!(scancode_to_cgkeycode(0x1C, false), Some(0x24)); // Enter
+        assert_eq!(scancode_to_cgkeycode(0x1D, false), Some(0x3B)); // Left Ctrl
+        assert_eq!(scancode_to_cgkeycode(0x2A, false), Some(0x38)); // Left Shift
+    }
+
+    #[test]
+    fn extended_flag_selects_a_different_table() {
+        // 0x1D is Left Ctrl normally but Right Ctrl when extended.
+        assert_eq!(scancode_to_cgkeycode(0x1D, false), Some(0x3B));
+        assert_eq!(scancode_to_cgkeycode(0x1D, true), Some(0x3E));
+        // 0x48 is numpad-8 normally but the Up arrow when extended.
+        assert_eq!(scancode_to_cgkeycode(0x48, false), Some(0x5B));
+        assert_eq!(scancode_to_cgkeycode(0x48, true), Some(0x7E));
+        // GUI / Windows key only exists in the extended table.
+        assert_eq!(scancode_to_cgkeycode(0x5B, true), Some(0x37));
+        assert_eq!(scancode_to_cgkeycode(0x5B, false), None);
+    }
+
+    #[test]
+    fn unmapped_scancodes_return_none() {
+        assert_eq!(scancode_to_cgkeycode(0x00, false), None);
+        assert_eq!(scancode_to_cgkeycode(0xFF, false), None);
+        assert_eq!(scancode_to_cgkeycode(0x46, false), None); // gap (ScrollLock)
+        assert_eq!(scancode_to_cgkeycode(0x00, true), None);
+        assert_eq!(scancode_to_cgkeycode(0xFF, true), None);
+    }
+
+    #[test]
+    fn numeric_pad_classification() {
+        assert!(is_numeric_pad_vk(0x52)); // numpad 0
+        assert!(is_numeric_pad_vk(0x59)); // numpad 7
+        assert!(is_numeric_pad_vk(0x4C)); // numpad Enter
+        assert!(!is_numeric_pad_vk(0x00)); // A
+        assert!(!is_numeric_pad_vk(0x24)); // Return
+        assert!(!is_numeric_pad_vk(0x46)); // reserved gap in the keypad range
+    }
+}

--- a/src/rdpdr/mod.rs
+++ b/src/rdpdr/mod.rs
@@ -28,15 +28,38 @@ pub fn shutdown_cleanup() {
     surface::shutdown_cleanup();
 }
 
+/// Map a client-returned [`NtStatus`] to the closest NFS status.
+///
+/// Extracted as a pure fn (no platform deps) so it's unit-tested on every
+/// target: these are routine client-side outcomes, and getting the translation
+/// right is what makes Finder report the correct thing. The headline case is a
+/// write to a protected location like the `C:\` root coming back `ACCESS_DENIED`
+/// → `NFS3ERR_ACCES` ("you don't have permission") rather than a generic I/O
+/// error. `None` (the client gave no concrete status) falls back to I/O.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn ntstatus_to_nfsstat3(status: Option<NtStatus>) -> nfsstat3 {
+    match status {
+        Some(s) if s == NtStatus::ACCESS_DENIED => nfsstat3::NFS3ERR_ACCES,
+        Some(s) if s == NtStatus::OBJECT_NAME_COLLISION => nfsstat3::NFS3ERR_EXIST,
+        Some(s) if s == NtStatus::NO_SUCH_FILE => nfsstat3::NFS3ERR_NOENT,
+        Some(s) if s == NtStatus::NOT_A_DIRECTORY => nfsstat3::NFS3ERR_NOTDIR,
+        Some(s) if s == NtStatus::DIRECTORY_NOT_EMPTY => nfsstat3::NFS3ERR_NOTEMPTY,
+        Some(s) if s == NtStatus::NOT_SUPPORTED => nfsstat3::NFS3ERR_NOTSUPP,
+        _ => nfsstat3::NFS3ERR_IO,
+    }
+}
+
 #[cfg(target_os = "macos")]
 use std::collections::HashMap;
 
 #[cfg(target_os = "macos")]
 use ironrdp_rdpdr::pdu::efs::DeviceType;
+use ironrdp_rdpdr::pdu::efs::NtStatus;
 use ironrdp_server::{
     AnnouncedDevice, RdpdrBackendFactory, RdpdrHandle, RdpdrServerFactory, RdpdrServerHandler,
     ServerEvent, ServerEventSender,
 };
+use nfsserve::nfs::nfsstat3;
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -179,4 +202,50 @@ fn hostname() -> String {
         }
     }
     "macrdp".to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `matches!` rather than `assert_eq!` so the test needs no PartialEq/Debug
+    // on nfsstat3.
+    #[test]
+    fn ntstatus_maps_to_expected_nfs_errors() {
+        assert!(matches!(
+            ntstatus_to_nfsstat3(Some(NtStatus::ACCESS_DENIED)),
+            nfsstat3::NFS3ERR_ACCES
+        ));
+        assert!(matches!(
+            ntstatus_to_nfsstat3(Some(NtStatus::OBJECT_NAME_COLLISION)),
+            nfsstat3::NFS3ERR_EXIST
+        ));
+        assert!(matches!(
+            ntstatus_to_nfsstat3(Some(NtStatus::NO_SUCH_FILE)),
+            nfsstat3::NFS3ERR_NOENT
+        ));
+        assert!(matches!(
+            ntstatus_to_nfsstat3(Some(NtStatus::NOT_A_DIRECTORY)),
+            nfsstat3::NFS3ERR_NOTDIR
+        ));
+        assert!(matches!(
+            ntstatus_to_nfsstat3(Some(NtStatus::DIRECTORY_NOT_EMPTY)),
+            nfsstat3::NFS3ERR_NOTEMPTY
+        ));
+        assert!(matches!(
+            ntstatus_to_nfsstat3(Some(NtStatus::NOT_SUPPORTED)),
+            nfsstat3::NFS3ERR_NOTSUPP
+        ));
+    }
+
+    #[test]
+    fn unknown_or_absent_status_falls_back_to_io() {
+        // No concrete status returned by the client → generic I/O.
+        assert!(matches!(ntstatus_to_nfsstat3(None), nfsstat3::NFS3ERR_IO));
+        // A status we don't specifically translate → generic I/O.
+        assert!(matches!(
+            ntstatus_to_nfsstat3(Some(NtStatus::UNSUCCESSFUL)),
+            nfsstat3::NFS3ERR_IO
+        ));
+    }
 }

--- a/src/rdpdr/surface.rs
+++ b/src/rdpdr/surface.rs
@@ -27,7 +27,6 @@ use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use ironrdp_rdpdr::pdu::efs::NtStatus;
 use ironrdp_server::{DirEntry as RdpEntry, RdpdrHandle, RdpdrStatus};
 use nfsserve::nfs::{
     fattr3, fileid3, filename3, ftype3, nfspath3, nfsstat3, nfsstring, nfstime3, sattr3, set_size3,
@@ -152,15 +151,7 @@ fn join_remote(dir: &str, name: &str) -> String {
 /// routine client-side outcomes, so they log at debug, not warn.
 fn nfs_err(context: &str, e: &anyhow::Error) -> nfsstat3 {
     let status = e.downcast_ref::<RdpdrStatus>().map(|s| s.status);
-    let mapped = match status {
-        Some(s) if s == NtStatus::ACCESS_DENIED => nfsstat3::NFS3ERR_ACCES,
-        Some(s) if s == NtStatus::OBJECT_NAME_COLLISION => nfsstat3::NFS3ERR_EXIST,
-        Some(s) if s == NtStatus::NO_SUCH_FILE => nfsstat3::NFS3ERR_NOENT,
-        Some(s) if s == NtStatus::NOT_A_DIRECTORY => nfsstat3::NFS3ERR_NOTDIR,
-        Some(s) if s == NtStatus::DIRECTORY_NOT_EMPTY => nfsstat3::NFS3ERR_NOTEMPTY,
-        Some(s) if s == NtStatus::NOT_SUPPORTED => nfsstat3::NFS3ERR_NOTSUPP,
-        _ => nfsstat3::NFS3ERR_IO,
-    };
+    let mapped = super::ntstatus_to_nfsstat3(status);
     debug!(error = %e, "rdpdr nfs: {context}");
     mapped
 }


### PR DESCRIPTION
## What

Adds the first two tiers of an automated regression harness + a CI job to run them. Until now `cargo test` ran in **no** CI (`release.yml` is tags-only), so the protocol/logic layer was guarded only by manual real-client testing.

### Layer 1 — pure-logic unit tests (Linux + macOS)
- **scancodes**: PS/2 → macOS keycode table coverage (mappings, extended keys, invalid codes, numpad).
- **audio**: extract `choose_audio_format`; test AAC-first preference, PCM-only client `wFormatNo` client-list indexing, no-match — guards the AAC-silenced-PCM regression.
- **capture**: extract `adopt_client_size`; test the `200..=8192` clamp / auto-size gate / no-op echo.
- **capture**: move `split_strips` to file scope; test passthrough + strip tiling.
- **input**: move `is_remappable_shortcut` to file scope so it (and its test) run on Linux.
- **rdpdr**: extract `ntstatus_to_nfsstat3`; test NTSTATUS→NFS mapping — guards the `C:\`-denial → `NFS3ERR_ACCES` translation.

### Layer 2 — trait-level
Make the non-macOS stub display programmable (injected update queue) and drive `RdpServerDisplayUpdates` end to end.

## Safety
Every production change is a **provably-safe extraction of pure decision logic into a free function + delegating call** — no changes to the async hot paths (`next_update` / `capture_loop` / `async_main`).

## CI
New `ci.yml`: `cargo test` on ubuntu-latest (+ a fmt gate) and the full suite on macos-14, on push-to-main and PRs.

## Verification
- Local macOS: `cargo fmt --check`, `clippy --all-targets -D warnings`, `cargo test -D warnings` → **56 passed**.
- Linux compile is what this PR's `test-linux` job confirms (no local cross toolchain available).

## Out of scope (deferred)
- Full in-process RDP client handshake (needs a client dev-dep + non-CredSSP test path).
- Vendored audio-lag math tests (would add fork divergence — revisit when upstreamed).
- Layers 3/4 (macOS backend smoke + soak) on a TCC-granted self-hosted runner.