### PR TITLE
feat(udp-multitransport): M1 — MS-RDPEMT negotiation + safe TCP fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ der = "0.7"
 
 # RDP protocol — ironrdp is split into many sub-crates; add only what you use.
 ironrdp = "0.14"
-ironrdp-server = { version = "0.10", features = ["egfx"] }  # patched locally — see [patch.crates-io] below
+ironrdp-server = { version = "0.10", features = ["egfx", "multitransport"] }  # patched locally — see [patch.crates-io] below
 ironrdp-acceptor = "0.8"
 ironrdp-pdu = "0.7"
 ironrdp-cliprdr = "0.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod file_promise_lazy;
 mod h264;
 mod input;
 mod keyboard_layout;
+mod multitransport;
 mod rdpdr;
 #[cfg(target_os = "macos")]
 mod runloop_thread;
@@ -447,6 +448,17 @@ struct Args {
     /// /smartcard). macOS-only.
     #[arg(long)]
     enable_smartcard_redirection: bool,
+
+    /// EXPERIMENTAL (M1, opt-in, default OFF). Offer RDP UDP multitransport
+    /// (MS-RDPEMT) to clients that advertise it. **M1 is negotiation only:**
+    /// the server sends the Initiate Multitransport Request and handles the
+    /// client's response, but there is NO UDP transport yet — the client's UDP
+    /// attempt times out (E_ABORT) and the session continues on TCP, unchanged.
+    /// This exists to prove the negotiation/framing + graceful fallback ahead of
+    /// the UDP data path (later milestones). No reason for end users to enable
+    /// it. macOS-only build; see docs/rdp-udp-multitransport-feasibility.md.
+    #[arg(long)]
+    enable_udp_multitransport: bool,
 
     /// Don't adopt the client's requested desktop resolution. By default —
     /// when mirroring the primary display without --width/--height/--hidpi —
@@ -1336,6 +1348,9 @@ fn args_from_config(path: &Path) -> Result<Args> {
     if on("ENABLE_SMARTCARD_REDIRECTION", false) {
         argv.push("--enable-smartcard-redirection".into());
     }
+    if on("ENABLE_UDP_MULTITRANSPORT", false) {
+        argv.push("--enable-udp-multitransport".into());
+    }
     if on("FORK_WORKERS", false) {
         argv.push("--fork-workers".into());
     }
@@ -2069,6 +2084,14 @@ async fn async_main() -> Result<()> {
     // pipeline all read.
     server.set_honor_client_desktop_size(auto_size);
 
+    // EXPERIMENTAL UDP multitransport (MS-RDPEMT) — M1 negotiation only. When
+    // enabled, install the provider so the server offers reliable UDP to clients
+    // that advertise it. There is no UDP transport yet (M1), so the client's UDP
+    // attempt times out and the session continues on TCP. See src/multitransport.rs.
+    if args.enable_udp_multitransport {
+        server.set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));
+    }
+
     // ironrdp_server::Credentials holds a plain String, so this copy is
     // outside our control and won't be zeroed when the server shuts down.
     // Our Zeroizing<String> still wipes its own allocation at scope exit.
@@ -2190,6 +2213,7 @@ mod config_tests {
              VD_HEIGHT=1440\n\
              PRIMARY_MODE=detach\n\
              FORK_WORKERS=1\n\
+             ENABLE_UDP_MULTITRANSPORT=1\n\
              EXTRA_FLAGS=\"--fps 30\"\n",
         );
         let args = args_from_config(&path).unwrap();
@@ -2207,6 +2231,7 @@ mod config_tests {
         assert!(args.detach_primary);
         assert!(!args.capture_primary);
         assert!(args.fork_workers);
+        assert!(args.enable_udp_multitransport);
         // USE_KEYCHAIN defaults on (matches the old wrapper).
         assert!(args.keychain);
         // EXTRA_FLAGS is parsed as real CLI tokens.
@@ -2224,6 +2249,7 @@ mod config_tests {
         assert!(!args.virtual_display);
         assert!(!args.enable_h264);
         assert!(!args.fork_workers);
+        assert!(!args.enable_udp_multitransport);
     }
 
     #[test]

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -27,3 +27,45 @@ impl MultitransportProvider for MacMultitransport {
         RequestedProtocol::UdpFecR
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::decode;
+    use ironrdp_pdu::mcs::McsMessage;
+    use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, RequestedProtocol};
+    use ironrdp_pdu::x224::X224;
+    use ironrdp_server::encode_initiate_request;
+
+    // The Initiate Multitransport Request the server sends in M1 is the one bit
+    // of new on-wire behavior that no real loopback client exercises (mstsc /
+    // sdl-freerdp don't advertise UDP over 127.0.0.1). This round-trips the
+    // exact bytes the server emits through ironrdp's own X.224/MCS + PDU
+    // decoders, proving the IO-channel framing is structurally well-formed
+    // (correct channel, BasicSecurityHeader/TRANSPORT_REQ, request fields) — the
+    // framing risk flagged in the M1 plan. On-wire acceptance by Windows is
+    // verified at M3 with a real UDP-capable client.
+    #[test]
+    fn initiate_request_round_trips_through_io_channel_framing() {
+        let cookie = [0xABu8; 16];
+        let bytes =
+            encode_initiate_request(42, RequestedProtocol::UdpFecR, cookie, 1003, 1002).unwrap();
+
+        let X224(msg) = decode::<X224<McsMessage<'_>>>(&bytes).unwrap();
+        let sdi = match msg {
+            McsMessage::SendDataIndication(sdi) => sdi,
+            other => panic!("expected SendDataIndication, got {other:?}"),
+        };
+        assert_eq!(
+            sdi.channel_id, 1003,
+            "Initiate Request must ride the IO channel"
+        );
+        assert_eq!(sdi.initiator_id, 1002);
+
+        // The inner PDU decodes as a MultitransportRequestPdu, which itself
+        // re-validates the TRANSPORT_REQ security-header flag on decode.
+        let req = decode::<MultitransportRequestPdu>(sdi.user_data.as_ref()).unwrap();
+        assert_eq!(req.request_id, 42);
+        assert_eq!(req.requested_protocol, RequestedProtocol::UdpFecR);
+        assert_eq!(req.security_cookie, cookie);
+    }
+}

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -1,0 +1,29 @@
+//! macrdp-side RDP UDP multitransport (MS-RDPEMT) provider.
+//!
+//! **M1: negotiation only.** This is a thin provider that tells the vendored
+//! server to *offer* reliable UDP (`UdpFecR` — RDPEUDP2 over the session's
+//! existing TLS) to clients that advertise support. There is no UDP listener
+//! yet, so the server's M1 path only performs the Initiate Request → Response
+//! handshake and falls back to TCP; see
+//! `vendor/ironrdp-server/src/multitransport/` and
+//! `docs/rdp-udp-multitransport-feasibility.md`. Wired in `main.rs` behind
+//! `--enable-udp-multitransport`.
+//!
+//! Cross-platform on purpose (it's pure protocol policy, no macOS APIs), so the
+//! Linux CI build that compiles the protocol layer exercises it too. Later
+//! milestones add the UDP listener/session here (which will be macOS-gated for
+//! the parts that touch capture/encode).
+
+use ironrdp_pdu::rdp::multitransport::RequestedProtocol;
+use ironrdp_server::MultitransportProvider;
+
+/// M1 provider: offer reliable UDP multitransport. Reliable (`UdpFecR`) rides
+/// the connection's existing rustls TLS, so no DTLS / new crypto dependency is
+/// needed. Lossy (`UdpFecL`, which needs DTLS) is a later milestone.
+pub struct MacMultitransport;
+
+impl MultitransportProvider for MacMultitransport {
+    fn requested_protocol(&self) -> RequestedProtocol {
+        RequestedProtocol::UdpFecR
+    }
+}

--- a/vendor/ironrdp-acceptor/CLAUDE.md
+++ b/vendor/ironrdp-acceptor/CLAUDE.md
@@ -57,3 +57,19 @@ vendor dir until divergence (1) is upstreamed AND released.
     (1), since exposing core-data fields on `AcceptorResult` is the same shape
     CBenoit floated for the desktop size. See the keyboard-layout quirk note
     in docs/known-quirks.md.
+
+(3) Expose the client's multitransport (MS-RDPEMT) support flags from its GCC
+    MultiTransportChannelData block (NOT upstreamed; added 2026-06-25 for UDP
+    multitransport M1): `Acceptor` gains a private
+    `client_multitransport: gcc::MultiTransportFlags` (captured in
+    `BasicSettingsWaitInitial` alongside (1)/(2), UNCONDITIONALLY — free and
+    harmless; empty if the client sent no block), carried across
+    `new_deactivation_reactivation`, and surfaced as a new
+    `pub multitransport_flags: gcc::MultiTransportFlags` field on
+    `AcceptorResult`. Upstream parses the block into
+    `ClientGccBlocks.multi_transport_channel` and then discards it (only
+    early-capability flags, core size, and keyboard layout are kept). Consumed
+    by `vendor/ironrdp-server` divergence (12), which decides whether to send a
+    Server Initiate Multitransport Request. Purely additive (same shape as (2)),
+    so trivially upstreamable — offer alongside (1)/(2). See the
+    docs/rdp-udp-multitransport-feasibility.md plan.

--- a/vendor/ironrdp-acceptor/src/connection.rs
+++ b/vendor/ironrdp-acceptor/src/connection.rs
@@ -54,6 +54,12 @@ pub struct Acceptor {
     /// `BasicSettingsWaitInitial` and surfaced on `AcceptorResult` so the
     /// server can serve the client's keyboard layout. 0 = unknown / not sent.
     client_keyboard_layout: u32,
+    /// (vendored) The client's announced multitransport support flags
+    /// (MS-RDPEMT) from its GCC MultiTransportChannelData block, captured in
+    /// `BasicSettingsWaitInitial` and surfaced on `AcceptorResult` so the
+    /// server can decide whether to offer a UDP transport. Empty if the client
+    /// sent no multitransport block.
+    client_multitransport: gcc::MultiTransportFlags,
 }
 
 #[derive(Debug)]
@@ -67,6 +73,10 @@ pub struct AcceptorResult {
     /// (vendored) The client's announced keyboard-layout identifier (KLID)
     /// from its GCC Client Core Data; 0 if the client didn't send one.
     pub keyboard_layout: u32,
+    /// (vendored) The client's announced multitransport (MS-RDPEMT) support
+    /// flags from its GCC MultiTransportChannelData block; empty if the client
+    /// sent no multitransport block.
+    pub multitransport_flags: gcc::MultiTransportFlags,
     /// Credentials received from the client during SecureSettingsExchange.
     ///
     /// Present for TLS-mode connections where the client sends credentials
@@ -99,6 +109,7 @@ impl Acceptor {
             reactivation: false,
             honor_client_desktop_size: false,
             client_keyboard_layout: 0,
+            client_multitransport: gcc::MultiTransportFlags::empty(),
         }
     }
 
@@ -150,6 +161,7 @@ impl Acceptor {
             reactivation: true,
             honor_client_desktop_size: consumed.honor_client_desktop_size,
             client_keyboard_layout: consumed.client_keyboard_layout,
+            client_multitransport: consumed.client_multitransport,
         })
     }
 
