### PR TITLE
feat(multitransport): M3b — UDP listener + RDPEUDP handshake on the wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-rdpeudp"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.11.1",
+ "ironrdp-core",
+]
+
+[[package]]
 name = "ironrdp-rdpsnd"
 version = "0.7.0"
 source = "git+https://github.com/Devolutions/IronRDP.git?rev=879ffed866c32748d30d26b54f9d667ad001c51c#879ffed866c32748d30d26b54f9d667ad001c51c"
@@ -1715,6 +1723,7 @@ dependencies = [
  "ironrdp-graphics",
  "ironrdp-pdu",
  "ironrdp-rdpdr",
+ "ironrdp-rdpeudp",
  "ironrdp-rdpsnd",
  "ironrdp-svc",
  "ironrdp-tokio",
@@ -1891,6 +1900,7 @@ dependencies = [
  "ironrdp-egfx",
  "ironrdp-pdu",
  "ironrdp-rdpdr",
+ "ironrdp-rdpeudp",
  "ironrdp-rdpsnd",
  "ironrdp-server",
  "ironrdp-svc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ nfsserve = "0.11.0"
 [dev-dependencies]
 ironrdp-connector = "0.8"
 ironrdp-tokio = "0.8"
+# For the UDP multitransport loopback test: decode the listener's SYN+ACK reply.
+ironrdp-rdpeudp = { path = "vendor/ironrdp-rdpeudp" }
 
 # macOS-only: screen capture + input synthesis
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -68,4 +68,69 @@ mod tests {
         assert_eq!(req.requested_protocol, RequestedProtocol::UdpFecR);
         assert_eq!(req.security_cookie, cookie);
     }
+
+    // M3b: the real UDP listener over loopback. The vendored ironrdp-server is
+    // built `test = false`, so this socket-level test lives here. It binds the
+    // listener to an ephemeral 127.0.0.1 UDP port, sends a REAL captured Microsoft
+    // client SYN from a second socket, and asserts the listener replies with a
+    // wire-correct, MTU-padded SYN+ACK (flags SYN|ACK|SYNEX, snSourceAck = the
+    // client's ISN, V3 negotiated, no cookie hash, no ack vector). Runs in CI
+    // (loopback UDP); a real Windows client accepting the SYN+ACK is verified
+    // live. The server ISN is listener-chosen, so we decode + assert fields
+    // rather than byte-compare the whole packet.
+    #[tokio::test]
+    async fn listener_answers_real_client_syn_over_loopback() {
+        use ironrdp_rdpeudp::datagram::Datagram;
+        use ironrdp_rdpeudp::pdu::{FecFlags, UdpVersion};
+        use ironrdp_server::{ListenerConfig, UdpMultitransportListener};
+        use std::time::Duration;
+        use tokio::net::UdpSocket;
+
+        #[rustfmt::skip]
+        let client_syn: [u8; 84] = [
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x40, 0x18, 0x01, 0x64, 0x7a, 0x02, 0xbc, 0x04, 0xd0,
+            0x04, 0xd0, 0x43, 0x33, 0x3c, 0x63, 0xee, 0x77, 0x40, 0x6e, 0x97, 0xdf, 0x80, 0x0c,
+            0xa1, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0xcb, 0x86, 0x4c, 0x5b,
+            0x54, 0x3a, 0xdc, 0x7a, 0x7a, 0x36, 0x7b, 0xb8, 0x11, 0x20, 0x71, 0x7c, 0x28, 0x6d,
+            0x09, 0x3d, 0x3f, 0x3a, 0xd8, 0x80, 0x2c, 0x59, 0x4f, 0x4f, 0x21, 0x99, 0x86, 0x94,
+        ];
+
+        let cfg = ListenerConfig::default();
+        let listener = UdpMultitransportListener::bind("127.0.0.1:0".parse().unwrap(), cfg)
+            .await
+            .expect("bind listener");
+        let server_addr = listener.local_addr();
+
+        let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        client.send_to(&client_syn, server_addr).await.unwrap();
+
+        let mut buf = vec![0u8; 2048];
+        let len = tokio::time::timeout(Duration::from_secs(2), client.recv(&mut buf))
+            .await
+            .expect("listener should reply within 2s")
+            .expect("recv");
+        let reply = &buf[..len];
+
+        // SYN/SYN+ACK packets are MTU-padded for path validation.
+        assert_eq!(len, cfg.mtu as usize, "SYN+ACK must be padded to the MTU");
+
+        let dg = Datagram::decode(reply).expect("decode SYN+ACK");
+        assert_eq!(
+            dg.fec.flags,
+            FecFlags::SYN | FecFlags::ACK | FecFlags::SYNEX
+        );
+        assert_eq!(
+            dg.fec.snd_source_ack as u32, 0x647a_02bc,
+            "snSourceAck must echo the client's ISN"
+        );
+        assert!(dg.ack_vector.is_none(), "SYN+ACK carries no ack vector");
+        let ex = dg.syn_ex.expect("SYNEX present");
+        assert_eq!(ex.udp_version, UdpVersion::V3, "V3/EUDP2 negotiated");
+        assert!(
+            ex.cookie_hash.is_none(),
+            "server SYN+ACK omits the cookie hash"
+        );
+        assert_eq!(dg.syn.expect("SYNDATA").upstream_mtu, 1232);
+    }
 }

--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,14 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **M3b (done — UDP listener, in `ironrdp-server`):** this crate became a real
+  dependency of `vendor/ironrdp-server` for the first time (path dep, gated by its
+  `multitransport` feature; revs already aligned so `ironrdp-core` unifies). The
+  listener (`src/multitransport/listener.rs` over there) drives a per-peer
+  `RdpeudpState` through the SYN→SYN+ACK handshake on a real socket. New here:
+  `Datagram::peek_fec_flags` (cheap SYN-detection so the listener MTU-pads
+  handshake packets). Tested over loopback from the macrdp crate (this crate stays
+  `test=true`/standalone; the server is `test=false`). 34 crate tests.
 - **M3a (done — server handshake wire-shaped to real Windows):** the server's
   **SYN+ACK** now matches a real Windows RDP server byte-exact (validated against
   a capture). `Datagram::syn_ack(client_isn, win, syn, version)` sets flags

--- a/vendor/ironrdp-rdpeudp/src/datagram.rs
+++ b/vendor/ironrdp-rdpeudp/src/datagram.rs
@@ -143,6 +143,21 @@ impl Datagram {
         }
     }
 
