### PR TITLE
feat(multitransport): M3c — bind the UDP listener into macrdp's accept path

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -4,25 +4,48 @@
 All "what IronRDP/FreeRDP do today" claims were web-verified on the date above;
 verify again before acting, code moves.*
 
-> **Status: M1 + M2 LANDED (2026-06-25).**
+> **Status: M1 + M2 + EUDP2 codec + M3a/M3b/M3c LANDED (2026-06-25).**
 > - **M1** (PR #15, `bf26824`): MS-RDPEMT negotiation + safe TCP fallback behind
 >   the `multitransport` cargo feature + `--enable-udp-multitransport` (default
 >   OFF). Verified live on mstsc + sdl-freerdp; Initiate Request framing has a
->   round-trip CI test. Loopback can't exercise the actual *send* (no client
->   advertises UDP for 127.0.0.1) → real-Windows send acceptance deferred to M3.
+>   round-trip CI test.
 > - **M2** (PRs #16/#17/#18): the offline `ironrdp-rdpeudp` crate — RDPEUDP v1 PDU
 >   codecs (`pdu.rs`, big-endian, spec-capture-anchored; flag values corrected
 >   against the spec), ACK-vector codec, whole-datagram assemble/parse
 >   (`datagram.rs`), and the **sans-I/O reliable transport state machine**
 >   (`state.rs`): handshake + in-order de-duplicated delivery + cumulative-ACK +
 >   RTO retransmit, proven by a two-instance in-memory loss/reorder/dup test.
+> - **EUDP2 codec** (PRs #21/#22/#23): the RDPEUDP2 (`0x0101`) data framing,
+>   reverse-engineered from FreeRDP's `rdp-udp.lua` dissector + a real capture and
+>   verified byte-exact — network-format transform (byte 0↔7 swap), base header,
+>   the full sub-header walk to the `DataBody`, and a framing-neutral inbound view.
+>   The underdocumented framing that previously blocked M3 is now fully decodable.
+> - **M3a** (PR #24): the server's RDPEUDP **SYN+ACK** wire-shaped byte-exact to a
+>   real Windows server (ACK flag without ack-vector; SYNEX without cookie hash;
+>   `snSourceAck` = client ISN; V3 negotiation) — capture-validated end to end.
+> - **M3b** (PR #25): the **UDP listener** (`UdpMultitransportListener`, vendored
+>   `ironrdp-server`, behind the feature) — owns a `tokio` `UdpSocket`, demuxes by
+>   peer, drives a per-peer `RdpeudpState` through SYN→SYN+ACK, MTU-pads handshake
+>   packets. CI-tested over loopback with the real captured client SYN.
+> - **M3c** (this change): **wired into macrdp's accept path** — when
+>   `--enable-udp-multitransport` is set (single-process path), macrdp binds the
+>   listener on the **same address/port as TCP** at startup, so a client's UDP SYN
+>   now reaches a live endpoint and gets a SYN+ACK. The session **still runs over
+>   TCP** (no TLS/EMT tunnel/migration yet). Cookie validation is soft; the server
+>   logs the issued cookie and the listener logs the client's `cookieHash` so the
+>   hash formula can be derived from a live run. Not supported under
+>   `--fork-workers` (the persistent UDP socket would belong to the supervisor —
+>   deferred; warns + falls back to TCP).
 >
-> **Next: M3 — UDP listener + RDPEUDP SYN handshake on the wire. BLOCKED on a
-> spike that needs the USER:** a real mstsc UDP capture (Wireshark) to author the
-> underdocumented **RDPEUDP2 (`0x0101`) bit-packed data framing** — mstsc's data
-> path — against real bytes. The crate's algorithm is framing-agnostic and ready
-> to reuse; cumulative-ACK only so far (selective retransmit + congestion control
-> deferred).
+> **Next: derive the cookie-hash formula + the EUDP2 data path.** What remains
+> needs a **real, non-loopback client** (pure loopback suppresses the client's UDP
+> advertisement): point mstsc-in-a-VM at macrdp on the host IP, capture macrdp's
+> own cookie (server log) + the client's resulting `cookieHash` (listener log) →
+> derive/verify the hash → tighten validation. Then **M4** (rustls over the
+> reliable stream + the MS-RDPEMT tunnel) and **M5** (migrate the EGFX channel to
+> UDP). The reliability SM is framing-agnostic and the EUDP2 inbound adapter is
+> ready; the EUDP2 *encode*/SM-send side is the remaining piece that a live V3
+> bidirectional capture will validate.
 
 ## TL;DR
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,14 +449,14 @@ struct Args {
     #[arg(long)]
     enable_smartcard_redirection: bool,
 
-    /// EXPERIMENTAL (M1, opt-in, default OFF). Offer RDP UDP multitransport
-    /// (MS-RDPEMT) to clients that advertise it. **M1 is negotiation only:**
-    /// the server sends the Initiate Multitransport Request and handles the
-    /// client's response, but there is NO UDP transport yet — the client's UDP
-    /// attempt times out (E_ABORT) and the session continues on TCP, unchanged.
-    /// This exists to prove the negotiation/framing + graceful fallback ahead of
-    /// the UDP data path (later milestones). No reason for end users to enable
-    /// it. macOS-only build; see docs/rdp-udp-multitransport-feasibility.md.
+    /// EXPERIMENTAL (M3, opt-in, default OFF). Offer RDP UDP multitransport
+    /// (MS-RDPEMT) to clients that advertise it, and bind a UDP listener on the
+    /// same address/port as TCP. **The session still runs over TCP:** the listener
+    /// answers the RDPEUDP SYN→SYN+ACK handshake (negotiating RDPEUDP2), but there
+    /// is no TLS/EMT tunnel or channel migration yet, so nothing actually moves to
+    /// UDP. Cookie validation is soft. No reason for end users to enable it. Not
+    /// supported under --fork-workers (falls back to TCP). macOS-only build; see
+    /// docs/rdp-udp-multitransport-feasibility.md.
     #[arg(long)]
     enable_udp_multitransport: bool,
 
@@ -1502,6 +1502,16 @@ async fn async_main() -> Result<()> {
         if !args.allow_sleep {
             prevent_sleep();
         }
+        if args.enable_udp_multitransport {
+            // The persistent UDP socket would have to live in the supervisor (one
+            // socket per port, demuxed across worker reconnects); that's not wired
+            // yet. The M1 offer still happens in each worker, so clients fall back
+            // to TCP. Deferred — see the multitransport plan.
+            warn!(
+                "UDP multitransport listener is not started under --fork-workers yet; \
+                 clients will fall back to TCP"
+            );
+        }
         return run_fork_supervisor(args.bind, vd, blank, args.app_switcher_hud).await;
     }
     if let Some(fd) = worker_fd {
@@ -2084,13 +2094,55 @@ async fn async_main() -> Result<()> {
     // pipeline all read.
     server.set_honor_client_desktop_size(auto_size);
 
-    // EXPERIMENTAL UDP multitransport (MS-RDPEMT) — M1 negotiation only. When
-    // enabled, install the provider so the server offers reliable UDP to clients
-    // that advertise it. There is no UDP transport yet (M1), so the client's UDP
-    // attempt times out and the session continues on TCP. See src/multitransport.rs.
-    if args.enable_udp_multitransport {
-        server.set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));
-    }
+    // EXPERIMENTAL UDP multitransport (MS-RDPEMT). When enabled, install the
+    // provider so the server offers reliable UDP to clients that advertise it,
+    // and (M3) bind a real UDP listener on the same address/port as TCP — the
+    // client reuses the server address for the auxiliary UDP flow. The handle is
+    // held in `_udp_listener` for the process lifetime (Drop aborts its task).
+    //
+    // M3 scope: the listener answers the RDPEUDP SYN→SYN+ACK handshake (V3/EUDP2
+    // negotiation); cookie validation is soft and there's no TLS/EMT tunnel or
+    // channel migration yet, so a client that completes the handshake still runs
+    // the session over TCP. Single-process path only — under --fork-workers the
+    // persistent UDP socket would have to live in the supervisor (deferred; we
+    // warn above and fall back to TCP). worker_fd.is_some() ⇒ a fork worker.
+    let _udp_listener = if args.enable_udp_multitransport && worker_fd.is_none() {
+        // The server ISN isn't client-validated; seed it from the clock to avoid a
+        // new RNG dependency (the security-relevant value is the cookie, not this).
+        let isn_seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let cfg = ironrdp_server::ListenerConfig {
+            server_isn_seed: isn_seed,
+            ..Default::default()
+        };
+        match ironrdp_server::UdpMultitransportListener::bind(args.bind, cfg).await {
+            Ok(listener) => {
+                info!(
+                    addr = %args.bind,
+                    "UDP multitransport listener bound (M3: RDPEUDP handshake; \
+                     session still runs over TCP)"
+                );
+                server
+                    .set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));
+                Some(listener)
+            }
+            Err(e) => {
+                // Non-fatal: fall back to TCP-only. Most common cause is the UDP
+                // port already being in use.
+                warn!(error = %e, addr = %args.bind, "could not bind UDP multitransport listener; continuing TCP-only");
+                None
+            }
+        }
+    } else {
+        if args.enable_udp_multitransport {
+            // Fork worker: the provider still offers UDP (M1), but the listener is
+            // the supervisor's job (deferred), so the client falls back to TCP.
+            server.set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));
+        }
+        None
+    };
 
     // ironrdp_server::Credentials holds a plain String, so this copy is
     // outside our control and won't be zeroed when the server shuts down.

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -274,3 +274,12 @@ AND released — #1276 landing is NOT sufficient.
     `test = false`): bind to `127.0.0.1:0`, send a real captured client SYN, assert
     the MTU-padded SYN+ACK fields. Cross-platform (pure tokio/std), so Linux CI
     runs it.
