### PR TITLE
fix: USB trigger picker uses ioreg (GUI + CLI); release v0.8.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,7 +1871,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macrdp"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrdp"
-version = "0.8.13"
+version = "0.8.14"
 edition = "2021"
 description = "Native RDP server for macOS"
 license = "MIT OR Apache-2.0"

--- a/gui/README.md
+++ b/gui/README.md
@@ -71,10 +71,17 @@ macrdpController.app/Contents/MacOS/macrdptray --print-paths      # diagnose res
 - **Start · Stop · Restart** — self-installs on first run, then `kickstart -k` /
   `bootout` the agent (with EIO retry).
 - **Options** — H.264 / AAC / HiDPI / **Un-minimize on Cmd+Tab** / **App-switcher HUD** /
-  **Per-connection workers (reconnect fix)** checkmarks, plus **Allow network
-  connections** (flips `BIND` between `127.0.0.1` and `0.0.0.0`, preserving the
-  port, with a confirmation before exposing to the LAN); shows the current
-  listening address. All write `config.env` and live-`kickstart` if running.
+  **Per-connection workers (reconnect fix)** checkmarks, **Drive / Smart-card
+  redirection** toggles, plus **Allow network connections** (flips `BIND` between
+  `127.0.0.1` and `0.0.0.0`, preserving the port, with a confirmation before
+  exposing to the LAN); shows the current listening address. All write
+  `config.env` and live-`kickstart` if running.
+- **Install smart-card handler…** — one-time privileged install of the PC/SC IFD
+  handler (the redirection toggle only flips the server flag). Pops up a list of
+  your **attached USB devices** to pick the load trigger (macOS loads the driver
+  only on a USB hotplug matching its VID/PID), passes the choice to the embedded
+  installer as `IFD_VID`/`IFD_PID`, and runs it (one admin prompt). Choose
+  *Keep default trigger* to leave the bundle's baked-in IDs.
 - **Display** — **Virtual display (headless)** toggle, a **Primary screen** radio
   (`PRIMARY_MODE`: *Keep local screen on* / *Detach — move apps to remote* /
   *Blank — keep apps on Mac*), and a **Virtual display resolution** picker

--- a/gui/Sources/macrdptray/main.swift
+++ b/gui/Sources/macrdptray/main.swift
@@ -611,12 +611,87 @@ final class AppController: NSObject, NSApplicationDelegate, NSMenuDelegate {
         applyIfRunning()
     }
 
+    /// An attached USB device, for the smart-card trigger picker.
+    struct UsbDevice {
+        let vid: String // "0x2174" (4-digit lowercase hex)
+        let pid: String // "0x2100"
+        let label: String // human-readable name
+    }
+
+    /// Enumerate attached USB devices via `ioreg -a -r -c IOUSBHostDevice`, which
+    /// emits an XML-plist array of device dicts (idVendor/idProduct as decimal
+    /// ints, plus name strings). We deliberately use ioreg, NOT
+    /// `system_profiler SPUSBDataType`: some USB-C devices (e.g. a Transcend
+    /// ESD310C SSD — the dev trigger) are visible in ioreg but never appear in
+    /// the SPUSBDataType tree, so a system_profiler-based picker silently misses
+    /// them. install-ifd-handler.sh's hint dump already uses ioreg for the same
+    /// reason. VID/PID are formatted as the 4-digit lowercase hex the bundle's
+    /// Info.plist wants.
+    func usbDevices() -> [UsbDevice] {
+        let out = run("/usr/sbin/ioreg", ["-a", "-r", "-c", "IOUSBHostDevice"])
+        guard out.code == 0, let data = out.stdout.data(using: .utf8),
+              let list = try? PropertyListSerialization.propertyList(
+                  from: data, options: [], format: nil) as? [[String: Any]] else { return [] }
+        func hex4(_ any: Any?) -> String? {
+            // idVendor/idProduct come as NSNumber; tolerate a string too.
+            if let n = any as? Int { return String(format: "0x%04x", n & 0xFFFF) }
+            if let s = any as? String, let n = Int(s) { return String(format: "0x%04x", n & 0xFFFF) }
+            return nil
+        }
+        var devices: [UsbDevice] = []
+        var seen = Set<String>()
+        for it in list {
+            guard let vid = hex4(it["idVendor"]), let pid = hex4(it["idProduct"]) else { continue }
+            let name = (it["USB Product Name"] as? String)
+                ?? (it["IORegistryEntryName"] as? String) ?? "USB device"
+            let man = (it["USB Vendor Name"] as? String) ?? ""
+            let label = (man.isEmpty || name.contains(man)) ? name : "\(name) (\(man))"
+            // De-dupe identical VID/PID (e.g. two of the same stick) by key.
+            let key = "\(vid):\(pid):\(label)"
+            if seen.insert(key).inserted { devices.append(UsbDevice(vid: vid, pid: pid, label: label)) }
+        }
+        return devices
+    }
+
+    enum TriggerChoice {
+        case cancel // abort the install
+        case keepDefault // install, leave the bundle's baked-in trigger
+        case device(vid: String, pid: String) // install, rebind to this device
+    }
+
+    /// Show a native popup of attached USB devices to use as the smart-card load
+    /// trigger (macOS loads the IFD driver only on a USB hotplug whose VID/PID
+    /// match the bundle). Returns the user's choice; "Keep default" leaves the
+    /// trigger unchanged, a device rebinds it via IFD_VID/IFD_PID.
+    func pickUsbTrigger() -> TriggerChoice {
+        let devices = usbDevices()
+        let a = NSAlert()
+        a.messageText = "Choose the USB trigger device"
+        a.informativeText = "macOS loads the smart-card driver only while a USB device with a "
+            + "matching ID is plugged in. Pick the device you'll keep attached as the trigger "
+            + "(any USB stick works), or choose \u{201C}Keep default trigger\u{201D} to leave it "
+            + "unchanged."
+        a.addButton(withTitle: "Install")
+        a.addButton(withTitle: "Cancel")
+        let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 340, height: 26))
+        popup.addItem(withTitle: "Keep default trigger")
+        for d in devices { popup.addItem(withTitle: "\(d.label)  —  \(d.vid):\(d.pid)") }
+        a.accessoryView = popup
+        a.window.initialFirstResponder = popup
+        NSApp.activate(ignoringOtherApps: true)
+        guard a.runModal() == .alertFirstButtonReturn else { return .cancel }
+        let idx = popup.indexOfSelectedItem
+        if idx <= 0 { return .keepDefault }
+        let d = devices[idx - 1]
+        return .device(vid: d.vid, pid: d.pid)
+    }
+
     /// One-time privileged install of the smart-card IFD handler (the toggle only
     /// flips the server flag; the handler still has to be copied into the system
