### PR TITLE
feat(udp-multitransport): M2b-2 — reliable RDPEUDP transport state machine

### DIFF
--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -38,11 +38,22 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 - **M2a (done):** MS-RDPEUDP **v1** PDU codecs in `src/pdu.rs` — `FecHeader` +
   `FecFlags`, `SynData`, `SynDataEx` (+ `UdpVersion`/`SynExFlags`, the `0x0101`
   selector for RDPEUDP2), `CorrelationId`, `SourcePayloadHeader`. Round-trip
-  tested.
-- **M2b (next):** `RDPUDP_ACK_VECTOR_HEADER` (fetch its exact padding from
-  MS-RDPEUDP 2.2.2.7 first) + the reliability state machine (`step()`/`enqueue()`
-  over v1 framing), tested in-memory under loss/reorder/dup.
+  tested. (`FecFlags` values were corrected against the spec in M2b-1 — they were
+  wrong from `0x0080` up when first authored from memory.)
+- **M2b-1 (done):** `RDPUDP_ACK_VECTOR_HEADER` codec in `src/pdu.rs`
+  (`VectorElementState` 2-bit + `AckVectorElement` 6-bit run length +
+  `AckVectorHeader`, padded to a 4-byte multiple).
+- **M2b-2 (done):** `src/datagram.rs` (whole-datagram assemble/parse: SYN /
+  SYN+ACK / DATA / ACK) + `src/state.rs` — the sans-I/O reliable transport state
+  machine (`RdpeudpState::{start,enqueue,step}`, `now_ms` clock). Passive+active
+  open, reliable in-order de-duplicated delivery (receiver buffers out-of-order,
+  sender uses cumulative ACK + RTO retransmit), fixed window. Tested by two
+  instances over an in-memory lossy/reorder/dup channel across seeds. **Scope
+  caveats:** cumulative-ACK only (selective retransmit via the ACK *vector* and
+  congestion control are deferred); the two-instance test proves the *algorithm*
+  (my SM ↔ my SM), not Windows wire-compat — mstsc's data path is EUDP2.
 - **EUDP2 (spike-gated, NOT started):** the RDPEUDP2 (`0x0101`) bit-packed
-  framing is underdocumented — **validate against a real mstsc capture +
-  FreeRDP's `rdpudp` source before authoring the structs** (do NOT author from
-  the spec alone; internal round-trip tests would be circular).
+  framing is underdocumented and is what mstsc actually uses for data — **validate
+  against a real mstsc capture + FreeRDP's `rdpudp` source before authoring the
+  structs** (do NOT author from the spec alone; internal round-trip tests would
+  be circular). Needs a capture from the user; gates M3/M4 real-client interop.

