### PR TITLE
feat(rdpeudp): EUDP2 sub-header walk → DataBody extraction

### DIFF
--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -62,7 +62,17 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
   1 ack). Sub-header order + sizes are known (ACK 7+nacks, OverheadSize 1,
   DelayAckInfo 3, AckOfAcks 2, DataHeader 4 [seq2+chanseq2], AckVector var) and
   confirmed against the capture's DataBody offsets.
-- **EUDP2 next:** walk the optional sub-headers to extract the DataBody (pin the
-  ACK NumDelayedAcks/TimeScale bit-split + the AckVector internals first), then
-  wire EUDP2 into the reliability state machine (the algorithm is
-  framing-agnostic) for the V3 data path. Capture: ~/Documents/Projects/mstscpcap.pcapng.
+- **EUDP2 sub-header walk (done):** `Eudp2Packet::parse` walks the ordered
+  optional sub-headers and returns the `DataBody` slice. Field splits taken from
+  the FreeRDP dissector's `dissectV2` and validated against the same 3 captured
+  packets (`parse_real_*` tests). Order: ACK, OverheadSize, DelayAckInfo,
+  AckOfAcks, Data(SeqNumber), AckVector, Data(ChannelSeqNumber)+DataBody. **The
+  DataHeader is SPLIT** — `SeqNumber` (2B) before the AckVector, `ChannelSeqNumber`
+  (2B) + body after it; a dummy packet (`Packet_Type_Index==8`) carries only
+  `SeqNumber`, no body. Sub-header sizes: ACK = 7 + NumDelayedAcks (combined byte
+  = NumDelayedAcks low-nibble | DelayedTimeScale high-nibble; AckTimestamp is
+  24-bit LE), OverheadSize 1, DelayAckInfo 3, AckOfAcks 2, AckVector =
+  BaseSeq(2)+sizeByte(1, high-bit=have-ts, low-7=coded size)+[Timestamp(4)]+vector.
+- **EUDP2 next:** wire `Eudp2Packet`/`body` into the reliability state machine
+  (`src/state.rs` — the algorithm is framing-agnostic), then M3 (UDP listener +
+  on-wire SYN+ACK). Capture: ~/Documents/Projects/mstscpcap.pcapng.

--- a/vendor/ironrdp-rdpeudp/src/eudp2.rs
+++ b/vendor/ironrdp-rdpeudp/src/eudp2.rs
@@ -23,10 +23,20 @@
 //! offset-7 byte to tell RDP-UDP2 from RDP-UDP v1 (a v1 packet has an invalid
 //! prefix there).
 //!
-//! M-eudp2 step 1 (this module): the transform + the `PacketPrefixByte` + the
-//! base `Eudp2Header`. Walking the optional sub-headers to extract the DataBody
-//! is the next step (the ACK / AckVector internals need their exact field
-//! splits pinned down first).
+//! M-eudp2 step 1: the transform + the `PacketPrefixByte` + the base
+//! `Eudp2Header`. Step 2 ([`Eudp2Packet::parse`]): walking the ordered optional
+//! sub-headers to extract the `DataBody` — the reliable byte-stream payload that
+//! feeds the [`crate::state`] reliability machine (and, above it, rustls). The
+//! sub-header field splits are taken from the same FreeRDP dissector and
+//! validated against the same capture (see the `parse_real_*` tests).
+//!
+//! # Sub-header order (the non-obvious split)
+//!
+//! After the base header the sub-headers appear in this fixed order, each gated
+//! by its flag: **ACK, OverheadSize, DelayAckInfo, AckOfAcks, Data(SeqNumber),
+//! AckVector, Data(ChannelSeqNumber)+DataBody**. The `DataHeader` is **split**:
+//! its 2-byte `SeqNumber` is read *before* the AckVector, but its 2-byte
+//! `ChannelSeqNumber` (and then the body) come *after* it.
 
 use bitflags::bitflags;
 use ironrdp_core::{ensure_size, invalid_field_err, Decode, DecodeResult, ReadCursor};