+    **M3c (added 2026-06-25): wired into the accept path.** macrdp's `main.rs` now
+    binds the listener on the same address/port as TCP at startup when
+    `--enable-udp-multitransport` is set (single-process path; `--fork-workers`
+    warns + falls back — the persistent UDP socket would belong to the supervisor,
+    deferred). The only server-crate change here is that `maybe_offer_multitransport`
+    now logs the issued 16-byte security cookie (hex) at `debug`, so it can be
+    correlated with the listener's logged client SYNEX `cookieHash` to derive the
+    hash formula from a live run (cookie validation is still soft). The session
+    still runs over TCP (no TLS/EMT tunnel or migration yet).

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -1379,10 +1379,14 @@ impl RdpServer {
             cookie,
             protocol,
         });
+        // Log the issued cookie (hex) so it can be correlated with the UDP
+        // listener's logged client SYNEX `cookieHash` to derive the hash formula
+        // from a live run (cookie validation is still soft — see M3 in the plan).
         debug!(
             request_id,
             ?protocol,
-            "sent Server Initiate Multitransport Request (M1: negotiation only; expecting E_ABORT fallback)"
+            cookie = %cookie.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+            "sent Server Initiate Multitransport Request"
         );
         Ok(())
     }


### PR DESCRIPTION
## What