--- a/vendor/ironrdp-rdpeudp/src/datagram.rs
+++ b/vendor/ironrdp-rdpeudp/src/datagram.rs
@@ -1,0 +1,257 @@
+//! Whole-datagram assembly/parsing for RDPEUDP **v1**: composes the [`pdu`]
+//! primitives (FEC header + optional SYN / ACK-vector / source sections) into a
+//! single datagram and back, driven by the [`FecFlags`].
+//!
+//! This is the wire layer the reliability state machine ([`crate::state`]) emits
+//! and consumes. It deliberately models only what that machine needs (SYN /
+//! SYN+ACK / data / ack), not every optional MS-RDPEUDP section (ACK-of-acks and
+//! FEC payloads are not produced). The RDPEUDP2 (`0x0101`) data framing is a
+//! separate, spike-gated codec — see the crate docs.
+//!
+//! [`pdu`]: crate::pdu
+//! [`FecFlags`]: crate::pdu::FecFlags
+
+use ironrdp_core::{
+    decode_cursor, encode_cursor, DecodeResult, EncodeResult, ReadCursor, WriteCursor,
+};
+
+use crate::pdu::{
+    AckVectorHeader, CorrelationId, FecFlags, FecHeader, SourcePayloadHeader, SynData, SynDataEx,
+};
+
+/// The application payload carried by a source (DATA) packet, with its sequence
+/// header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourcePacket {
+    pub header: SourcePayloadHeader,
+    pub payload: Vec<u8>,
+}
+
+/// A decoded/decodable RDPEUDP v1 datagram: the mandatory [`FecHeader`] plus
+/// whichever optional sections its flags select. Construct via the helpers
+/// ([`Datagram::syn`], [`Datagram::data`], [`Datagram::ack`]) so the flags and
+/// sections stay consistent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Datagram {
+    pub fec: FecHeader,
+    pub ack_vector: Option<AckVectorHeader>,
+    pub source: Option<SourcePacket>,
+    pub syn: Option<SynData>,
+    pub correlation: Option<CorrelationId>,
+    pub syn_ex: Option<SynDataEx>,
+}
+
+impl Datagram {
+    /// A SYN (or SYN+ACK, when `ack_vector` is `Some`) datagram: carries SYNDATA
+    /// and optionally SYNEX (version negotiation). `snSourceAck` is the caller's
+    /// (use `-1` for an initial SYN).
+    pub fn syn(
+        snd_source_ack: i32,
+        recv_window: u16,
+        syn: SynData,
+        syn_ex: Option<SynDataEx>,
+        ack_vector: Option<AckVectorHeader>,
+    ) -> Self {
+        let mut flags = FecFlags::SYN;
+        if syn_ex.is_some() {
+            flags |= FecFlags::SYNEX;
+        }
+        if ack_vector.is_some() {
+            flags |= FecFlags::ACK;
+        }
+        Self {
+            fec: FecHeader {
+                snd_source_ack,
+                recv_window,
+                flags,
+            },
+            ack_vector,
+            source: None,
+            syn: Some(syn),
+            correlation: None,
+            syn_ex,
+        }
+    }
+
+    /// A DATA+ACK datagram: a source payload plus the cumulative/selective ACK.
+    pub fn data(
+        snd_source_ack: i32,
+        recv_window: u16,
+        ack_vector: AckVectorHeader,
+        source: SourcePacket,
+    ) -> Self {
+        Self {
+            fec: FecHeader {
+                snd_source_ack,
+                recv_window,
+                flags: FecFlags::DATA | FecFlags::ACK,
+            },
+            ack_vector: Some(ack_vector),
+            source: Some(source),
+            syn: None,
+            correlation: None,
+            syn_ex: None,
+        }
+    }
+
+    /// A pure ACK datagram (no payload).
+    pub fn ack(snd_source_ack: i32, recv_window: u16, ack_vector: AckVectorHeader) -> Self {
+        Self {
+            fec: FecHeader {
+                snd_source_ack,
+                recv_window,
+                flags: FecFlags::ACK,
+            },
+            ack_vector: Some(ack_vector),
+            source: None,
+            syn: None,
+            correlation: None,
+            syn_ex: None,
+        }
+    }
+
+    pub fn encode(&self) -> EncodeResult<Vec<u8>> {
+        // Worst-case size; the cursor encoder only writes what's present.
+        let cap = 8 + 8 + 8 + 4 + 32 + 36 + self.source.as_ref().map_or(0, |s| s.payload.len());
+        let mut buf = vec![0u8; cap];
+        let written = {
+            let mut cursor = WriteCursor::new(&mut buf);
+            self.encode_cursor(&mut cursor)?;
+            cursor.pos()
+        };
+        buf.truncate(written);
+        Ok(buf)
+    }
+
+    fn encode_cursor(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        encode_cursor(&self.fec, dst)?;
+        // Section order mirrors MS-RDPEUDP: ACK vector, then (for data) the
+        // source payload; for SYN datagrams the SYN sections follow.
+        if let Some(ack) = &self.ack_vector {
+            encode_cursor(ack, dst)?;
+        }
+        if let Some(src) = &self.source {
+            encode_cursor(&src.header, dst)?;
+            dst.write_slice(&src.payload);
+        }
+        if let Some(syn) = &self.syn {
+            encode_cursor(syn, dst)?;
+        }
+        if let Some(corr) = &self.correlation {
+            encode_cursor(corr, dst)?;
+        }
+        if let Some(ex) = &self.syn_ex {
+            encode_cursor(ex, dst)?;
+        }
+        Ok(())
+    }
+
+    pub fn decode(bytes: &[u8]) -> DecodeResult<Self> {
+        let mut cursor = ReadCursor::new(bytes);
+        let fec: FecHeader = decode_cursor(&mut cursor)?;
+        let flags = fec.flags;
+
+        let ack_vector = if flags.contains(FecFlags::ACK) {
+            Some(decode_cursor::<AckVectorHeader>(&mut cursor)?)
+        } else {
+            None
+        };
+
+        // For a SYN datagram the trailing bytes are SYN sections, not a source
+        // payload; for a data datagram they are the source header + payload.
+        let (source, syn, correlation, syn_ex) = if flags.contains(FecFlags::SYN) {
+            let syn = Some(decode_cursor::<SynData>(&mut cursor)?);
+            let correlation = if flags.contains(FecFlags::CORRELATION_ID) {
+                Some(decode_cursor::<CorrelationId>(&mut cursor)?)
+            } else {
+                None
+            };
+            let syn_ex = if flags.contains(FecFlags::SYNEX) {
+                Some(decode_cursor::<SynDataEx>(&mut cursor)?)
+            } else {
+                None
+            };
+            (None, syn, correlation, syn_ex)
+        } else if flags.contains(FecFlags::DATA) {
+            let header: SourcePayloadHeader = decode_cursor(&mut cursor)?;
+            let payload = cursor.read_remaining().to_vec();
+            (Some(SourcePacket { header, payload }), None, None, None)
+        } else {
+            (None, None, None, None)
+        };
+
+        Ok(Self {
+            fec,
+            ack_vector,
+            source,
+            syn,
+            correlation,
+            syn_ex,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pdu::{AckVectorElement, UdpVersion, VectorElementState};
+
+    fn empty_ack() -> AckVectorHeader {
+        AckVectorHeader { elements: vec![] }
+    }
+
+    #[test]
+    fn syn_with_synex_round_trips() {
+        let d = Datagram::syn(
+            -1,
+            64,
+            SynData {
+                initial_seq: 0x1111_2222,
+                upstream_mtu: 1232,
+                downstream_mtu: 1232,
+            },
+            Some(SynDataEx {
+                flags: crate::pdu::SynExFlags::VERSION_INFO_VALID,
+                udp_version: UdpVersion::V2,
+                cookie_hash: None,
+            }),
+            None,
+        );
+        let bytes = d.encode().unwrap();
+        assert_eq!(Datagram::decode(&bytes).unwrap(), d);
+    }
+
+    #[test]
+    fn data_packet_round_trips() {
+        let d = Datagram::data(
+            41,
+            64,
+            AckVectorHeader {
+                elements: vec![AckVectorElement {
+                    state: VectorElementState::Received,
+                    run_length: 3,
+                }],
+            },
+            SourcePacket {
+                header: SourcePayloadHeader {
+                    sn_coded: 42,
+                    sn_source_start: 42,
+                },
+                payload: b"hello rdpeudp".to_vec(),
+            },
+        );
+        let bytes = d.encode().unwrap();
+        let back = Datagram::decode(&bytes).unwrap();
+        assert_eq!(back, d);
+        assert_eq!(back.source.unwrap().payload, b"hello rdpeudp");
+    }
+
+    #[test]
+    fn pure_ack_round_trips() {
+        let d = Datagram::ack(7, 64, empty_ack());
+        let bytes = d.encode().unwrap();
+        let back = Datagram::decode(&bytes).unwrap();
+        assert_eq!(back, d);
+        assert!(back.source.is_none() && back.syn.is_none());
+    }
+}

--- a/vendor/ironrdp-rdpeudp/src/lib.rs
+++ b/vendor/ironrdp-rdpeudp/src/lib.rs
@@ -25,4 +25,6 @@
 //! little-endian. Every multi-byte field here is encoded/decoded big-endian (via
 //! `to_be_bytes`/`from_be_bytes`), confirmed against the spec's capture example.
 
+pub mod datagram;
 pub mod pdu;
+pub mod state;

--- a/vendor/ironrdp-rdpeudp/src/state.rs
+++ b/vendor/ironrdp-rdpeudp/src/state.rs
@@ -1,0 +1,520 @@
+//! Sans-I/O reliable RDPEUDP **v1** transport state machine.
+//!
+//! Feed it inbound datagrams + a monotonic millisecond clock; it returns the
+//! application bytes to deliver (in order, exactly once) and the datagrams to
+//! put on the wire. No sockets, no async — the caller owns I/O and the clock,
+//! which makes the whole thing deterministically testable (two instances driven
+//! against each other over an in-memory lossy channel; see the tests).
+//!
+//! # Scope (M2b-2)
+//!
+//! - Passive (server) **and** active (client) open, so two instances can talk.
+//! - Reliable, in-order, de-duplicated delivery: the receiver buffers
+//!   out-of-order datagrams and delivers contiguous runs; the sender uses the
+//!   **cumulative** ACK (`snSourceAck`) to release in-flight packets and
+//!   retransmits the unacked window on RTO. (Selective retransmit via the ACK
+//!   *vector* is a later optimization — the vector is sent empty for now.)
+//! - Fixed send window bounded by the peer's `uReceiveWindowSize`. No congestion
+//!   control / FEC yet.
+//!
+//! The on-wire framing is v1 ([`crate::datagram`]); the algorithm here is
+//! framing-agnostic and is what an RDPEUDP2 codec would later reuse.
+
+use std::collections::{BTreeMap, VecDeque};
+
+use crate::datagram::{Datagram, SourcePacket};
+use crate::pdu::{AckVectorHeader, SourcePayloadHeader};
+
+/// Which end of the connection this instance is. macrdp (the RDP server) is the
+/// passive [`Role::Server`]; [`Role::Client`] exists so two instances can be
+/// driven against each other in tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// Active opener — sends the SYN.
+    Client,
+    /// Passive opener — waits for a SYN, replies SYN+ACK.
+    Server,
+}
+
+/// Per-connection configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    /// Advertised receive window, in datagrams (`uReceiveWindowSize`).
+    pub recv_window: u16,
+    /// Our MTU (1132..=1232 per spec); bounds the per-packet payload.
+    pub mtu: u16,
+    /// Our initial sequence number (the first source-packet sequence we send).
+    pub initial_seq: u32,
+    /// Retransmit timeout, milliseconds.
+    pub rto_ms: u64,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            recv_window: 64,
+            mtu: 1232,
+            initial_seq: 0,
+            rto_ms: 300,
+        }
+    }
+}
+
+/// What a [`RdpeudpState::step`]/[`RdpeudpState::enqueue`] call produced.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct StepOutput {
+    /// Application payloads to hand up, in order, each exactly once.
+    pub delivered: Vec<Vec<u8>>,
+    /// Encoded datagrams to transmit.
+    pub to_send: Vec<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnState {
+    /// Server, before any SYN.
+    Listen,
+    /// Client, SYN sent, awaiting SYN+ACK.
+    SynSent,
+    Established,
+}
+
+struct Unacked {
+    seq: u32,
+    payload: Vec<u8>,
+    last_sent_ms: u64,
+}
+
+/// A reliable RDPEUDP v1 transport endpoint.
+pub struct RdpeudpState {
+    role: Role,
+    state: ConnState,
+    cfg: Config,
+
+    // Negotiated from the peer's SYN / SYN+ACK.
+    peer_recv_window: u16,
+
+    // Send side.
+    send_next: u32,
+    out_queue: VecDeque<u8>,
+    unacked: VecDeque<Unacked>,
+    syn_last_sent_ms: u64,
+
+    // Receive side.
+    recv_next: u32,
+    reorder: BTreeMap<u32, Vec<u8>>,
+    need_ack: bool,
+    have_peer_seq: bool,
+}
+
+/// `a <= b` in 32-bit wrapping sequence space (RFC 793 style).
+fn seq_leq(a: u32, b: u32) -> bool {
+    b.wrapping_sub(a) < 0x8000_0000
+}
+
+impl RdpeudpState {
+    pub fn new(role: Role, cfg: Config) -> Self {
+        Self {
+            role,
+            state: match role {
+                Role::Client => ConnState::SynSent, // becomes active on `start`
+                Role::Server => ConnState::Listen,
+            },
+            cfg,
+            peer_recv_window: 1,
+            send_next: cfg.initial_seq,
+            out_queue: VecDeque::new(),
+            unacked: VecDeque::new(),
+            syn_last_sent_ms: 0,
+            recv_next: 0,
+            reorder: BTreeMap::new(),
+            need_ack: false,
+            have_peer_seq: false,
+        }
+    }
+
+    pub fn is_established(&self) -> bool {
+        self.state == ConnState::Established
+    }
+
+    /// Client: emit the initial SYN. Server: no-op (it waits for the SYN).
+    pub fn start(&mut self, now_ms: u64) -> StepOutput {
+        let mut out = StepOutput::default();
+        if self.role == Role::Client {
+            self.state = ConnState::SynSent;
+            self.syn_last_sent_ms = now_ms;
+            out.to_send.push(self.encode_syn());
+        }
+        self.pump(now_ms, &mut out);
+        out
+    }
+
+    /// Queue application bytes for reliable delivery, then pump.
+    pub fn enqueue(&mut self, now_ms: u64, data: &[u8]) -> StepOutput {
+        self.out_queue.extend(data.iter().copied());
+        let mut out = StepOutput::default();
+        self.pump(now_ms, &mut out);
+        out
+    }
+
+    /// Process an inbound datagram (or `None` for a timer-only tick), then pump.
+    pub fn step(&mut self, now_ms: u64, inbound: Option<&[u8]>) -> StepOutput {
+        let mut out = StepOutput::default();
+        if let Some(bytes) = inbound {
+            if let Ok(dg) = Datagram::decode(bytes) {
+                self.handle(&dg, &mut out);
+            }
+            // Malformed datagrams are dropped (UDP — anything can arrive).
+        }
+        self.pump(now_ms, &mut out);
+        out
+    }
+
+    fn handle(&mut self, dg: &Datagram, out: &mut StepOutput) {
+        // Learn the peer's first sequence number from its SYN / SYN+ACK.
+        if let Some(syn) = &dg.syn {
+            self.peer_recv_window = self.peer_recv_window.max(dg.fec.recv_window).max(1);
+            if !self.have_peer_seq {
+                self.recv_next = syn.initial_seq;
+                self.have_peer_seq = true;
+            }
+            match self.role {
+                // Server: a (possibly duplicate) SYN — (re)send SYN+ACK and be established.
+                Role::Server => {
+                    self.state = ConnState::Established;
+                    out.to_send.push(self.encode_syn());
+                }
+                // Client: the SYN+ACK completes our open.
+                Role::Client => {
+                    if self.state == ConnState::SynSent {
+                        self.state = ConnState::Established;
+                    }
+                }
+            }
+        } else {
+            self.peer_recv_window = dg.fec.recv_window.max(1);
+        }
+
+        // Release packets the peer has cumulatively acknowledged.
+        self.process_ack(dg.fec.snd_source_ack);
+
+        // Take in a source payload.
+        if let Some(src) = &dg.source {
+            self.recv_source(src, out);
+        }
+    }
+
+    fn process_ack(&mut self, snd_source_ack: i32) {
+        let ack = snd_source_ack as u32;
+        while let Some(front) = self.unacked.front() {
+            // Drop everything up to and including the cumulative ack.
+            if seq_leq(front.seq, ack) {
+                self.unacked.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn recv_source(&mut self, src: &SourcePacket, out: &mut StepOutput) {
+        let seq = src.header.sn_source_start;
+        if !self.have_peer_seq {
+            // Data before we learned the peer's ISN: adopt it.
+            self.recv_next = seq;
+            self.have_peer_seq = true;
+        }
+        self.need_ack = true;
+
+        if seq == self.recv_next {
+            out.delivered.push(src.payload.clone());
+            self.recv_next = self.recv_next.wrapping_add(1);
+            // Drain any contiguous buffered datagrams.
+            while let Some(payload) = self.reorder.remove(&self.recv_next) {
+                out.delivered.push(payload);
+                self.recv_next = self.recv_next.wrapping_add(1);
+            }
+        } else if seq_leq(self.recv_next, seq) {
+            // Future datagram within/after the window: buffer it (dedup by seq).
+            self.reorder
+                .entry(seq)
+                .or_insert_with(|| src.payload.clone());
+        }
+        // else: already-delivered duplicate — ignore (but still re-ACK).
+    }
+
+    /// Retransmit timed-out packets, send new data within the window, and emit a
+    /// trailing pure ACK if one is still owed.
+    fn pump(&mut self, now_ms: u64, out: &mut StepOutput) {
+        // Client SYN retransmission.
+        if self.state == ConnState::SynSent
+            && now_ms.wrapping_sub(self.syn_last_sent_ms) >= self.cfg.rto_ms
+        {
+            self.syn_last_sent_ms = now_ms;
+            out.to_send.push(self.encode_syn());
+        }
+
+        if !self.is_established() {
+            return;
+        }
+
+        let mut sent_data = false;
+
+        // Retransmit unacked packets whose RTO elapsed.
+        for entry in &mut self.unacked {
+            if now_ms.wrapping_sub(entry.last_sent_ms) >= self.cfg.rto_ms {
+                entry.last_sent_ms = now_ms;
+                out.to_send.push(encode_data(
+                    self.recv_next,
+                    self.have_peer_seq,
+                    self.cfg.recv_window,
+                    entry.seq,
+                    &entry.payload,
+                ));
+                sent_data = true;
+            }
+        }
+
+        // Send new data while the in-flight window allows.
+        let max_payload = (self.cfg.mtu as usize)
+            .saturating_sub(HEADERS_OVERHEAD)
+            .max(1);
+        while !self.out_queue.is_empty() && self.unacked.len() < self.peer_recv_window as usize {
+            let take = self.out_queue.len().min(max_payload);
+            let payload: Vec<u8> = self.out_queue.drain(..take).collect();
+            let seq = self.send_next;
+            self.send_next = self.send_next.wrapping_add(1);
+            out.to_send.push(encode_data(
+                self.recv_next,
+                self.have_peer_seq,
+                self.cfg.recv_window,
+                seq,
+                &payload,
+            ));
+            self.unacked.push_back(Unacked {
+                seq,
+                payload,
+                last_sent_ms: now_ms,
+            });
+            sent_data = true;
+        }
+
+        // Any owed ACK was piggybacked on data; otherwise send a pure ACK.
+        if self.need_ack && !sent_data {
+            out.to_send.push(
+                Datagram::ack(self.ack_num(), self.cfg.recv_window, empty_ack())
+                    .encode()
+                    .expect("encode ack"),
+            );
+        }
+        if sent_data || self.need_ack {
+            self.need_ack = false;
+        }
+    }
+
+    fn ack_num(&self) -> i32 {
+        // Cumulative: the highest in-order sequence delivered so far. Before any
+        // data, one below the peer's ISN ("nothing received").
+        if self.have_peer_seq {
+            self.recv_next.wrapping_sub(1) as i32
+        } else {
+            -1
+        }
+    }
+
+    fn encode_syn(&self) -> Vec<u8> {
+        let syn = crate::pdu::SynData {
+            initial_seq: self.cfg.initial_seq,
+            upstream_mtu: self.cfg.mtu,
+            downstream_mtu: self.cfg.mtu,
+        };
+        Datagram::syn(self.ack_num(), self.cfg.recv_window, syn, None, None)
+            .encode()
+            .expect("encode syn")
+    }
+}
+
+/// FEC header (8) + ACK vector (4, empty) + source payload header (8).
+const HEADERS_OVERHEAD: usize = 8 + 4 + 8;
+
+fn empty_ack() -> AckVectorHeader {
+    AckVectorHeader { elements: vec![] }
+}
+
+fn encode_data(
+    recv_next: u32,
+    have_peer_seq: bool,
+    recv_window: u16,
+    seq: u32,
+    payload: &[u8],
+) -> Vec<u8> {
+    let ack = if have_peer_seq {
+        recv_next.wrapping_sub(1) as i32
+    } else {
+        -1
+    };
+    Datagram::data(
+        ack,
+        recv_window,
+        empty_ack(),
+        SourcePacket {
+            header: SourcePayloadHeader {
+                sn_coded: seq,
+                sn_source_start: seq,
+            },
+            payload: payload.to_vec(),
+        },
+    )
+    .encode()
+    .expect("encode data")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(initial_seq: u32) -> Config {
+        Config {
+            recv_window: 8,
+            mtu: 1132, // → small-ish payloads exercise fragmentation
+            initial_seq,
+            rto_ms: 100,
+        }
+    }
+
+    /// Drive client↔server to the established state.
+    fn handshook() -> (RdpeudpState, RdpeudpState, u64) {
+        let mut client = RdpeudpState::new(Role::Client, cfg(1000));
+        let mut server = RdpeudpState::new(Role::Server, cfg(9000));
+        let mut now = 0;
+        let o = client.start(now);
+        // SYN → server
+        for dg in o.to_send {
+            let so = server.step(now, Some(&dg));
+            for back in so.to_send {
+                client.step(now, Some(&back));
+            }
+        }
+        now += 1;
+        assert!(client.is_established() && server.is_established());
+        (client, server, now)
+    }
+
+    #[test]
+    fn handshake_establishes_both_ends() {
+        let (c, s, _) = handshook();
+        assert!(c.is_established());
+        assert!(s.is_established());
+    }
+
+    #[test]
+    fn delivers_in_order_no_loss() {
+        let (mut client, mut server, mut now) = handshook();
+        let msg = b"the quick brown fox jumps over the lazy dog".repeat(5);
+        let out = client.enqueue(now, &msg);
+        let mut delivered = Vec::new();
+        let mut wire = out.to_send;
+        // Bounce datagrams until quiescent.
+        for _ in 0..200 {
+            if wire.is_empty() {
+                break;
+            }
+            let mut next_wire = Vec::new();
+            for dg in wire.drain(..) {
+                let so = server.step(now, Some(&dg));
+                for p in so.delivered {
+                    delivered.extend_from_slice(&p);
+                }
+                for back in so.to_send {
+                    let co = client.step(now, Some(&back));
+                    next_wire.extend(co.to_send);
+                }
+            }
+            now += 1;
+            wire = next_wire;
+        }
+        assert_eq!(delivered, msg);
+    }
+
+    /// Deterministic lossy/reordering/duplicating channel: a tiny LCG decides,
+    /// per datagram, to drop / duplicate / hold-and-reorder. Asserts the full
+    /// message is still delivered in order.
+    #[test]
+    fn delivers_under_loss_reorder_dup() {
+        for seed in [1u64, 7, 42, 1234] {
+            let (mut client, mut server, mut now) = handshook();
+            let msg: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+            client.enqueue(now, &msg);
+
+            // Each "wire" holds (deliver_at_ms, bytes). A held packet models reorder.
+            let mut c2s: Vec<(u64, Vec<u8>)> = Vec::new();
+            let mut s2c: Vec<(u64, Vec<u8>)> = Vec::new();
+            let mut rng = seed;
+            let next = |rng: &mut u64| {
+                *rng = rng
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (*rng >> 33) as u32
+            };
+            // Seed the wires with the client's initial output.
+            for o in client.step(now, None).to_send {
+                c2s.push((now, o));
+            }
+
+            let mut delivered = Vec::new();
+            for _round in 0..20000 {
+                let done = delivered.len() >= msg.len() && c2s.is_empty() && s2c.is_empty();
+                if done {
+                    break;
+                }
+
+                // Deliver due client→server datagrams (with loss/dup).
+                let (due, held): (Vec<_>, Vec<_>) = c2s.into_iter().partition(|(t, _)| *t <= now);
+                c2s = held;
+                for (_, dg) in due {
+                    let r = next(&mut rng) % 10;
+                    if r == 0 {
+                        continue; // drop
+                    }
+                    let times = if r == 1 { 2 } else { 1 }; // occasional dup
+                    for _ in 0..times {
+                        let so = server.step(now, Some(&dg));
+                        for p in so.delivered {
+                            delivered.extend_from_slice(&p);
+                        }
+                        for back in so.to_send {
+                            // reorder: random small delay
+                            let delay = u64::from(next(&mut rng) % 3);
+                            s2c.push((now + delay, back));
+                        }
+                    }
+                }
+
+                // Deliver due server→client datagrams.
+                let (due, held): (Vec<_>, Vec<_>) = s2c.into_iter().partition(|(t, _)| *t <= now);
+                s2c = held;
+                for (_, dg) in due {
+                    if next(&mut rng) % 10 == 0 {
+                        continue; // drop
+                    }
+                    let co = client.step(now, Some(&dg));
+                    for back in co.to_send {
+                        let delay = u64::from(next(&mut rng) % 3);
+                        c2s.push((now + delay, back));
+                    }
+                }
+
+                // Advance the clock; periodically fire timers so retransmits flow.
+                now += 1;
+                if now % 50 == 0 {
+                    for o in client.step(now, None).to_send {
+                        c2s.push((now, o));
+                    }
+                    let so = server.step(now, None);
+                    for o in so.to_send {
+                        s2c.push((now, o));
+                    }
+                }
+            }
+            assert_eq!(delivered, msg, "seed {seed}: full in-order delivery");
+        }
+    }
+}


### PR DESCRIPTION
The algorithmic heart of M2 — fully offline, no client needed. Completes M2.

## What's in it (two new modules in `ironrdp-rdpeudp`)
- **`src/datagram.rs`** — whole-datagram assemble/parse (SYN / SYN+ACK / DATA / ACK), composing the v1 PDU primitives by `FecFlags`. Round-trip tested.
- **`src/state.rs`** — `RdpeudpState`, a **sans-I/O reliable transport state machine**: `start()` / `enqueue()` / `step()` driven by a monotonic `now_ms` clock, returning `(delivered, to_send)`. Passive (server) + active (client) open; reliable, in-order, de-duplicated delivery (receiver buffers out-of-order datagrams → delivers contiguous runs; sender releases the in-flight window on the cumulative `snSourceAck` and retransmits on RTO); fixed window bounded by the peer's `uReceiveWindowSize`.

## Verification
Two instances driven against each other over an in-memory channel that **deterministically drops / duplicates / reorders** datagrams (4 seeds) → asserts **byte-exact in-order delivery** of a 4 KB message, plus handshake + clean-path tests. **18 crate tests pass**; `fmt --check` + `clippy -D warnings` clean (standalone-crate CI step).

## Scope caveats (documented in the crate CLAUDE.md)
- **Cumulative-ACK only** — selective retransmit via the ACK *vector* + congestion control are deferred.
- The two-instance test proves the **algorithm** (my SM ↔ my SM), **not Windows wire-compat** — mstsc's *data* path is **EUDP2**, which stays **spike-gated** on a real capture (M3+). The algorithm here is framing-agnostic and is what an EUDP2 codec would reuse.

This is the last fully-offline piece; M3 (UDP listener on the wire) is where the EUDP2 capture spike comes in.