+    /// Peek the FEC flags of a **v1** datagram without a full decode — cheap
+    /// enough to call per outbound datagram so the UDP listener can tell whether
+    /// a packet is a SYN-family handshake packet (which MS-RDPEUDP requires be
+    /// zero-padded to the MTU) vs an ordinary data/ack packet (not padded).
+    /// Returns `None` if the buffer is shorter than the 8-byte FEC header.
+    pub fn peek_fec_flags(bytes: &[u8]) -> Option<FecFlags> {
+        if bytes.len() < FecHeader::FIXED_PART_SIZE {
+            return None;
+        }
+        // FEC header: snSourceAck(4) + uReceiveWindowSize(2) + uFlags(2, BE).
+        Some(FecFlags::from_bits_retain(u16::from_be_bytes([
+            bytes[6], bytes[7],
+        ])))
+    }
+
     pub fn encode(&self) -> EncodeResult<Vec<u8>> {
         // Worst-case size; the cursor encoder only writes what's present.
         let cap = 8 + 8 + 8 + 4 + 32 + 36 + self.source.as_ref().map_or(0, |s| s.payload.len());
@@ -286,6 +301,33 @@ mod tests {
         let back = Datagram::decode(&bytes).unwrap();
         assert_eq!(back, d);
         assert_eq!(back.source.unwrap().payload, b"hello rdpeudp");
+    }
+
+    #[test]
+    fn peek_fec_flags_reads_syn_without_full_decode() {
+        let syn = Datagram::syn(
+            -1,
+            64,
+            SynData {
+                initial_seq: 1,
+                upstream_mtu: 1232,
+                downstream_mtu: 1232,
+            },
+            None,
+            None,
+        )
+        .encode()
+        .unwrap();
+        assert!(Datagram::peek_fec_flags(&syn)
+            .unwrap()
+            .contains(FecFlags::SYN));
+
+        // A pure ack has no SYN bit; a too-short buffer returns None.
+        let ack = Datagram::ack(7, 64, empty_ack()).encode().unwrap();
+        assert!(!Datagram::peek_fec_flags(&ack)
+            .unwrap()
+            .contains(FecFlags::SYN));
+        assert!(Datagram::peek_fec_flags(&[0, 1, 2]).is_none());
     }
 
     #[test]

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -255,3 +255,22 @@ AND released — #1276 landing is NOT sufficient.
     transport + EGFX channel migration) and grow the trait. Feature-off path is
     cfg-split to keep the original `?`-based decode byte-identical. See
     `docs/rdp-udp-multitransport-feasibility.md` (the M1→M5 plan).