@@ -205,6 +217,7 @@ impl Acceptor {
                 reactivation: self.reactivation,
                 credentials: self.received_credentials.take(),
                 keyboard_layout: self.client_keyboard_layout,
+                multitransport_flags: self.client_multitransport,
             }),
             previous_state => {
                 self.state = previous_state;
@@ -464,6 +477,16 @@ impl Sequence for Acceptor {
                 // the server can serve a non-US layout. Always recorded (it's
                 // free); whether to act on it is the server's choice.
                 self.client_keyboard_layout = gcc_blocks.core.keyboard_layout;
+
+                // (vendored) Capture the client's multitransport (MS-RDPEMT)
+                // support flags so the server can decide whether to offer a UDP
+                // transport. Always recorded (it's free); whether to act on it
+                // is the server's choice. Empty if the client sent no block.
+                self.client_multitransport = gcc_blocks
+                    .multi_transport_channel
+                    .as_ref()
+                    .map(|m| m.flags)
+                    .unwrap_or_else(gcc::MultiTransportFlags::empty);
 
                 // (vendored) Adopt the client's requested desktop size from
                 // its Client Core Data before the server's Demand Active is

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -226,3 +226,32 @@ AND released — #1276 landing is NOT sufficient.
     upstreamable alongside the acceptor change. Verified live: sdl-freerdp
     `/kbd:layout:0x040C` → server logs `client keyboard layout announced
     klid=1036`, input handler logs `auto-selected … layout=com.apple.keylayout.French`.
+
+(12) RDP UDP multitransport (MS-RDPEMT) server support — **M1: negotiation only**
+    (NOT upstreamed; added 2026-06-25; behind the new `multitransport` cargo
+    feature, default OFF so the standard build is byte-identical; pairs with
+    `vendor/ironrdp-acceptor` divergence (3)). New `src/multitransport/mod.rs`
+    defines the `MultitransportProvider` trait (M1: one method,
+    `requested_protocol()`) + `MigrationState`. `RdpServer` gains
+    `multitransport: Option<Box<dyn MultitransportProvider>>` (setter
+    `set_multitransport_provider`, mirroring the handle-setter pattern) and a
+    per-connection `multitransport_migration: Option<MigrationState>`. In
+    `client_accepted` (initial accept only, not reactivation),
+    `maybe_offer_multitransport` sends a `MultitransportRequestPdu`
+    (`UdpFecR`/reliable) on the IO channel via a `SendDataIndication`
+    (BasicSecurityHeader-wrapped; NOT a ShareControl PDU — framed like
+    `encode_share_data_pdu` minus the ShareControl/ShareData wrapping) when the
+    client advertised `TRANSPORT_TYPE_UDP_FECR` + `SOFT_SYNC_TCP_TO_UDP`
+    (from acceptor divergence (3)). `handle_io_channel_data` tries `ShareControl`
+    decode first and, on failure, decodes a `MultitransportResponsePdu`
+    (re-validates the `TRANSPORT_RSP` flag) → `handle_multitransport_response`.
+    **M1 has NO UDP listener**: the client's out-of-band UDP attempt times out
+    and it reports `E_ABORT`, and the session continues on TCP unchanged — this
+    proves the negotiation/framing contract + graceful fallback before any
+    socket code. The negotiation PDUs (`MultitransportRequest/ResponsePdu`,
+    `RequestedProtocol`) and GCC `MultiTransportFlags` already exist in
+    `ironrdp-pdu` (unused upstream); only the server-side wiring is new. Later
+    milestones add `listener`/`session`/`router`/`migration` submodules (the UDP
+    transport + EGFX channel migration) and grow the trait. Feature-off path is
+    cfg-split to keep the original `?`-based decode byte-identical. See
+    `docs/rdp-udp-multitransport-feasibility.md` (the M1→M5 plan).

--- a/vendor/ironrdp-server/Cargo.toml
+++ b/vendor/ironrdp-server/Cargo.toml
@@ -26,6 +26,10 @@ rayon = ["dep:rayon"]
 qoi = ["dep:qoicoubeh", "ironrdp-pdu/qoi"]
 qoiz = ["dep:zstd-safe", "qoi", "ironrdp-pdu/qoiz"]
 egfx = ["dep:ironrdp-egfx"]
+# (vendored) RDP UDP multitransport (MS-RDPEMT) server support. Default off so
+# the standard build is byte-identical. M1 only performs the negotiation
+# handshake (Initiate Request -> Response) and always continues on TCP.
+multitransport = []
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at any time.

--- a/vendor/ironrdp-server/src/lib.rs
+++ b/vendor/ironrdp-server/src/lib.rs
@@ -18,6 +18,8 @@ mod gfx;
 mod handler;
 #[cfg(feature = "helper")]
 mod helper;
+#[cfg(feature = "multitransport")]
+mod multitransport;
 mod rdpdr;
 mod server;
 mod sound;
@@ -33,6 +35,8 @@ pub use echo::{EchoDvcBridge, EchoRoundTripMeasurement, EchoServerHandle, EchoSe
 #[cfg(feature = "egfx")]
 pub use gfx::{EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle};
 pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
+#[cfg(feature = "multitransport")]
+pub use multitransport::MultitransportProvider;
 pub use rdpdr::{
     AnnouncedDevice, DirEntry, RdpdrBackendFactory, RdpdrHandle, RdpdrServer, RdpdrServerFactory, RdpdrServerHandler,
     RdpdrServerMessage, RdpdrStatus, SCARD_EJECT_CARD, SCARD_LEAVE_CARD, SCARD_RESET_CARD, SCARD_SHARE_DIRECT,

--- a/vendor/ironrdp-server/src/lib.rs
+++ b/vendor/ironrdp-server/src/lib.rs
@@ -36,7 +36,7 @@ pub use echo::{EchoDvcBridge, EchoRoundTripMeasurement, EchoServerHandle, EchoSe
 pub use gfx::{EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle};
 pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "multitransport")]
-pub use multitransport::MultitransportProvider;
+pub use multitransport::{MultitransportProvider, encode_initiate_request};
 pub use rdpdr::{
     AnnouncedDevice, DirEntry, RdpdrBackendFactory, RdpdrHandle, RdpdrServer, RdpdrServerFactory, RdpdrServerHandler,
     RdpdrServerMessage, RdpdrStatus, SCARD_EJECT_CARD, SCARD_LEAVE_CARD, SCARD_RESET_CARD, SCARD_SHARE_DIRECT,

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -21,7 +21,12 @@
 //! `migration` submodules (the UDP transport + channel migration); the trait
 //! will gain methods accordingly.
 
-use ironrdp_pdu::rdp::multitransport::RequestedProtocol;
+use anyhow::Result;
+use ironrdp_core::encode_vec;
+use ironrdp_pdu::mcs::SendDataIndication;
+use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
+use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, RequestedProtocol};
+use ironrdp_pdu::x224::X224;
 
 /// Server-side hook for RDP UDP multitransport. A provider, when installed via
 /// [`RdpServer::set_multitransport_provider`](crate::RdpServer::set_multitransport_provider),
@@ -34,6 +39,37 @@ pub trait MultitransportProvider: Send {
     /// M1 implementations return [`RequestedProtocol::UdpFecR`] (reliable —
     /// RDPEUDP2 + TLS, no DTLS). Lossy (`UdpFecL`) is a later milestone.
     fn requested_protocol(&self) -> RequestedProtocol;
+}
+
+/// Encode a Server Initiate Multitransport Request (MS-RDPBCGR 2.2.15.1) as a
+/// `SendDataIndication` on the IO channel. The Initiate Request is a
+/// `BasicSecurityHeader`-wrapped PDU, **not** a ShareControl PDU — so this
+/// mirrors `server::encode_share_data_pdu` minus the ShareControl/ShareData
+/// wrapping. Pure + exported so the framing can be round-trip tested (the
+/// vendored crate itself is built with `test = false`, so the test lives in the
+/// macrdp crate).
+pub fn encode_initiate_request(
+    request_id: u32,
+    protocol: RequestedProtocol,
+    security_cookie: [u8; 16],
+    io_channel_id: u16,
+    user_channel_id: u16,
+) -> Result<Vec<u8>> {
+    let pdu = MultitransportRequestPdu {
+        security_header: BasicSecurityHeader {
+            flags: BasicSecurityHeaderFlags::TRANSPORT_REQ,
+        },
+        request_id,
+        requested_protocol: protocol,
+        security_cookie,
+    };
+    let user_data = encode_vec(&pdu)?.into();
+    let mcs_pdu = SendDataIndication {
+        initiator_id: user_channel_id,
+        channel_id: io_channel_id,
+        user_data,
+    };
+    Ok(encode_vec(&X224(mcs_pdu))?)
 }
 
 /// Per-connection negotiation state for an in-flight multitransport request:

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -1,0 +1,52 @@
+//! (vendored) Server-side RDP UDP multitransport (MS-RDPEMT) support.
+//!
+//! Gated behind the `multitransport` cargo feature (default off) so the
+//! standard build is byte-identical. This is the macrdp UDP-multitransport
+//! effort; see `docs/rdp-udp-multitransport-feasibility.md` and the
+//! `vendor/ironrdp-server/CLAUDE.md` divergence (12) for the full plan.
+//!
+//! # Milestone status
+//!
+//! **M1 (this code): negotiation only.** When a [`MultitransportProvider`] is
+//! installed AND the client advertised UDP support in its GCC
+//! `MultiTransportChannelData` block (surfaced by the vendored acceptor on
+//! `AcceptorResult::multitransport_flags`), the server sends a
+//! `MultitransportRequestPdu` on the IO channel after licensing and matches the
+//! client's `MultitransportResponsePdu`. There is **no UDP listener yet**, so
+//! the client's out-of-band UDP attempt times out and it reports `E_ABORT`; the
+//! session continues on TCP unchanged. This proves the negotiation/framing
+//! contract and the graceful-fallback path before any socket code exists.
+//!
+//! Later milestones grow this module with `listener`/`session`/`router`/
+//! `migration` submodules (the UDP transport + channel migration); the trait
+//! will gain methods accordingly.
+
+use ironrdp_pdu::rdp::multitransport::RequestedProtocol;
+
+/// Server-side hook for RDP UDP multitransport. A provider, when installed via
+/// [`RdpServer::set_multitransport_provider`](crate::RdpServer::set_multitransport_provider),
+/// makes the server *offer* an auxiliary UDP transport to clients that
+/// advertise support. The provider expresses **what** to offer; the server owns
+/// the negotiation handshake and (in later milestones) the transport itself.
+pub trait MultitransportProvider: Send {
+    /// Which UDP transport protocol to request from the client.
+    ///
+    /// M1 implementations return [`RequestedProtocol::UdpFecR`] (reliable —
+    /// RDPEUDP2 + TLS, no DTLS). Lossy (`UdpFecL`) is a later milestone.
+    fn requested_protocol(&self) -> RequestedProtocol;
+}
+
+/// Per-connection negotiation state for an in-flight multitransport request:
+/// the `request_id` + 16-byte security cookie the server issued in the
+/// `MultitransportRequestPdu`, used to match the client's
+/// `MultitransportResponsePdu` (and, in later milestones, to bind the inbound
+/// UDP flow to this session).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MigrationState {
+    pub request_id: u32,
+    /// Issued in the request and (M1) not read again — later milestones bind the
+    /// inbound UDP flow to this session by matching the echoed cookie.
+    #[allow(dead_code)]
+    pub cookie: [u8; 16],
+    pub protocol: RequestedProtocol,
+}

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -1336,8 +1336,7 @@ impl RdpServer {
         W: FramedWrite,
     {
         use ironrdp_pdu::gcc::MultiTransportFlags;
-        use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
-        use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, RequestedProtocol};
+        use ironrdp_pdu::rdp::multitransport::RequestedProtocol;
 
         let Some(provider) = self.multitransport.as_ref() else {
             return Ok(());
@@ -1367,21 +1366,13 @@ impl RdpServer {
             *b = (request_id.wrapping_mul(2_654_435_761).wrapping_add(i as u32) & 0xff) as u8;
         }
 
-        let pdu = MultitransportRequestPdu {
-            security_header: BasicSecurityHeader {
-                flags: BasicSecurityHeaderFlags::TRANSPORT_REQ,
-            },
+        let data = crate::multitransport::encode_initiate_request(
             request_id,
-            requested_protocol: protocol,
-            security_cookie: cookie,
-        };
-        let user_data = encode_vec(&pdu)?.into();
-        let mcs_pdu = SendDataIndication {
-            initiator_id: user_channel_id,
-            channel_id: io_channel_id,
-            user_data,
-        };
-        let data = encode_vec(&X224(mcs_pdu))?;
+            protocol,
+            cookie,
+            io_channel_id,
+            user_channel_id,
+        )?;
         writer.write_all(&data).await?;
         self.multitransport_migration = Some(crate::multitransport::MigrationState {
             request_id,

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -332,6 +332,17 @@ pub struct RdpServer {
     /// `MacInputHandler`) holds a clone and auto-selects a matching layout, so
     /// non-US clients type correctly with no manual configuration. 0 = unknown.
     keyboard_layout: Option<Arc<AtomicU32>>,
+    /// (vendored) Optional UDP-multitransport provider (MS-RDPEMT). When set,
+    /// the server offers an auxiliary UDP transport to clients that advertise
+    /// support in their GCC MultiTransportChannelData block. M1: negotiation
+    /// only (no UDP listener); see `src/multitransport/`.
+    #[cfg(feature = "multitransport")]
+    multitransport: Option<Box<dyn crate::multitransport::MultitransportProvider>>,
+    /// (vendored) Per-connection multitransport negotiation state (the issued
+    /// `request_id` + cookie) used to match the client's
+    /// `MultitransportResponsePdu`. Reset every connection in `client_accepted`.
+    #[cfg(feature = "multitransport")]
+    multitransport_migration: Option<crate::multitransport::MigrationState>,
 }
 
 #[derive(Debug)]
@@ -430,6 +441,10 @@ impl RdpServer {
             display_suppressed: Arc::new(AtomicBool::new(false)),
             keyboard_layout: None,
             honor_client_desktop_size: false,
+            #[cfg(feature = "multitransport")]
+            multitransport: None,
+            #[cfg(feature = "multitransport")]
+            multitransport_migration: None,
         }
     }
 
@@ -484,6 +499,19 @@ impl RdpServer {
     /// called before any client connects.
     pub fn set_keyboard_layout_handle(&mut self, handle: Arc<AtomicU32>) {
         self.keyboard_layout = Some(handle);
+    }
+
+    /// (vendored) Install a UDP-multitransport provider (MS-RDPEMT). When set,
+    /// the server offers an auxiliary UDP transport to clients that advertise
+    /// support in their GCC MultiTransportChannelData block (surfaced by the
+    /// acceptor). M1 performs only the negotiation handshake and always
+    /// continues on TCP. Must be called before any client connects.
+    #[cfg(feature = "multitransport")]
+    pub fn set_multitransport_provider(
+        &mut self,
+        provider: Option<Box<dyn crate::multitransport::MultitransportProvider>>,
+    ) {
+        self.multitransport = provider;
     }
 
     /// Returns the shared ECHO server handle for runtime probe requests and RTT measurements.
@@ -1291,6 +1319,123 @@ impl RdpServer {
         state
     }
 
+    /// (vendored, feature=multitransport) Send a Server Initiate Multitransport
+    /// Request (MS-RDPEMT) on the IO channel when a provider is installed and the
+    /// client advertised matching UDP support + soft-sync. M1 has no UDP
+    /// listener, so this only proves the negotiation/framing contract and the
+    /// graceful `E_ABORT` fallback; the session stays on TCP.
+    #[cfg(feature = "multitransport")]
+    async fn maybe_offer_multitransport<W>(
+        &mut self,
+        writer: &mut Framed<W>,
+        io_channel_id: u16,
+        user_channel_id: u16,
+        client_flags: ironrdp_pdu::gcc::MultiTransportFlags,
+    ) -> Result<()>
+    where
+        W: FramedWrite,
+    {
+        use ironrdp_pdu::gcc::MultiTransportFlags;
+        use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
+        use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, RequestedProtocol};
+
+        let Some(provider) = self.multitransport.as_ref() else {
+            return Ok(());
+        };
+        let protocol = provider.requested_protocol();
+        let needed = match protocol {
+            RequestedProtocol::UdpFecR => MultiTransportFlags::TRANSPORT_TYPE_UDP_FECR,
+            RequestedProtocol::UdpFecL => MultiTransportFlags::TRANSPORT_TYPE_UDP_FECL,
+        };
+        if !client_flags.contains(needed) || !client_flags.contains(MultiTransportFlags::SOFT_SYNC_TCP_TO_UDP) {
+            debug!(
+                ?protocol,
+                ?client_flags,
+                "not offering multitransport: client lacks the requested UDP transport + soft-sync"
+            );
+            return Ok(());
+        }
+
+        // `request_id` is a process-wide counter; the 16-byte cookie will bind
+        // the future UDP flow to this TCP session. M1 has no listener, so the
+        // cookie is never validated — a deterministic placeholder is fine here.
+        // TODO(M3): generate the cookie from a CSPRNG once the listener exists.
+        static MT_REQUEST_ID: AtomicU32 = AtomicU32::new(1);
+        let request_id = MT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+        let mut cookie = [0u8; 16];
+        for (i, b) in cookie.iter_mut().enumerate() {
+            *b = (request_id.wrapping_mul(2_654_435_761).wrapping_add(i as u32) & 0xff) as u8;
+        }
+
+        let pdu = MultitransportRequestPdu {
+            security_header: BasicSecurityHeader {
+                flags: BasicSecurityHeaderFlags::TRANSPORT_REQ,
+            },
+            request_id,
+            requested_protocol: protocol,
+            security_cookie: cookie,
+        };
+        let user_data = encode_vec(&pdu)?.into();
+        let mcs_pdu = SendDataIndication {
+            initiator_id: user_channel_id,
+            channel_id: io_channel_id,
+            user_data,
+        };
+        let data = encode_vec(&X224(mcs_pdu))?;
+        writer.write_all(&data).await?;
+        self.multitransport_migration = Some(crate::multitransport::MigrationState {
+            request_id,
+            cookie,
+            protocol,
+        });
+        debug!(
+            request_id,
+            ?protocol,
+            "sent Server Initiate Multitransport Request (M1: negotiation only; expecting E_ABORT fallback)"
+        );
+        Ok(())
+    }
+
+    /// (vendored, feature=multitransport) Handle the client's Initiate
+    /// Multitransport Response. M1 has no UDP transport, so this only logs the
+    /// outcome and clears the in-flight request; the session stays on TCP.
+    #[cfg(feature = "multitransport")]
+    fn handle_multitransport_response(
+        &mut self,
+        resp: &ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu,
+    ) {
+        match self.multitransport_migration.take() {
+            Some(state) if state.request_id == resp.request_id => {
+                if resp.is_success() {
+                    debug!(
+                        request_id = resp.request_id,
+                        protocol = ?state.protocol,
+                        "multitransport response S_OK (unexpected in M1 with no listener); staying on TCP"
+                    );
+                } else {
+                    debug!(
+                        request_id = resp.request_id,
+                        protocol = ?state.protocol,
+                        hr = format_args!("{:#010x}", resp.hr_response),
+                        "multitransport response: client could not establish UDP; continuing on TCP (expected in M1)"
+                    );
+                }
+            }
+            Some(other) => {
+                let in_flight = other.request_id;
+                self.multitransport_migration = Some(other);
+                warn!(
+                    got = resp.request_id,
+                    in_flight, "multitransport response with mismatched request_id; ignoring"
+                );
+            }
+            None => warn!(
+                request_id = resp.request_id,
+                "multitransport response with no request in flight; ignoring"
+            ),
+        }
+    }
+
     async fn client_accepted<R, W>(
         &mut self,
         reader: &mut Framed<R>,
@@ -1332,6 +1477,22 @@ impl RdpServer {
                 let response = server_encode_svc_messages(svc_responses, channel_id, result.user_channel_id)?;
                 writer.write_all(&response).await?;
             }
+        }
+
+        // (vendored, feature=multitransport) Offer an auxiliary UDP transport
+        // (MS-RDPEMT) when a provider is installed and the client advertised
+        // matching support. Initial accept only (not a reactivation resize).
+        // M1: negotiation only — no UDP listener, so the client's UDP attempt
+        // times out and it reports E_ABORT; the session continues on TCP.
+        #[cfg(feature = "multitransport")]
+        if !result.reactivation {
+            self.maybe_offer_multitransport(
+                writer,
+                result.io_channel_id,
+                result.user_channel_id,
+                result.multitransport_flags,
+            )
+            .await?;
         }
 
         let mut update_codecs = UpdateEncoderCodecs::new();
@@ -1493,7 +1654,26 @@ impl RdpServer {
     }
 
     async fn handle_io_channel_data(&mut self, data: SendDataRequest<'_>) -> Result<bool> {
+        #[cfg(not(feature = "multitransport"))]
         let control: rdp::headers::ShareControlHeader = decode(data.user_data.as_ref())?;
+        // (vendored, feature=multitransport) The client's Initiate Multitransport
+        // Response rides the IO channel as a BasicSecurityHeader PDU (not a
+        // ShareControl PDU). Try ShareControl first (the common case, and it
+        // validates its pduType so a security-header PDU fails it); only on
+        // failure attempt the response, which re-checks the TRANSPORT_RSP flag.
+        #[cfg(feature = "multitransport")]
+        let control: rdp::headers::ShareControlHeader = match decode(data.user_data.as_ref()) {
+            Ok(control) => control,
+            Err(e) => {
+                if let Ok(resp) = decode::<ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu>(
+                    data.user_data.as_ref(),
+                ) {
+                    self.handle_multitransport_response(&resp);
+                    return Ok(false);
+                }
+                return Err(e.into());
+            }
+        };
 
         match control.share_control_pdu {
             ShareControlPdu::Data(header) => match header.share_data_pdu {


### PR DESCRIPTION
First milestone of **RDP UDP multitransport** (MS-RDPEMT over RDPEUDP) — see the approved plan in `docs/rdp-udp-multitransport-feasibility.md` (M1→M5).

## What this is — and isn't
**M1 is negotiation only.** When enabled, the server tells UDP-capable clients it's willing to do reliable UDP, sends the *Initiate Multitransport Request*, and handles the client's response. **There is NO UDP listener yet**, so the client's out-of-band UDP attempt times out → it reports `E_ABORT` → the session continues on **TCP, unchanged**. The point is to prove the negotiation/framing contract and the graceful-fallback path *before* any socket/RDPEUDP code (which lands in M2–M5).

Gated behind the new `multitransport` cargo feature + `--enable-udp-multitransport` (default OFF). The feature-off path is byte-identical (cfg-split decode).

## Changes
- **acceptor** (divergence 3): surface the client's GCC `MultiTransportChannelData` flags on `AcceptorResult.multitransport_flags` — mirrors the existing `keyboard_layout` divergence (upstream parses them, then discards).
- **server** (divergence 12): new `src/multitransport/` module (`MultitransportProvider` trait + `MigrationState`); `RdpServer` field + `set_multitransport_provider`; `client_accepted` sends a `MultitransportRequestPdu` (`UdpFecR`) on the IO channel when the client advertised `TRANSPORT_TYPE_UDP_FECR` + `SOFT_SYNC_TCP_TO_UDP`; `handle_io_channel_data` tries `ShareControl` first, then decodes the `BasicSecurityHeader`-wrapped `MultitransportResponsePdu`. The negotiation PDUs + GCC flags already exist (unused) in `ironrdp-pdu` — only the server wiring is new.
- **macrdp**: `--enable-udp-multitransport` flag + `ENABLE_UDP_MULTITRANSPORT` config key + `src/multitransport.rs` provider; enables the feature on the `ironrdp-server` dep. Config tests cover the flag.

## Verification
- `cargo build` + `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.
- **63 tests pass**, incl. the `conn_test` reconnect/codec regression suite — confirms the TCP path is intact with the feature on.
- The `conn_test` IronRDP-client harness can't exercise UDP (no client-side RDPEUDP); **real-client M1 acceptance is manual**: mstsc/FreeRDP advertise UDP → server logs the flags + sends the request → client replies `E_ABORT` → desktop renders over TCP normally.

Part of the staged effort (M1 first, then iterate). No user-facing surfaces (GUI toggle / config.env.example) yet — the flag is dev/experimental until the UDP data path exists.