### PR TITLE
feat(rdpeudp): EUDP2 inbound adapter (framing-neutral reliability view)

### DIFF
--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -73,6 +73,19 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
   = NumDelayedAcks low-nibble | DelayedTimeScale high-nibble; AckTimestamp is
   24-bit LE), OverheadSize 1, DelayAckInfo 3, AckOfAcks 2, AckVector =
   BaseSeq(2)+sizeByte(1, high-bit=have-ts, low-7=coded size)+[Timestamp(4)]+vector.
-- **EUDP2 next:** wire `Eudp2Packet`/`body` into the reliability state machine
-  (`src/state.rs` — the algorithm is framing-agnostic), then M3 (UDP listener +
-  on-wire SYN+ACK). Capture: ~/Documents/Projects/mstscpcap.pcapng.
+- **EUDP2 inbound adapter (done):** `Eudp2Packet::inbound_view()` →
+  `Eudp2Inbound { cumulative_ack: Option<u16>, peer_log_window, data:
+  Option<(u16 seq, &[u8] body)> }` — the framing-neutral projection the
+  reliability layer consumes (the v1 path exposes the analogous fields on
+  `Datagram` directly). Capture-validated (`inbound_view_*` tests). The ACK
+  sub-header's AckSeq IS the cumulative ack point (the dissector tracks it as
+  `senderLow`); AckVector is selective info, exposed separately. Dummy packets
+  (type==8) project `data: None`.
+- **EUDP2 next — SM wiring deferred to M3 (on purpose):** the **encode** half +
+  feeding `inbound_view` into `RdpeudpState` needs EUDP2's **16-bit** sequence
+  space (vs v1's 32-bit; needs its own `seq_leq` half-window) AND the delayed-
+  ack-vector model — and the **encode/send** side can't be validated offline (no
+  bidirectional EUDP2 capture with known-good *server* output). Do it at M3
+  against a live V3 client (propose V3, record the client's reaction to our
+  output). Until then the SM stays v1-only (correct for the SYN handshake, which
+  is always v1). Capture: ~/Documents/Projects/mstscpcap.pcapng.

--- a/vendor/ironrdp-rdpeudp/src/eudp2.rs
+++ b/vendor/ironrdp-rdpeudp/src/eudp2.rs
@@ -363,6 +363,50 @@ impl<'a> Eudp2Packet<'a> {
             body,
         })
     }
+
+    /// Project this packet onto the framing-neutral fields the reliability layer
+    /// acts on — the **adapter seam** that lets a (framing-agnostic) transport
+    /// state machine consume RDP-UDP2 without knowing its wire layout. The v1
+    /// path exposes the analogous fields directly on [`crate::datagram::Datagram`]
+    /// (`fec.snd_source_ack`, `fec.recv_window`, `source`).
+    ///
+    /// This is the **decode (inbound) half** of the adapter — capture-validated
+    /// (see `inbound_view_*` tests). Wiring it into [`crate::state::RdpeudpState`]
+    /// (which then needs EUDP2's 16-bit sequence space and the symmetric *encode*
+    /// half) is deferred to the on-wire milestone, where a bidirectional V3
+    /// capture can validate what a real client accepts as our output.
+    pub fn inbound_view(&self) -> Eudp2Inbound<'a> {
+        Eudp2Inbound {
+            // ACK sub-header's AckSeq is the peer's cumulative ack point (the
+            // dissector tracks it as `senderLow`). AckVector (mutually exclusive
+            // with ACK) is *selective* info, exposed separately via `self.ack_vec`.
+            cumulative_ack: self.ack.map(|a| a.ack_seq),
+            peer_log_window: self.header.log_window,
+            // A dummy packet (`Packet_Type_Index == 8`) carries no deliverable
+            // body, so `data` is None even though the DATA flag may be set.
+            data: match &self.data {
+                Some(d) if d.channel_seq_number.is_some() => Some((d.seq_number, self.body)),
+                _ => None,
+            },
+        }
+    }
+}
+
+/// The framing-neutral, reliability-relevant projection of an inbound RDP-UDP2
+/// packet (see [`Eudp2Packet::inbound_view`]). Holds only what a transport state
+/// machine needs, lifted out of the EUDP2 wire layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Eudp2Inbound<'a> {
+    /// The peer's cumulative ack (highest in-order transport sequence it has
+    /// received), if this packet carried an ACK sub-header. EUDP2 sequences are
+    /// 16-bit, so callers compare in 16-bit wrapping space.
+    pub cumulative_ack: Option<u16>,
+    /// The peer's advertised receive window as `log2(window / MTU)` — the window
+    /// is `(1 << peer_log_window)` MTUs.
+    pub peer_log_window: u8,
+    /// A deliverable data segment `(transport seq number, body)` — present iff
+    /// the packet carries a non-dummy DATA payload.
+    pub data: Option<(u16, &'a [u8])>,
 }
 
 #[cfg(test)]