+    **M3b (added 2026-06-25): the UDP listener.** New
+    `src/multitransport/listener.rs` (`UdpMultitransportListener` +
+    `ListenerConfig`, re-exported from `lib.rs`) owns a `tokio::net::UdpSocket`,
+    demuxes inbound datagrams by peer address, and drives a per-peer
+    `RdpeudpState` (from the new `ironrdp-rdpeudp` dep, pulled in by the
+    `multitransport` feature: `multitransport = ["dep:ironrdp-rdpeudp"]`) through
+    the RDPEUDP SYN→SYN+ACK handshake — answering a real client's SYN with the
+    wire-correct SYN+ACK (M3a) and negotiating V3/EUDP2. SYN-family packets are
+    zero-padded to the MTU (`Datagram::peek_fec_flags` detects them). Background
+    task; `Drop` aborts it. **Cookie validation is soft** (the SYNEX `cookieHash`
+    is logged, not verified) — the listener produces the first macrdp↔client
+    capture needed to derive the hash formula; strict binding + wiring the
+    listener to bind on connect (with the `MigrationState` cookie, on the same
+    port as TCP) is M3c. Not yet connected to the server's accept path or to a
+    data consumer — it's a standalone, separately-testable unit. Tested via a
+    loopback integration test in the **macrdp** crate (this vendored crate is
+    `test = false`): bind to `127.0.0.1:0`, send a real captured client SYN, assert
+    the MTU-padded SYN+ACK fields. Cross-platform (pure tokio/std), so Linux CI
+    runs it.

--- a/vendor/ironrdp-server/Cargo.toml
+++ b/vendor/ironrdp-server/Cargo.toml
@@ -27,9 +27,10 @@ qoi = ["dep:qoicoubeh", "ironrdp-pdu/qoi"]
 qoiz = ["dep:zstd-safe", "qoi", "ironrdp-pdu/qoiz"]
 egfx = ["dep:ironrdp-egfx"]
 # (vendored) RDP UDP multitransport (MS-RDPEMT) server support. Default off so