@@ -151,6 +161,210 @@ impl Decode<'_> for Eudp2Header {
     }
 }
 
+/// The ACK sub-header (flag [`Eudp2Flags::ACK`]) — the receiver's cumulative ack
+/// plus a short run of per-packet delayed-ack deltas. Layout (all little-endian):
+/// `AckSeq(2) AckTimestamp(3) SendTimeGap(1) [NumDelayedAcks:4 | DelayedTimeScale:4](1)`
+/// then `NumDelayedAcks` bytes of `DelayedAck` deltas.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AckSubheader<'a> {
+    /// Highest in-order sequence number the sender has received (cumulative ack).
+    pub ack_seq: u16,
+    /// 24-bit timestamp the ack was generated at (microseconds, sender clock).
+    pub ack_timestamp: u32,
+    /// Gap between this ack and the previous one.
+    pub send_time_gap: u8,
+    /// Number of `delayed_acks` delta bytes that follow (low nibble of the combined byte).
+    pub num_delayed_acks: u8,
+    /// `log2` scale applied to each `delayed_acks` delta (high nibble).
+    pub delayed_time_scale: u8,
+    /// Per-packet delayed-ack timestamp deltas (one byte each, scaled by `delayed_time_scale`).
+    pub delayed_acks: &'a [u8],
+}
+
+/// The DelayAckInfo sub-header (flag [`Eudp2Flags::DELAYACK`]): the sender telling
+/// the receiver how to batch its acks. `MaxDelayedAcks(1) DelayedAckTimeoutMs(2 LE)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DelayAckInfo {
+    pub max_delayed_acks: u8,
+    pub delayed_ack_timeout_ms: u16,
+}
+
+/// The AckVector sub-header (flag [`Eudp2Flags::ACKVEC`]): a coded
+/// received/lost run-length/bitmap vector starting at `base_seq`, optionally
+/// preceded by a 4-byte timestamp. `BaseSeq(2) [HaveTs:1 | CodedSize:7](1)
+/// [Timestamp(4)]? CodedVector(CodedSize)`. The coded-vector bytes are kept raw
+/// here (decoded run-by-run by the reliability layer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AckVec<'a> {
+    /// Sequence number the first vector element refers to.
+    pub base_seq: u16,
+    /// Optional 4-byte timestamp (present iff the high bit of the size byte is set).
+    pub timestamp: Option<u32>,
+    /// Raw coded ack-vector bytes (`coded_ack_vec_size` of them).
+    pub coded_vector: &'a [u8],
+}
+
+/// The DataHeader (flag [`Eudp2Flags::DATA`]). **Split on the wire**: `seq_number`
+/// is read before the AckVector sub-header, `channel_seq_number` after it (and a
+/// dummy packet, `Packet_Type_Index == 8`, carries only `seq_number` — no channel
+/// number, no body).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DataHeader {
+    pub seq_number: u16,
+    /// `None` for a dummy packet (no body follows).
+    pub channel_seq_number: Option<u16>,
+}
+
+/// A fully-parsed RDP-UDP2 packet: the base header, whichever optional
+/// sub-headers its flags selected, and the `DataBody` slice (empty when there is
+/// no `DATA` payload or for a dummy packet). Borrows the unwrapped buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Eudp2Packet<'a> {
+    pub header: Eudp2Header,
+    pub ack: Option<AckSubheader<'a>>,
+    pub overhead_size: Option<u8>,
+    pub delay_ack_info: Option<DelayAckInfo>,
+    pub ack_of_acks: Option<u16>,
+    pub ack_vec: Option<AckVec<'a>>,
+    pub data: Option<DataHeader>,
+    /// The reliable byte-stream payload (TLS records, once secured). Empty if the
+    /// packet carries no data.
+    pub body: &'a [u8],
+}
+
+/// Read a 24-bit little-endian unsigned integer (RDP-UDP2 timestamps are 3 bytes).
+fn read_u24_le(src: &mut ReadCursor<'_>) -> u32 {
+    let b = src.read_array::<3>();
+    u32::from_le_bytes([b[0], b[1], b[2], 0])
+}
+
+impl<'a> Eudp2Packet<'a> {
+    /// Parse a complete RDP-UDP2 packet from an **unwrapped** buffer (run
+    /// [`unwrap_packet`] on the wire bytes first). Walks the sub-headers in wire
+    /// order and returns the remaining bytes as [`Eudp2Packet::body`].
+    pub fn parse(unwrapped: &'a [u8]) -> DecodeResult<Self> {
+        let mut src = ReadCursor::new(unwrapped);
+        let header = <Eudp2Header as Decode<'_>>::decode(&mut src)?;
+        let flags = header.flags;
+
+        let ack = if flags.contains(Eudp2Flags::ACK) {
+            // AckSeq(2) AckTs(3) SendTimeGap(1) combined(1) = 7 fixed bytes.
+            ensure_size!(in: src, size: 7);
+            let ack_seq = src.read_u16();
+            let ack_timestamp = read_u24_le(&mut src);
+            let send_time_gap = src.read_u8();
+            let combined = src.read_u8();
+            let num_delayed_acks = combined & 0x0f;
+            let delayed_time_scale = (combined >> 4) & 0x0f;
+            ensure_size!(in: src, size: usize::from(num_delayed_acks));
+            let delayed_acks = src.read_slice(usize::from(num_delayed_acks));
+            Some(AckSubheader {
+                ack_seq,
+                ack_timestamp,
+                send_time_gap,
+                num_delayed_acks,
+                delayed_time_scale,
+                delayed_acks,
+            })
+        } else {
+            None
+        };
+
+        let overhead_size = if flags.contains(Eudp2Flags::OVERHEAD) {
+            ensure_size!(in: src, size: 1);
+            Some(src.read_u8())
+        } else {
+            None
+        };
+
+        let delay_ack_info = if flags.contains(Eudp2Flags::DELAYACK) {
+            ensure_size!(in: src, size: 3);
+            let max_delayed_acks = src.read_u8();
+            let delayed_ack_timeout_ms = src.read_u16();
+            Some(DelayAckInfo {
+                max_delayed_acks,
+                delayed_ack_timeout_ms,
+            })
+        } else {
+            None
+        };
+
+        let ack_of_acks = if flags.contains(Eudp2Flags::AOA) {
+            ensure_size!(in: src, size: 2);
+            Some(src.read_u16())
+        } else {
+            None
+        };
+
+        // DataHeader is split: SeqNumber here, ChannelSeqNumber after the AckVector.
+        let is_dummy = header.prefix.is_dummy();
+        let data_seq = if flags.contains(Eudp2Flags::DATA) {
+            ensure_size!(in: src, size: 2);
+            Some(src.read_u16())
+        } else {
+            None
+        };
+
+        let ack_vec = if flags.contains(Eudp2Flags::ACKVEC) {
+            ensure_size!(in: src, size: 3);
+            let base_seq = src.read_u16();
+            let size_byte = src.read_u8();
+            let coded_ack_vec_size = usize::from(size_byte & 0x7f);
+            let have_ts = size_byte & 0x80 != 0;
+            let timestamp = if have_ts {
+                ensure_size!(in: src, size: 4);
+                Some(src.read_u32())
+            } else {
+                None
+            };
+            ensure_size!(in: src, size: coded_ack_vec_size);
+            let coded_vector = src.read_slice(coded_ack_vec_size);
+            Some(AckVec {
+                base_seq,
+                timestamp,
+                coded_vector,
+            })
+        } else {
+            None
+        };
+
+        // Second half of the DataHeader + the body (skipped entirely for a dummy).
+        let (data, body): (Option<DataHeader>, &[u8]) = match (data_seq, is_dummy) {
+            (Some(seq_number), false) => {
+                ensure_size!(in: src, size: 2);
+                let channel_seq_number = src.read_u16();
+                let body = src.remaining();
+                (
+                    Some(DataHeader {
+                        seq_number,
+                        channel_seq_number: Some(channel_seq_number),
+                    }),
+                    body,
+                )
+            }
+            (Some(seq_number), true) => (
+                Some(DataHeader {
+                    seq_number,
+                    channel_seq_number: None,
+                }),
+                &[],
+            ),
+            (None, _) => (None, &[]),
+        };
+
+        Ok(Self {
+            header,
+            ack,
+            overhead_size,
+            delay_ack_info,
+            ack_of_acks,
+            ack_vec,
+            data,
+            body,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -224,5 +438,106 @@ mod tests {
         assert!(h.flags.contains(Eudp2Flags::ACK | Eudp2Flags::OVERHEAD));
         assert!(!h.flags.contains(Eudp2Flags::DATA));
         assert_eq!(h.log_window, 15);
+    }
+
+    // Full sub-header walk against the same three real captured packets — these
+    // pin the DelayAckInfo/AckOfAcks/Data(split)/Ack sizes to the wire and prove
+    // the DataBody (TLS) is extracted at the right offset.
+
+    #[test]
+    fn parse_real_data_packet_pkt3() {
+        // DATA|AOA|DELAYACK -> DelayAckInfo(3) + AckOfAcks(2) + DataSeq(2) +
+        // ChannelSeq(2) + body. No ACK/OVERHEAD/ACKVEC.
+        let wire = [
+            0x00, 0x14, 0xf3, 0x01, 0x14, 0x00, 0x64, 0xe0, //
+            0x64, 0x00, 0x01, 0x00, 0x16, 0x03, 0x01, 0x01,
+        ];
+        let u = unwrap_packet(&wire).unwrap();
+        let p = Eudp2Packet::parse(&u).unwrap();
+        assert!(p.ack.is_none());
+        assert!(p.overhead_size.is_none());
+        assert!(p.ack_vec.is_none());
+        assert_eq!(
+            p.delay_ack_info,
+            Some(DelayAckInfo {
+                max_delayed_acks: 0x01,
+                delayed_ack_timeout_ms: 0x0014,
+            })
+        );
+        assert_eq!(p.ack_of_acks, Some(0x0064));
+        assert_eq!(
+            p.data,
+            Some(DataHeader {
+                seq_number: 0x0064,
+                channel_seq_number: Some(0x0001),
+            })
+        );
+        // The body is the start of a TLS record (ClientHello fragment).
+        assert_eq!(p.body, &[0x16, 0x03, 0x01, 0x01]);
+    }
+
+    #[test]
+    fn parse_real_data_packet_pkt5() {
+        // DATA|AOA (no DelayAck) -> AckOfAcks(2) + DataSeq(2) + ChannelSeq(2) + body.
+        let wire = [
+            0x01, 0x14, 0xf2, 0x66, 0x00, 0x66, 0x00, 0xe0, //
+            0x00, 0x16, 0x03, 0x01, 0x01, 0x9d, 0x01, 0x00,
+        ];
+        let u = unwrap_packet(&wire).unwrap();
+        let p = Eudp2Packet::parse(&u).unwrap();
+        assert!(p.delay_ack_info.is_none());
+        assert_eq!(p.ack_of_acks, Some(0x0066));
+        assert_eq!(
+            p.data,
+            Some(DataHeader {
+                seq_number: 0x0066,
+                channel_seq_number: Some(0x0001),
+            })
+        );
+        assert_eq!(p.body, &[0x16, 0x03, 0x01, 0x01, 0x9d, 0x01, 0x00]);
+    }
+
+    #[test]
+    fn parse_real_ack_packet() {
+        // ACK|OVERHEAD, no DATA. The ACK sub-header carries 2 delayed-ack deltas,
+        // then the single OverheadSize byte lands exactly at end-of-packet.
+        let wire = [
+            0x02, 0x41, 0xf0, 0x6a, 0x00, 0xc4, 0x04, 0xe0, //
+            0x00, 0x02, 0xdf, 0x73, 0x05,
+        ];
+        let u = unwrap_packet(&wire).unwrap();
+        let p = Eudp2Packet::parse(&u).unwrap();
+        let ack = p.ack.expect("ACK present");
+        assert_eq!(ack.ack_seq, 0x006a);
+        assert_eq!(ack.ack_timestamp, 0x0204c4); // 24-bit LE of c4 04 02
+        assert_eq!(ack.send_time_gap, 0x00);
+        assert_eq!(ack.num_delayed_acks, 2);
+        assert_eq!(ack.delayed_time_scale, 0);
+        assert_eq!(ack.delayed_acks, &[0xdf, 0x73]);
+        assert_eq!(p.overhead_size, Some(0x05));
+        assert!(p.data.is_none());
+        assert!(p.body.is_empty());
+    }
+
+    #[test]
+    fn parse_ack_vector_with_timestamp() {
+        // Synthetic (no captured ACKVEC packet): exercises the AckVec branch with
+        // the timestamp bit set. flags=ACKVEC, logwin=0.
+        // prefix, flags-word(LE 0x0008), base_seq(0x0010), size byte 0x82
+        // (coded size 2 + have-ts), ts(0x0a0b0c0d LE), vector[0xc1,0x80].
+        let unwrapped = [
+            0xe0, 0x08, 0x00, // prefix + flags word (ACKVEC, logwin 0)
+            0x10, 0x00, // base_seq = 0x0010
+            0x82, // have_ts | coded_size=2
+            0x0d, 0x0c, 0x0b, 0x0a, // timestamp 0x0a0b0c0d (LE)
+            0xc1, 0x80, // 2 coded-vector bytes
+        ];
+        let p = Eudp2Packet::parse(&unwrapped).unwrap();
+        let v = p.ack_vec.expect("AckVec present");
+        assert_eq!(v.base_seq, 0x0010);
+        assert_eq!(v.timestamp, Some(0x0a0b_0c0d));
+        assert_eq!(v.coded_vector, &[0xc1, 0x80]);
+        assert!(p.data.is_none());
+        assert!(p.body.is_empty());
     }
 }


### PR DESCRIPTION
## What

Builds on the EUDP2 framing foundation (#21). `Eudp2Packet::parse` walks the ordered optional sub-headers after the base header and returns the **DataBody** slice — the reliable byte-stream payload that will feed the M2 reliability state machine (and, above it, rustls).

Field splits taken from FreeRDP's `tools/wireshark/rdp-udp.lua` dissector (`dissectV2`) and validated against the same 3 captured packets as the header tests.

## The non-obvious part: the DataHeader is split

On the wire the `DataHeader` is **not contiguous**:
- `SeqNumber` (2B) is read *before* the AckVector sub-header
- `ChannelSeqNumber` (2B) + the DataBody come *after* it

A dummy packet (`Packet_Type_Index == 8`) carries only `SeqNumber` — no channel number, no body.

## Sub-header layouts (in wire order)

| Flag | Sub-header | Size |
|------|-----------|------|
| ACK | AckSeq(2) AckTs(3 LE) SendTimeGap(1) [NumDelayedAcks:4 \| TimeScale:4](1) + deltas | 7 + NumDelayedAcks |
| OVERHEAD | OverheadSize | 1 |
| DELAYACK | MaxDelayedAcks(1) TimeoutMs(2 LE) | 3 |
| AOA | AckOfAcks(2) | 2 |
| DATA | SeqNumber(2) … ChannelSeqNumber(2) + body | split around AckVec |
| ACKVEC | BaseSeq(2) [HaveTs:1\|CodedSize:7](1) [Ts(4)]? Vector(CodedSize) | var |

## Tests

4 new (28 crate total): the 3 real captured packets — each asserting the exact sub-header values **and** that the DataBody lands at the right offset (TLS `16 03 01 …`) — plus a synthetic AckVector-with-timestamp packet to cover that branch.

Next: feed `Eudp2Packet`/`body` into the reliability state machine, then M3 (UDP listener + on-wire SYN+ACK handshake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)