Wires the M3b UDP listener into macrdp. When `--enable-udp-multitransport` is set (single-process path), macrdp now binds `UdpMultitransportListener` on the **same address/port as TCP** at startup and holds it for the process lifetime — so a client's auxiliary UDP SYN reaches a live endpoint and gets the wire-correct SYN+ACK (M3a) instead of timing out.

Verified locally: the process binds **both TCP and UDP** on the port and logs `UDP multitransport listener bound`:
```
INFO macrdp: UDP multitransport listener bound (M3: RDPEUDP handshake; session still runs over TCP) addr=127.0.0.1:13392
# lsof shows both:  UDP 127.0.0.1:13392   and   TCP 127.0.0.1:13392 (LISTEN)
```

## Scope / behavior

- **The session still runs over TCP** — there's no TLS/EMT tunnel or channel migration yet, so completing the RDPEUDP handshake doesn't move any data to UDP. This is the handshake reaching a live endpoint, nothing more.
- **Cookie validation stays soft**, but is now *derivable*: the server logs the issued 16-byte security cookie (hex) at `debug` next to the listener's logged client SYNEX `cookieHash`, so the hash formula can be reversed from a live run before validation is tightened.
- **Not supported under `--fork-workers`**: the persistent UDP socket would have to live in the supervisor (one socket per port, demuxed across worker reconnects) — deferred; it warns and falls back to TCP.
- Listener bind failure is **non-fatal** (logs + continues TCP-only). The server ISN seed comes from the clock (not client-validated; the security-relevant value is the cookie).

## Other

Updated the `--enable-udp-multitransport` help text (M1→M3), the feasibility-doc status block, and the `ironrdp-server` divergence log. No new tests (the listener logic is already covered by the M3b loopback test; this PR is process-level wiring, smoke-tested by hand).

## Next

Needs a **real, non-loopback client** (pure loopback suppresses the client's UDP advertisement): point mstsc-in-a-VM at macrdp on the host IP → capture the cookie + cookieHash → derive the hash → tighten validation. Then M4 (rustls + EMT tunnel) and M5 (EGFX migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)