@@ -517,6 +561,56 @@ mod tests {
         assert_eq!(p.overhead_size, Some(0x05));
         assert!(p.data.is_none());
         assert!(p.body.is_empty());
+    }
+
+    // The adapter seam: the framing-neutral projection the reliability layer
+    // consumes, validated against the same captured packets.
+
+    #[test]
+    fn inbound_view_of_real_data_packet() {
+        let wire = [
+            0x00, 0x14, 0xf3, 0x01, 0x14, 0x00, 0x64, 0xe0, //
+            0x64, 0x00, 0x01, 0x00, 0x16, 0x03, 0x01, 0x01,
+        ];
+        let u = unwrap_packet(&wire).unwrap();
+        let v = Eudp2Packet::parse(&u).unwrap().inbound_view();
+        // No ACK sub-header on this data packet.
+        assert_eq!(v.cumulative_ack, None);
+        assert_eq!(v.peer_log_window, 15);
+        assert_eq!(v.data, Some((0x0064, &[0x16, 0x03, 0x01, 0x01][..])));
+    }
+
+    #[test]
+    fn inbound_view_of_real_ack_packet() {
+        let wire = [
+            0x02, 0x41, 0xf0, 0x6a, 0x00, 0xc4, 0x04, 0xe0, //
+            0x00, 0x02, 0xdf, 0x73, 0x05,
+        ];
+        let u = unwrap_packet(&wire).unwrap();
+        let v = Eudp2Packet::parse(&u).unwrap().inbound_view();
+        // Cumulative ack point carried in the ACK sub-header; no data to deliver.
+        assert_eq!(v.cumulative_ack, Some(0x006a));
+        assert_eq!(v.data, None);
+    }
+
+    #[test]
+    fn inbound_view_of_dummy_packet_has_no_data() {
+        // Packet_Type_Index == 8 (dummy): DATA flag set but no body to deliver.
+        // prefix byte: type=8 -> (8<<1)=0x10, len7 -> (7<<5)=0xe0 => 0xf0.
+        let unwrapped = [
+            0xf0, 0x04, 0x00, // prefix(type=8) + flags word (DATA, logwin 0)
+            0x2a, 0x00, // DataHeader SeqNumber = 0x002a (dummy: no channel seq / body)
+        ];
+        let p = Eudp2Packet::parse(&unwrapped).unwrap();
+        assert!(p.header.prefix.is_dummy());
+        assert_eq!(
+            p.data,
+            Some(DataHeader {
+                seq_number: 0x002a,
+                channel_seq_number: None,
+            })
+        );
+        assert_eq!(p.inbound_view().data, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

`Eudp2Packet::inbound_view()` projects an RDP-UDP2 packet onto the fields the reliability state machine acts on, lifted out of the EUDP2 wire layout. This is the **adapter seam** that will let the framing-agnostic transport SM consume EUDP2 without knowing its framing — the v1 path already exposes the analogous fields on `Datagram` directly (`fec.snd_source_ack` / `fec.recv_window` / `source`).

```rust
pub struct Eudp2Inbound<'a> {
    pub cumulative_ack: Option<u16>,   // ACK sub-header's AckSeq (dissector's senderLow)
    pub peer_log_window: u8,           // window = (1 << peer_log_window) MTUs
    pub data: Option<(u16, &'a [u8])>, // (transport seq, body) — None for dummy packets
}
```

The ACK sub-header's `AckSeq` is the peer's cumulative ack point (FreeRDP's dissector tracks it as `senderLow`); the AckVector (mutually exclusive with ACK) is *selective* info, left on the packet for the reliability layer to read separately. A dummy packet (`Packet_Type_Index == 8`) projects `data: None`.

## Why the SM wiring is deferred to M3 (on purpose)

This is the **decode (inbound) half** of the adapter — capture-validated. Wiring it into `RdpeudpState` is deliberately a later step because it needs:
1. **EUDP2's 16-bit sequence space** (vs v1's 32-bit — its own `seq_leq` half-window), and
2. the symmetric **encode half**, whose send side **can't be validated offline** — there's no bidirectional EUDP2 capture with known-good *server* output to check our emitted packets against.

That validation only becomes possible at M3 against a live V3 client (propose V3, record how the client reacts to our output). Until then the SM stays v1-only, which is correct for the SYN handshake (always v1 regardless of the negotiated data version).

## Tests

3 new (31 crate total): `inbound_view` of a real data packet (→ `(seq, TLS body)`, no ack), of the real ack packet (→ `cumulative_ack`, no data), and of a dummy packet (→ `data: None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)