-    /// drivers dir). Runs macrdp.app's embedded installer, which prompts for admin
-    /// via its own GUI dialog. No USB picker here (no tty when launched from the
-    /// menu) — it uses the bundle's default trigger; advanced users can rebind via
-    /// the CLI installer with IFD_VID/IFD_PID.
+    /// drivers dir). Lets the user pick the USB trigger device from a popup
+    /// (matching the CLI's select-usb-trigger.sh), passes it to the embedded
+    /// installer as IFD_VID/IFD_PID, then runs it (it prompts for admin via its
+    /// own GUI dialog).
     @objc func installSmartcardHandler() {
         func say(_ msg: String, _ info: String) {
             let a = NSAlert()
@@ -636,10 +711,21 @@ final class AppController: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 "This macrdp.app build doesn't bundle the smart-card handler installer.")
             return
         }
-        let out = run("/bin/bash", [installer])
+        var env: [String: String] = [:]
+        var picked: String?
+        switch pickUsbTrigger() {
+        case .cancel: return
+        case .keepDefault: break
+        case let .device(vid, pid):
+            env["IFD_VID"] = vid
+            env["IFD_PID"] = pid
+            picked = "\(vid):\(pid)"
+        }
+        let out = run("/bin/bash", [installer], env: env)
         if out.code == 0 {
+            let trigger = picked.map { "the chosen trigger device (\($0))" } ?? "the USB trigger device"
             say("Smart-card handler installed",
-                "Unplug/replug the USB trigger device so macOS loads the driver, and make sure "
+                "Unplug/replug \(trigger) so macOS loads the driver, and make sure "
                     + "the connecting client redirects its smart card.")
         } else {
             say("Install failed",
@@ -854,10 +940,16 @@ final class AppController: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // MARK: - Process helper
 
-    func run(_ path: String, _ args: [String]) -> (code: Int32, stdout: String) {
+    func run(_ path: String, _ args: [String], env: [String: String]? = nil)
+        -> (code: Int32, stdout: String) {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: path)
         p.arguments = args
+        if let env = env, !env.isEmpty {
+            var merged = ProcessInfo.processInfo.environment
+            for (k, v) in env { merged[k] = v }
+            p.environment = merged
+        }
         let pipe = Pipe()
         p.standardOutput = pipe
         p.standardError = pipe

--- a/packaging/select-usb-trigger.sh
+++ b/packaging/select-usb-trigger.sh
@@ -15,38 +15,43 @@
 # So install-ifd-handler.sh can do:  sel="$(select-usb-trigger.sh)" && bind $sel
 set -euo pipefail
 
-# Enumerate USB devices via system_profiler JSON (VID/PID already come as 0x..
-# strings there; ioreg reports them in decimal). Flatten the hub tree, keep only
-# leaves that expose both a hex vendor_id and a product_id. Emits TSV:
+# Enumerate USB devices via `ioreg -a` (an XML plist; idVendor/idProduct come as
+# decimal ints). Keep only entries that expose both. Emits TSV:
 #   <vid>\t<pid>\t<label>
+#
+# We use ioreg, NOT `system_profiler SPUSBDataType`: some USB-C devices (e.g. a
+# Transcend ESD310C SSD — the dev trigger default) are visible in ioreg but never
+# appear in the SPUSBDataType tree, so a system_profiler-based list silently
+# misses them. The GUI controller's picker uses ioreg for the same reason.
 list_devices() {
     # NOTE: `python3 -c`, NOT `python3 - <<HEREDOC` — a heredoc would BECOME
-    # python's stdin, so json.load(sys.stdin) would read the script instead of
-    # the piped JSON. With -c the pipe stays stdin. The python body is single-
-    # quote-safe (only double quotes / f-strings inside). Each match is printed
-    # newline-terminated so bash `while read` doesn't drop the last line.
-    system_profiler -json SPUSBDataType 2>/dev/null | /usr/bin/python3 -c '
-import json, sys, re
-def walk(items, out):
-    for it in items or []:
-        pid = it.get("product_id", "")
-        m = re.search(r"0x[0-9a-fA-F]+", it.get("vendor_id", ""))
-        if pid.startswith("0x") and m:
-            name = it.get("_name", "?")
-            man = it.get("manufacturer", "")
-            label = name if (not man or man in name) else f"{name} ({man})"
-            vid = "0x%04x" % int(m.group(0), 16)   # 4-digit lc hex, as Info.plist wants
-            pidn = "0x%04x" % int(pid, 16)
-            out.append(f"{vid}\t{pidn}\t{label}")
-        walk(it.get("_items"), out)
-out = []
+    # python's stdin, so plistlib would read the script instead of the piped
+    # plist. With -c the pipe stays stdin. The python body is single-quote-safe
+    # (only double quotes / f-strings inside). Each match is printed newline-
+    # terminated so bash `while read` doesn't drop the last line.
+    ioreg -a -r -c IOUSBHostDevice 2>/dev/null | /usr/bin/python3 -c '
+import sys, plistlib
 try:
-    d = json.load(sys.stdin)
+    devs = plistlib.loads(sys.stdin.buffer.read())
 except Exception:
-    d = {}
-walk(d.get("SPUSBDataType"), out)
-for line in out:
-    print(line)
+    devs = []
+if not isinstance(devs, list):
+    devs = [devs] if devs else []
+seen = set()
+for it in devs:
+    v = it.get("idVendor"); p = it.get("idProduct")
+    if not isinstance(v, int) or not isinstance(p, int):
+        continue
+    name = it.get("USB Product Name") or it.get("IORegistryEntryName") or "USB device"
+    man = it.get("USB Vendor Name") or ""
+    label = name if (not man or man in name) else f"{name} ({man})"
+    vid = "0x%04x" % (v & 0xFFFF)   # 4-digit lc hex, as Info.plist wants
+    pidn = "0x%04x" % (p & 0xFFFF)
+    key = (vid, pidn, label)
+    if key in seen:
+        continue
+    seen.add(key)
+    print(f"{vid}\t{pidn}\t{label}")
 ' 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Problem
The smart-card IFD-handler trigger pickers enumerated USB devices via `system_profiler SPUSBDataType`, which silently omits some USB-C devices (e.g. a Transcend ESD310C SSD — the bundle's default trigger): the device is visible in `ioreg` but never appears in the `SPUSBDataType` tree, so it never showed up to pick. Reported live (plugged-in trigger device not appearing in the GUI).

## Fix
Switch both pickers to `ioreg -a -r -c IOUSBHostDevice` (the same source `install-ifd-handler.sh`'s hint dump already used):

- **GUI controller** — new native USB-trigger popup in *Install smart-card handler…*: lists attached devices, passes the choice to the installer as `IFD_VID`/`IFD_PID`. Previously the GUI always used the baked-in default trigger because there was no tty for the CLI picker.
- **`packaging/select-usb-trigger.sh`** — parse the `ioreg` plist instead of `system_profiler` JSON.

Verified live: the CLI picker now lists `ESD310C (Transcend) VID=0x2174 PID=0x2100`; GUI uses identical logic.

## Release
Bumps to **v0.8.14**. DMG/controller change only — the server binary is unchanged from 0.8.13.