### PR TITLE
feat(rdpeudp): M3a — server SYN+ACK wire-shaped to real Windows

### DIFF
--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,21 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **M3a (done — server handshake wire-shaped to real Windows):** the server's
+  **SYN+ACK** now matches a real Windows RDP server byte-exact (validated against
+  a capture). `Datagram::syn_ack(client_isn, win, syn, version)` sets flags
+  `SYN|ACK|SYNEX`, `snSourceAck = client_isn`, and a SYNEX with the negotiated
+  version — with two quirks the generic `syn` couldn't express: **ACK flag set
+  but NO ack-vector section** (the ack rides `snSourceAck`), and **SYNEX omits the
+  cookie hash even for V3** (it's client→server only). `SynDataEx::decode_directional`
+  decides cookie-hash presence by direction (the `Decode` impl defaults to the
+  client-SYN case); `Datagram::decode` reads an ack vector only for
+  `ACK && !SYN`, and decodes the SYNEX hash only on a plain SYN. `RdpeudpState`
+  (server) captures the client's ISN + SYNEX version from the incoming SYN and
+  emits the proper SYN+ACK (`negotiated_version()` accessor exposes V3). Tests:
+  byte-exact `syn_ack` vs capture + an **end-to-end** test feeding the real client
+  SYN through the SM and asserting the emitted SYN+ACK == the real server's.
+  33 crate tests.
 - **M2a (done):** MS-RDPEUDP **v1** PDU codecs in `src/pdu.rs` — `FecHeader` +
   `FecFlags`, `SynData`, `SynDataEx` (+ `UdpVersion`/`SynExFlags`, the `0x0101`
   selector for RDPEUDP2), `CorrelationId`, `SourcePayloadHeader`. Round-trip

--- a/vendor/ironrdp-rdpeudp/src/datagram.rs
+++ b/vendor/ironrdp-rdpeudp/src/datagram.rs
@@ -17,6 +17,7 @@ use ironrdp_core::{
 
 use crate::pdu::{
     AckVectorHeader, CorrelationId, FecFlags, FecHeader, SourcePayloadHeader, SynData, SynDataEx,
+    SynExFlags, UdpVersion,
 };
 
 /// The application payload carried by a source (DATA) packet, with its sequence
@@ -42,9 +43,10 @@ pub struct Datagram {
 }
 
 impl Datagram {
-    /// A SYN (or SYN+ACK, when `ack_vector` is `Some`) datagram: carries SYNDATA
+    /// A client→server **SYN** (or a generic SYN-with-ack-vector): carries SYNDATA
     /// and optionally SYNEX (version negotiation). `snSourceAck` is the caller's
-    /// (use `-1` for an initial SYN).
+    /// (use `-1` for an initial SYN). For the server's reply use the dedicated
+    /// [`Datagram::syn_ack`], which matches real Windows (ACK flag, no vector).
     pub fn syn(
         snd_source_ack: i32,
         recv_window: u16,
@@ -70,6 +72,37 @@ impl Datagram {
             syn: Some(syn),
             correlation: None,
             syn_ex,
+        }
+    }
+
+    /// A server→client **SYN+ACK** matching what a real Windows RDP server emits
+    /// (verified byte-exact against a capture): flags `SYN | ACK | SYNEX`,
+    /// `snSourceAck = client_isn` (the ISN from the client's SYNDATA), our own
+    /// SYNDATA, and a SYNEX echoing the negotiated `udp_version`. Two quirks the
+    /// generic [`Datagram::syn`] can't express: the ACK flag is set but **no
+    /// ack-vector section is appended** (the ack rides `snSourceAck`), and the
+    /// SYNEX **omits the cookie hash even for V3** (it's client→server only).
+    pub fn syn_ack(
+        client_isn: u32,
+        recv_window: u16,
+        syn: SynData,
+        udp_version: UdpVersion,
+    ) -> Self {
+        Self {
+            fec: FecHeader {
+                snd_source_ack: client_isn as i32,
+                recv_window,
+                flags: FecFlags::SYN | FecFlags::ACK | FecFlags::SYNEX,
+            },
+            ack_vector: None,
+            source: None,
+            syn: Some(syn),
+            correlation: None,
+            syn_ex: Some(SynDataEx {
+                flags: SynExFlags::VERSION_INFO_VALID,
+                udp_version,
+                cookie_hash: None,
+            }),
         }
     }
 
@@ -151,7 +184,10 @@ impl Datagram {
         let fec: FecHeader = decode_cursor(&mut cursor)?;
         let flags = fec.flags;
 
-        let ack_vector = if flags.contains(FecFlags::ACK) {
+        // A SYN / SYN+ACK carries NO ack-vector section even when the ACK flag is
+        // set (its acknowledgment rides `snSourceAck`); the vector appears only on
+        // non-SYN data/ack packets. Verified against a real SYN+ACK capture.
+        let ack_vector = if flags.contains(FecFlags::ACK) && !flags.contains(FecFlags::SYN) {
             Some(decode_cursor::<AckVectorHeader>(&mut cursor)?)
         } else {
             None
@@ -167,7 +203,13 @@ impl Datagram {
                 None
             };
             let syn_ex = if flags.contains(FecFlags::SYNEX) {
-                Some(decode_cursor::<SynDataEx>(&mut cursor)?)
+                // A SYN+ACK (ACK flag set) omits the cookie hash; a plain client
+                // SYN includes it for V3.
+                let expect_cookie_hash = !flags.contains(FecFlags::ACK);
+                Some(SynDataEx::decode_directional(
+                    &mut cursor,
+                    expect_cookie_hash,
+                )?)
             } else {
                 None
             };
@@ -253,6 +295,45 @@ mod tests {
         let back = Datagram::decode(&bytes).unwrap();
         assert_eq!(back, d);
         assert!(back.source.is_none() && back.syn.is_none());
+    }
+
+    /// The server's SYN+ACK must be byte-shaped exactly like a real Windows RDP
+    /// server's. These 20 bytes are the meaningful prefix (before MTU zero-pad) of
+    /// the **server→client SYN+ACK** captured opposite the client SYN below:
+    /// FEC(snSourceAck=client ISN, win 64, flags SYN|ACK|SYNEX) + SYNDATA(server
+    /// ISN, MTUs) + SYNEX(VERSION_INFO_VALID, V3) — no ack vector, no cookie hash.
+    #[test]
+    fn syn_ack_matches_real_server_capture() {
+        #[rustfmt::skip]
+        let expected: [u8; 20] = [
+            0x64, 0x7a, 0x02, 0xbc, // snSourceAck = client ISN 0x647a02bc
+            0x00, 0x40,             // uReceiveWindowSize = 64
+            0x10, 0x05,             // uFlags = SYN|ACK|SYNEX
+            0x61, 0xf7, 0xb6, 0xe3, // SYNDATA snInitialSequenceNumber (server ISN)
+            0x04, 0xd0,             // uUpStreamMtu = 1232
+            0x04, 0xd0,             // uDownStreamMtu = 1232
+            0x00, 0x01,             // uSynExFlags = VERSION_INFO_VALID
+            0x01, 0x01,             // uUdpVer = 0x0101 = V3 (no cookie hash follows)
+        ];
+
+        let d = Datagram::syn_ack(
+            0x647a_02bc,
+            64,
+            SynData {
+                initial_seq: 0x61f7_b6e3,
+                upstream_mtu: 1232,
+                downstream_mtu: 1232,
+            },
+            UdpVersion::V3,
+        );
+        let bytes = d.encode().unwrap();
+        assert_eq!(
+            bytes, expected,
+            "SYN+ACK must match the captured server bytes"
+        );
+        // And it must round-trip back (ACK flag set but no ack vector; V3 SYNEX
+        // with no cookie hash — the directional-decode path).
+        assert_eq!(Datagram::decode(&bytes).unwrap(), d);
     }
 
     /// Decode a **real Microsoft RDP client's SYN** from a user capture — the

--- a/vendor/ironrdp-rdpeudp/src/pdu.rs
+++ b/vendor/ironrdp-rdpeudp/src/pdu.rs
@@ -195,6 +195,36 @@ impl SynDataEx {
     const NAME: &'static str = "RDPUDP_SYNDATAEX_PAYLOAD";
     pub const FIXED_PART_SIZE: usize = 2 /* uSynExFlags */ + 2 /* uUdpVer */;
     const COOKIE_HASH_SIZE: usize = 32;
+
+    /// Decode a SYNEX, choosing whether to expect the 32-byte `cookie_hash`.
+    ///
+    /// The hash's presence is **directional**, not derivable from the version
+    /// alone: the **client→server SYN** carries it (V3), but the **server→client
+    /// SYN+ACK omits it even for V3** (verified against a real capture). The
+    /// caller — which knows the FEC flags — passes `expect_cookie_hash = false`
+    /// for a SYN+ACK (ACK flag set) and `true` for a plain client SYN. The
+    /// [`Decode`] impl defaults to the client-SYN case (the only one decoded in
+    /// the server's production path).
+    pub fn decode_directional(
+        src: &mut ReadCursor<'_>,
+        expect_cookie_hash: bool,
+    ) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let flags = SynExFlags::from_bits_retain(src.read_u16_be());
+        let udp_version = UdpVersion::from_u16(src.read_u16_be())
+            .ok_or_else(|| invalid_field_err!("uUdpVer", "unknown RDP-UDP protocol version"))?;
+        let cookie_hash = if expect_cookie_hash && udp_version == UdpVersion::V3 {
+            ensure_size!(in: src, size: Self::COOKIE_HASH_SIZE);
+            Some(src.read_array::<{ Self::COOKIE_HASH_SIZE }>())
+        } else {
+            None
+        };
+        Ok(Self {
+            flags,
+            udp_version,
+            cookie_hash,
+        })
+    }
 }
 
 impl Encode for SynDataEx {
@@ -224,23 +254,11 @@ impl Encode for SynDataEx {
 }
 
 impl Decode<'_> for SynDataEx {
+    /// Decodes a **client→server SYN**'s SYNEX (the production server path), where
+    /// a V3 version carries the cookie hash. A SYN+ACK's SYNEX is decoded via
+    /// [`SynDataEx::decode_directional`] with `expect_cookie_hash = false`.
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        ensure_fixed_part_size!(in: src);
-        let flags = SynExFlags::from_bits_retain(src.read_u16_be());
-        let udp_version = UdpVersion::from_u16(src.read_u16_be())
-            .ok_or_else(|| invalid_field_err!("uUdpVer", "unknown RDP-UDP protocol version"))?;
-        // The cookie hash is present only for protocol version 3.
-        let cookie_hash = if udp_version == UdpVersion::V3 {
-            ensure_size!(in: src, size: Self::COOKIE_HASH_SIZE);
-            Some(src.read_array::<{ Self::COOKIE_HASH_SIZE }>())
-        } else {
-            None
-        };
-        Ok(Self {
-            flags,
-            udp_version,
-            cookie_hash,
-        })
+        Self::decode_directional(src, true)
     }
 }
 

--- a/vendor/ironrdp-rdpeudp/src/state.rs
+++ b/vendor/ironrdp-rdpeudp/src/state.rs
@@ -23,7 +23,7 @@
 use std::collections::{BTreeMap, VecDeque};
 
 use crate::datagram::{Datagram, SourcePacket};
-use crate::pdu::{AckVectorHeader, SourcePayloadHeader};
+use crate::pdu::{AckVectorHeader, SourcePayloadHeader, UdpVersion};
 
 /// Which end of the connection this instance is. macrdp (the RDP server) is the
 /// passive [`Role::Server`]; [`Role::Client`] exists so two instances can be
@@ -92,6 +92,13 @@ pub struct RdpeudpState {
 
     // Negotiated from the peer's SYN / SYN+ACK.
     peer_recv_window: u16,
+    /// The peer's initial sequence number (from its SYNDATA). The server echoes
+    /// it as `snSourceAck` in the SYN+ACK (matching real Windows).
+    peer_isn: u32,
+    /// The RDP-UDP version negotiated from the client's SYNEX (defaults to
+    /// [`UdpVersion::V2`] if the client sent no SYNEX). A `V3` result means the
+    /// data path upgrades to RDPEUDP2 framing after the handshake.
+    negotiated_version: UdpVersion,
 
     // Send side.
     send_next: u32,
@@ -121,6 +128,8 @@ impl RdpeudpState {
             },
             cfg,
             peer_recv_window: 1,
+            peer_isn: 0,
+            negotiated_version: UdpVersion::V2,
             send_next: cfg.initial_seq,
             out_queue: VecDeque::new(),
             unacked: VecDeque::new(),
@@ -134,6 +143,12 @@ impl RdpeudpState {
 
     pub fn is_established(&self) -> bool {
         self.state == ConnState::Established
+    }
+
+    /// The RDP-UDP version negotiated from the client's SYNEX. [`UdpVersion::V3`]
+    /// means the data path should use RDPEUDP2 framing after the handshake.
+    pub fn negotiated_version(&self) -> UdpVersion {
+        self.negotiated_version
     }
 
     /// Client: emit the initial SYN. Server: no-op (it waits for the SYN).
@@ -173,6 +188,12 @@ impl RdpeudpState {
         // Learn the peer's first sequence number from its SYN / SYN+ACK.
         if let Some(syn) = &dg.syn {
             self.peer_recv_window = self.peer_recv_window.max(dg.fec.recv_window).max(1);
+            self.peer_isn = syn.initial_seq;
+            // Negotiate the data-path version from the client's SYNEX (V3 = upgrade
+            // to RDPEUDP2). A SYN with no SYNEX leaves the V2 default.
+            if let Some(ex) = &dg.syn_ex {
+                self.negotiated_version = ex.udp_version;
+            }
             if !self.have_peer_seq {
                 self.recv_next = syn.initial_seq;
                 self.have_peer_seq = true;
@@ -181,7 +202,7 @@ impl RdpeudpState {
                 // Server: a (possibly duplicate) SYN — (re)send SYN+ACK and be established.
                 Role::Server => {
                     self.state = ConnState::Established;
-                    out.to_send.push(self.encode_syn());
+                    out.to_send.push(self.encode_syn_ack());
                 }
                 // Client: the SYN+ACK completes our open.
                 Role::Client => {
@@ -330,6 +351,25 @@ impl RdpeudpState {
             .encode()
             .expect("encode syn")
     }
+
+    /// Server reply: a SYN+ACK echoing the client's ISN as `snSourceAck` and the
+    /// negotiated version in its SYNEX — byte-shaped like a real Windows server's
+    /// (no ack vector, no cookie hash). See [`Datagram::syn_ack`].
+    fn encode_syn_ack(&self) -> Vec<u8> {
+        let syn = crate::pdu::SynData {
+            initial_seq: self.cfg.initial_seq,
+            upstream_mtu: self.cfg.mtu,
+            downstream_mtu: self.cfg.mtu,
+        };
+        Datagram::syn_ack(
+            self.peer_isn,
+            self.cfg.recv_window,
+            syn,
+            self.negotiated_version,
+        )
+        .encode()
+        .expect("encode syn+ack")
+    }
 }
 
 /// FEC header (8) + ACK vector (4, empty) + source payload header (8).
@@ -432,6 +472,54 @@ mod tests {
             wire = next_wire;
         }
         assert_eq!(delivered, msg);
+    }
+
+    /// End-to-end capture validation: feed a **real Microsoft client's SYN**
+    /// (V3/EUDP2, with cookie hash) into a server `RdpeudpState` configured with
+    /// the **real server's** ISN/window/MTU, and assert the SYN+ACK it emits is
+    /// byte-identical to the **real server's SYN+ACK** captured in reply. This
+    /// pins the whole server handshake path (decode client SYN → negotiate V3 →
+    /// encode SYN+ACK) to the wire, not just the isolated codecs.
+    #[test]
+    fn server_syn_ack_matches_capture_end_to_end() {
+        #[rustfmt::skip]
+        let client_syn: [u8; 84] = [
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x40, 0x18, 0x01, 0x64, 0x7a, 0x02, 0xbc, 0x04, 0xd0,
+            0x04, 0xd0, 0x43, 0x33, 0x3c, 0x63, 0xee, 0x77, 0x40, 0x6e, 0x97, 0xdf, 0x80, 0x0c,
+            0xa1, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0xcb, 0x86, 0x4c, 0x5b,
+            0x54, 0x3a, 0xdc, 0x7a, 0x7a, 0x36, 0x7b, 0xb8, 0x11, 0x20, 0x71, 0x7c, 0x28, 0x6d,
+            0x09, 0x3d, 0x3f, 0x3a, 0xd8, 0x80, 0x2c, 0x59, 0x4f, 0x4f, 0x21, 0x99, 0x86, 0x94,
+        ];
+        #[rustfmt::skip]
+        let expected_syn_ack: [u8; 20] = [
+            0x64, 0x7a, 0x02, 0xbc, 0x00, 0x40, 0x10, 0x05, 0x61, 0xf7, 0xb6, 0xe3, 0x04, 0xd0,
+            0x04, 0xd0, 0x00, 0x01, 0x01, 0x01,
+        ];
+
+        // The real server used ISN 0x61f7b6e3, window 64, MTU 1232.
+        let mut server = RdpeudpState::new(
+            Role::Server,
+            Config {
+                recv_window: 64,
+                mtu: 1232,
+                initial_seq: 0x61f7_b6e3,
+                rto_ms: 300,
+            },
+        );
+        let out = server.step(0, Some(&client_syn));
+
+        assert!(server.is_established());
+        assert_eq!(
+            server.negotiated_version(),
+            UdpVersion::V3,
+            "client requested V3 (EUDP2) in its SYNEX"
+        );
+        assert_eq!(out.to_send.len(), 1, "exactly one SYN+ACK, no extra acks");
+        assert_eq!(
+            out.to_send[0], expected_syn_ack,
+            "server SYN+ACK must be byte-identical to the captured Windows server reply"
+        );
     }
 
     /// Deterministic lossy/reordering/duplicating channel: a tiny LCG decides,


### PR DESCRIPTION
## What

First **M3** step — still sans-I/O and fully capture-validated, *before* any socket code. It makes the server's RDPEUDP **SYN+ACK byte-identical to what a real Windows RDP server emits**, so a real client will accept it once the UDP listener lands (M3b). Decoded from the user's capture (the client SYN and the Windows server's SYN+ACK reply, port 3390).

## Two quirks the generic `Datagram::syn` couldn't express (both capture-verified)

1. **ACK flag set, but NO ack-vector section.** A SYN+ACK's acknowledgment rides `snSourceAck` (= the client's ISN); the ack vector appears only on non-SYN data/ack packets. `Datagram::decode` now reads an ack vector only for `ACK && !SYN`.
2. **SYNEX omits the 32-byte cookie hash even for V3.** The hash is client→server only. Decode decides hash presence by *direction* (the ACK flag marks a SYN+ACK → no hash) via the new `SynDataEx::decode_directional`; the `Decode` impl keeps the client-SYN default — the only direction the server decodes in production.

## Changes

- `Datagram::syn_ack(client_isn, win, syn, version)` builds the SYN+ACK; `snSourceAck = client_isn`, flags `SYN|ACK|SYNEX`, SYNEX echoes the negotiated version, no vector, no hash.
- `RdpeudpState` (server role) captures the client's ISN + SYNEX version from the incoming SYN and emits the proper SYN+ACK. `negotiated_version()` exposes the V3/EUDP2 upgrade for the data path.

## Tests (33 total)

- **byte-exact** `syn_ack` output vs the captured Windows server bytes
- round-trip through the directional decode (ACK-without-vector, V3-without-hash)
- **end-to-end**: feed the *real client SYN* through the server SM, assert the emitted SYN+ACK is byte-identical to the *real server's SYN+ACK*
- the existing two-instance reliability tests still pass (now exchanging a V3-shaped SYN+ACK)

Next (M3b): the actual `tokio::net::UdpSocket` listener + per-peer session driving this handshake on the wire, behind the `multitransport` feature in `ironrdp-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)