-# the standard build is byte-identical. M1 only performs the negotiation
-# handshake (Initiate Request -> Response) and always continues on TCP.
-multitransport = []
+# the standard build is byte-identical. M1 performs the negotiation handshake;
+# M3 adds the UDP listener + RDPEUDP SYN/SYN+ACK handshake (pulls in the
+# sans-I/O ironrdp-rdpeudp crate for the wire codecs + reliability SM).
+multitransport = ["dep:ironrdp-rdpeudp"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at any time.
@@ -57,6 +58,11 @@ ironrdp-acceptor = "0.8" # public
 ironrdp-graphics = "0.7" # public
 ironrdp-rdpsnd = "0.7" # public
 ironrdp-rdpdr = "0.5" # public (vendored — server-direction RDPDR)
+# (vendored, multitransport-only) sans-I/O RDPEUDP/RDPEUDP2 wire codecs +
+# reliability state machine. Local path crate (not on crates.io); its own
+# [patch.crates-io] is ignored in the macrdp build, where ironrdp-core resolves
+# via the root patch to the same git rev.
+ironrdp-rdpeudp = { path = "../ironrdp-rdpeudp", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 x509-cert = { version = "0.2.5", optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }

--- a/vendor/ironrdp-server/src/lib.rs
+++ b/vendor/ironrdp-server/src/lib.rs
@@ -36,6 +36,8 @@ pub use echo::{EchoDvcBridge, EchoRoundTripMeasurement, EchoServerHandle, EchoSe
 pub use gfx::{EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle};
 pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "multitransport")]
+pub use multitransport::listener::{ListenerConfig, UdpMultitransportListener};
+#[cfg(feature = "multitransport")]
 pub use multitransport::{MultitransportProvider, encode_initiate_request};
 pub use rdpdr::{
     AnnouncedDevice, DirEntry, RdpdrBackendFactory, RdpdrHandle, RdpdrServer, RdpdrServerFactory, RdpdrServerHandler,

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -1,0 +1,179 @@
+//! (vendored, feature=multitransport) UDP listener + RDPEUDP SYN/SYN+ACK
+//! handshake on the wire — **M3b**.
+//!
+//! Owns a [`tokio::net::UdpSocket`], demultiplexes inbound datagrams by peer
+//! address, and drives a per-peer [`RdpeudpState`] (the sans-I/O reliability
+//! state machine from `ironrdp-rdpeudp`) through the RDPEUDP handshake: a real
+//! client's SYN is answered with a wire-correct SYN+ACK (matching real Windows;
+//! see `ironrdp-rdpeudp`'s `Datagram::syn_ack`), negotiating the data version
+//! (V3 = RDPEUDP2). The reliability/codec logic lives in `ironrdp-rdpeudp`; this
+//! file is purely the I/O layer.
+//!
+//! # Scope (M3b)
+//!
+//! - Handshake only: SYN → SYN+ACK, version negotiation, established detection.
+//!   No TLS, no MS-RDPEMT tunnel, no channel migration yet (M4/M5), and no data
+//!   delivery up to a consumer.
+//! - **Cookie validation is soft**: the client's SYNEX `cookieHash` is logged but
+//!   not verified against the issued security cookie. This listener produces the
+//!   first macrdp↔client capture (our own cookie + the client's resulting hash),
+//!   which is what's needed to derive/verify the exact hash formula; strict
+//!   binding to a specific TCP session lands in M3c.
+//! - Peers are demuxed by source address and never garbage-collected (one client
+//!   in the M3b path); GC + idle timeout come with M3c.
+//!
+//! Cross-platform (pure tokio/std networking), so Linux CI exercises it too — see
+//! the loopback integration test in the macrdp crate (the vendored server is
+//! built `test = false`).
+
+use std::collections::HashMap;
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use ironrdp_rdpeudp::datagram::Datagram;
+use ironrdp_rdpeudp::pdu::FecFlags;
+use ironrdp_rdpeudp::state::{Config, RdpeudpState, Role};
+use tokio::net::UdpSocket;
+use tokio::task::JoinHandle;
+use tracing::{debug, trace};
+
+/// Configuration for the UDP multitransport listener.
+#[derive(Debug, Clone, Copy)]
+pub struct ListenerConfig {
+    /// Advertised receive window, in datagrams (`uReceiveWindowSize`).
+    pub recv_window: u16,
+    /// Our MTU (1132..=1232 per spec). SYN/SYN+ACK packets are zero-padded to it.
+    pub mtu: u16,
+    /// Base server initial-sequence-number; each new peer session derives its ISN
+    /// from this. The exact value is not validated by clients — M3c will seed it
+    /// from a CSPRNG.
+    pub server_isn_seed: u32,
+    /// Retransmit timeout, milliseconds (passed to the reliability SM).
+    pub rto_ms: u64,
+}
+
+impl Default for ListenerConfig {
+    fn default() -> Self {
+        Self {
+            recv_window: 64,
+            mtu: 1232,
+            server_isn_seed: 0x5052_4400, // "PRD\0"-ish; replaced by a CSPRNG seed in M3c
+            rto_ms: 300,
+        }
+    }
+}
+
+/// A per-peer handshake/transport session: just the reliability SM for now.
+struct Peer {
+    sm: RdpeudpState,
+}
+
+/// A running UDP multitransport listener. The receive loop runs on a spawned
+/// task; dropping the listener aborts it (and closes the socket).
+pub struct UdpMultitransportListener {
+    local_addr: SocketAddr,
+    task: JoinHandle<()>,
+}
+
+impl UdpMultitransportListener {
+    /// Bind a UDP socket and start serving the RDPEUDP handshake on a background
+    /// task. `addr` is typically the same address/port as the TCP RDP listener
+    /// (the client reuses the server address for the UDP flow), or `:0` in tests.
+    pub async fn bind(addr: SocketAddr, cfg: ListenerConfig) -> io::Result<Self> {
+        let socket = UdpSocket::bind(addr).await?;
+        let local_addr = socket.local_addr()?;
+        let socket = Arc::new(socket);
+        debug!(%local_addr, ?cfg, "RDPEUDP multitransport listener bound");
+        let task = tokio::spawn(run_recv_loop(Arc::clone(&socket), cfg));
+        Ok(Self { local_addr, task })
+    }
+
+    /// The actual bound address (useful when binding to an ephemeral `:0` port).
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+}
+
+impl Drop for UdpMultitransportListener {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// Does this encoded datagram have the v1 SYN flag set (a SYN or SYN+ACK)?
+/// Such handshake packets must be zero-padded to the MTU.
+fn is_syn_family(bytes: &[u8]) -> bool {
+    Datagram::peek_fec_flags(bytes).is_some_and(|f| f.contains(FecFlags::SYN))
+}
+
+async fn run_recv_loop(socket: Arc<UdpSocket>, cfg: ListenerConfig) {
+    let mut peers: HashMap<SocketAddr, Peer> = HashMap::new();
+    let mut session_counter: u32 = 0;
+    let start = tokio::time::Instant::now();
+    let mut buf = vec![0u8; 2048];
+
+    loop {
+        let (len, peer_addr) = match socket.recv_from(&mut buf).await {
+            Ok(v) => v,
+            // UDP recv_from can surface a prior send_to's ICMP error (e.g. a
+            // ConnReset on Windows); it's per-datagram, so keep serving.
+            Err(e) => {
+                trace!(error = %e, "udp recv_from error; continuing");
+                continue;
+            }
+        };
+        let now_ms = start.elapsed().as_millis() as u64;
+        let data = &buf[..len];
+
+        // Log the client's SYN cookie hash + negotiated version (cookie check is
+        // soft in M3b — this is the data the future strict-validation work needs).
+        if is_syn_family(data) {
+            if let Ok(dg) = Datagram::decode(data) {
+                if let Some(ex) = dg.syn_ex {
+                    debug!(
+                        %peer_addr,
+                        version = ?ex.udp_version,
+                        has_cookie_hash = ex.cookie_hash.is_some(),
+                        "RDPEUDP SYN received (cookie validation is soft in M3b)"
+                    );
+                }
+            }
+        }
+
+        let peer = peers.entry(peer_addr).or_insert_with(|| {
+            session_counter = session_counter.wrapping_add(1);
+            let initial_seq = cfg.server_isn_seed.wrapping_add(session_counter);
+            Peer {
+                sm: RdpeudpState::new(
+                    Role::Server,
+                    Config {
+                        recv_window: cfg.recv_window,
+                        mtu: cfg.mtu,
+                        initial_seq,
+                        rto_ms: cfg.rto_ms,
+                    },
+                ),
+            }
+        });
+
+        let was_established = peer.sm.is_established();
+        let out = peer.sm.step(now_ms, Some(data));
+        for mut dg in out.to_send {
+            if is_syn_family(&dg) && dg.len() < cfg.mtu as usize {
+                dg.resize(cfg.mtu as usize, 0); // path-MTU validation padding
+            }
+            if let Err(e) = socket.send_to(&dg, peer_addr).await {
+                trace!(error = %e, %peer_addr, "udp send_to error");
+            }
+        }
+
+        if !was_established && peer.sm.is_established() {
+            debug!(
+                %peer_addr,
+                version = ?peer.sm.negotiated_version(),
+                "RDPEUDP handshake established"
+            );
+        }
+    }
+}

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -21,6 +21,8 @@
 //! `migration` submodules (the UDP transport + channel migration); the trait
 //! will gain methods accordingly.
 
+pub mod listener;
+
 use anyhow::Result;
 use ironrdp_core::encode_vec;
 use ironrdp_pdu::mcs::SendDataIndication;


### PR DESCRIPTION
## What

The first **socket-touching** milestone. A new `UdpMultitransportListener` (in the vendored `ironrdp-server`, behind the `multitransport` feature) owns a `tokio::net::UdpSocket`, demuxes inbound datagrams by peer address, and drives a per-peer `RdpeudpState` through the RDPEUDP **SYN → SYN+ACK** handshake — answering a real client's SYN with the wire-correct, V3-negotiating SYN+ACK from M3a.

This makes the sans-I/O `ironrdp-rdpeudp` crate a **real dependency of `ironrdp-server`** for the first time (path dep, pulled in only by `multitransport = ["dep:ironrdp-rdpeudp"]`; the `ironrdp-core` git revs were already aligned, so it unifies cleanly via the root `[patch.crates-io]`). New crate helper `Datagram::peek_fec_flags` lets the listener detect SYN-family packets and zero-pad them to the MTU (path-MTU validation).

## Scope (deliberately bounded)

- **Handshake only** — no TLS, no MS-RDPEMT tunnel, no channel migration, and not yet wired to the server accept path or a data consumer. It's a standalone, separately-testable unit.
- **Cookie validation is soft** — the client's SYNEX `cookieHash` is logged, not verified. This listener produces the *first macrdp↔client capture* (our own 16-byte cookie + the client's resulting hash), which is exactly what's needed to derive/verify the hash formula. Strict binding + bind-on-connect with the `MigrationState` cookie (on the same port as TCP) is **M3c**.
- Peers demuxed by source address, no GC yet (one client in the M3b path).

## Tests

A loopback integration test in the **macrdp** crate (the vendored server is `test = false`): bind to `127.0.0.1:0`, send a **real captured Microsoft client SYN** from a second `UdpSocket`, and assert the listener replies with an MTU-padded SYN+ACK carrying flags `SYN|ACK|SYNEX`, `snSourceAck` = the client's ISN, `V3` negotiated, no cookie hash, no ack vector. **Runs in CI** (loopback UDP) — a real Windows client accepting the SYN+ACK is verified live. Plus a crate unit test for `peek_fec_flags`. Cross-platform (pure tokio/std), so Linux CI exercises it too.

Next (M3c): bind the listener from the server accept path on the same port as TCP, seed the cookie/ISN from a CSPRNG, and validate the client's `cookieHash` against the issued security cookie (using the capture this milestone makes possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)