### PR TITLE
feat(multitransport): log the client's full cookie hash on RDPEUDP SYN

### DIFF
--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -131,11 +131,19 @@ async fn run_recv_loop(socket: Arc<UdpSocket>, cfg: ListenerConfig) {
         if is_syn_family(data) {
             if let Ok(dg) = Datagram::decode(data) {
                 if let Some(ex) = dg.syn_ex {
+                    // Log the full client cookie hash (hex). Cookie validation is
+                    // still soft; pair this with the server's logged issued cookie
+                    // ("sent Server Initiate Multitransport Request", cookie=…) from
+                    // a live run to derive the hash formula, then tighten.
+                    let cookie_hash = ex
+                        .cookie_hash
+                        .map(|h| h.iter().map(|b| format!("{b:02x}")).collect::<String>())
+                        .unwrap_or_else(|| "none".to_owned());
                     debug!(
                         %peer_addr,
                         version = ?ex.udp_version,
-                        has_cookie_hash = ex.cookie_hash.is_some(),
-                        "RDPEUDP SYN received (cookie validation is soft in M3b)"
+                        %cookie_hash,
+                        "RDPEUDP SYN received (cookie validation is soft; correlate cookie_hash with the issued cookie)"
                     );
                 }
             }


### PR DESCRIPTION
## What

Small prep so your **live cookie-formula derivation run** needs nothing but the logs. The UDP listener's SYN log now emits the client SYNEX **`cookieHash` as full hex** (it was just a `has_cookie_hash` bool).

Paired with the server's already-logged issued 16-byte cookie (`sent Server Initiate Multitransport Request`, `cookie=…`), a single live run gives both halves to reverse the hash formula — no pcap decode required. Cookie validation stays soft until the formula is confirmed.

## Verified

Fired the real captured client SYN at a running listener:
```
DEBUG …listener: RDPEUDP SYN received (cookie validation is soft; correlate cookie_hash with the issued cookie)
       peer_addr=127.0.0.1:58562 version=V3
       cookie_hash=cb864c5b543adc7a7a367bb81120717c286d093d3f3ad8802c594f4f21998694
```
— matches the 32 cookie-hash bytes of the captured SYN exactly.

## How to use it (live run)

Run macrdp on a real host IP with `--enable-udp-multitransport` and `RUST_LOG=info,ironrdp_server=debug`, point a UDP-capable client (e.g. mstsc in a VM) at it, and grep the logs for `cookie=` (server, issued) and `cookie_hash=` (listener, client) — then the relationship can be derived (likely `SHA-256(cookie)`, to be verified — could fold in other fields/HMAC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)