### PR TITLE
feat(multitransport): M3 — emit the offer from the acceptor; SYN handshake verified on mstsc

### DIFF
--- a/vendor/ironrdp-acceptor/CLAUDE.md
+++ b/vendor/ironrdp-acceptor/CLAUDE.md
@@ -73,3 +73,48 @@ vendor dir until divergence (1) is upstreamed AND released.
     Server Initiate Multitransport Request. Purely additive (same shape as (2)),
     so trivially upstreamable — offer alongside (1)/(2). See the
     docs/rdp-udp-multitransport-feasibility.md plan.
+
+    M3c (2026-06-25): the acceptor now also *advertises* and *emits* the
+    multitransport offer, not just surfaces the client's flags. Four additions,
+    all gated on the offer being set (so the default build is unchanged):
+    - **`advertise_extended_client_data: bool`** (setter
+      `set_advertise_extended_client_data`): when set, the X.224 Negotiation
+      Response carries `EXTENDED_CLIENT_DATA_SUPPORTED`. Load-bearing —
+      WITHOUT it mstsc omits ALL optional GCC client blocks (CS_MULTITRANSPORT,
+      CS_MCS_MSGCHANNEL, CS_MONITOR), so the server never sees UDP support.
+    - **`multitransport_offer: Option<MultitransportOffer>`** (setter
+      `set_multitransport_offer`; `MultitransportOffer { request_id, protocol,
+      cookie }` is a new pub type, re-exported from `lib.rs`). When set, the
+      server's GCC Connect Response echoes **SC_MULTITRANSPORT**
+      (`MultiTransportChannelData`) AND grants an **SC_MCS_MSGCHANNEL**
+      (`ServerMessageChannelData`) with an allocated MCS message channel id
+      (= io_channel + channel_count + 1, e.g. 1008). The message channel is a
+      hard requirement: clients route the bootstrap/autodetect PDUs by
+      `messageChannelId` and ignore an Initiate Request on the I/O channel
+      (FreeRDP logs `expected messageChannelId=1008, got 1003`).
+    - **Emit the Server Initiate Multitransport Request in `LicensingExchange`**
+      — after the licensing PDU, BEFORE Demand Active, on the message channel.
+      This is the ONLY window clients honor it (FreeRDP's
+      MULTITRANSPORT_BOOTSTRAPPING_REQUEST state, between LICENSING and
+      DEMAND_ACTIVE; mstsc the same). Sent post-finalization (the original M1
+      shape, on the I/O channel from the server crate) the client is ACTIVE and
+      misreads it as a share-control PDU and tears the session down. The issued
+      offer is recorded on `multitransport_offered: Option<MultitransportOffer>`
+      (new `AcceptorResult` field) so the server can build its MigrationState.
+    - **Finalization channel-skip** (`finalization.rs` + `CapabilitiesWaitConfirm`
+      in `connection.rs`): once a message channel exists, the client interleaves
+      PDUs on it — notably its **Client Initiate Multitransport Response**
+      (E_ABORT when it can't bring up UDP, or simply when it falls back) —
+      with the io-channel finalization PDUs. Both decode sites blindly decoded
+      the next `SendDataRequest`'s payload as a `ShareControlHeader`, so a
+      message-channel PDU killed the session with `invalid pdu_type` during
+      `accept_finalize`. Fix: skip any `SendDataRequest` whose `channel_id` !=
+      the io channel and stay in the same state. (Strictly more correct than the
+      old behaviour even ignoring multitransport: `WaitSynchronize`/
+      `WaitControlCooperate` previously swallowed a decode error AND advanced,
+      which would desync.) Verified live: FreeRDP + mstsc both reach ACTIVE and
+      render; mstsc additionally completes the RDPEUDP SYN→SYN+ACK handshake on
+      the wire (see server divergence (12) M3c). **Cookie finding:** mstsc
+      negotiates RDPEUDP **V2**, where the 16-byte security cookie is NOT in the
+      SYN (the SYN `cookieHash` is V3/RDPEUDP2 only) — it rides the MS-RDPEMT
+      `RDP_TUNNEL_CREATEREQUEST`, so strict cookie binding is an M4 concern.

--- a/vendor/ironrdp-acceptor/src/connection.rs
+++ b/vendor/ironrdp-acceptor/src/connection.rs
@@ -60,6 +60,50 @@ pub struct Acceptor {
     /// server can decide whether to offer a UDP transport. Empty if the client
     /// sent no multitransport block.
     client_multitransport: gcc::MultiTransportFlags,
+    /// (vendored) When true, set `EXTENDED_CLIENT_DATA_SUPPORTED` in the X.224
+    /// RDP Negotiation Response. mstsc only sends the OPTIONAL GCC client data
+    /// blocks — `CS_MULTITRANSPORT` (UDP support), `CS_MONITOR`,
+    /// `CS_MONITOR_EX`, `CS_MESSAGE_CHANNEL` — when the server advertises this
+    /// flag; without it, mstsc omits them all (so multitransport can never be
+    /// negotiated). Default false to keep the standard handshake byte-identical;
+    /// the server turns it on only when a multitransport provider is installed,
+    /// since enabling extended data can change the core-data desktop size a
+    /// multi-monitor client reports.
+    advertise_extended_client_data: bool,
+    /// (vendored) The UDP multitransport (MS-RDPEMT) offer to send, if any. When
+    /// set (and the client advertised matching support), the acceptor emits a
+    /// Server Initiate Multitransport Request **right after the licensing PDU and
+    /// before Demand Active** — the only window in which clients accept it
+    /// (FreeRDP's `MULTITRANSPORT_BOOTSTRAPPING_REQUEST` state sits between
+    /// `LICENSING` and `CAPABILITIES_EXCHANGE_DEMAND_ACTIVE`; mstsc is the same).
+    /// Sending it after finalization — once the client is ACTIVE — makes the
+    /// client misparse it as a share-control PDU and tear the session down.
+    multitransport_offer: Option<MultitransportOffer>,
+    /// (vendored) Set to the offer actually emitted (offer present AND the client
+    /// advertised the requested transport), so the server can bind the UDP flow /
+    /// match the client's Multitransport Response. `None` if nothing was sent.
+    multitransport_offered: Option<MultitransportOffer>,
+    /// (vendored) The MCS message-channel id allocated when offering UDP
+    /// multitransport, announced to the client in `SC_MCS_MSGCHANNEL`. The Server
+    /// Initiate Multitransport Request MUST ride this channel (not the I/O
+    /// channel): clients route the autodetect/multitransport bootstrap PDUs by
+    /// channel id and silently ignore a request on the I/O channel when a message
+    /// channel exists (verified — FreeRDP logs `expected messageChannelId=0`).
+    /// `None` when not offering multitransport (default path unchanged).
+    message_channel_id: Option<u16>,
+}
+
+/// (vendored) A UDP multitransport (MS-RDPEMT) offer the server asks the acceptor
+/// to send during the connection sequence. See [`Acceptor::set_multitransport_offer`].
+#[derive(Debug, Clone, Copy)]
+pub struct MultitransportOffer {
+    /// Correlates the request with the client's Multitransport Response and the
+    /// tunnel-creation request over the new transport.
+    pub request_id: u32,
+    /// Which UDP transport the server is requesting (reliable / lossy).
+    pub protocol: rdp::multitransport::RequestedProtocol,
+    /// 16-byte security cookie echoed by the client to bind the UDP flow.
+    pub cookie: [u8; 16],
 }
 
 #[derive(Debug)]
@@ -77,6 +121,11 @@ pub struct AcceptorResult {
     /// flags from its GCC MultiTransportChannelData block; empty if the client
     /// sent no multitransport block.
     pub multitransport_flags: gcc::MultiTransportFlags,
+    /// (vendored) The UDP multitransport offer the acceptor actually sent during
+    /// the connection sequence (after licensing, before Demand Active), or `None`
+    /// if none was sent. The server uses it to match the client's Multitransport
+    /// Response and bind the inbound UDP flow.
+    pub multitransport_offered: Option<MultitransportOffer>,
     /// Credentials received from the client during SecureSettingsExchange.
     ///
     /// Present for TLS-mode connections where the client sends credentials
@@ -110,6 +159,10 @@ impl Acceptor {
             honor_client_desktop_size: false,
             client_keyboard_layout: 0,
             client_multitransport: gcc::MultiTransportFlags::empty(),
+            advertise_extended_client_data: false,
+            multitransport_offer: None,
+            multitransport_offered: None,
+            message_channel_id: None,
         }
     }
 
@@ -118,6 +171,22 @@ impl Acceptor {
     /// `honor_client_desktop_size` field for the rationale.
     pub fn set_honor_client_desktop_size(&mut self, honor: bool) {
         self.honor_client_desktop_size = honor;
+    }
+
+    /// (vendored) Advertise `EXTENDED_CLIENT_DATA_SUPPORTED` so the client sends
+    /// its optional GCC blocks (notably `CS_MULTITRANSPORT`). See the field doc.
+    pub fn set_advertise_extended_client_data(&mut self, advertise: bool) {
+        self.advertise_extended_client_data = advertise;
+    }
+
+    /// (vendored) Offer an auxiliary UDP multitransport (MS-RDPEMT) transport.
+    /// When set, the acceptor sends a Server Initiate Multitransport Request right
+    /// after the licensing PDU (before Demand Active) — the only point in the
+    /// sequence at which clients accept it — provided the client advertised the
+    /// requested transport in its GCC `MultiTransportChannelData`. The emitted
+    /// offer is reported back on [`AcceptorResult::multitransport_offered`].
+    pub fn set_multitransport_offer(&mut self, offer: Option<MultitransportOffer>) {
+        self.multitransport_offer = offer;
     }
 
     pub fn new_deactivation_reactivation(
@@ -162,6 +231,12 @@ impl Acceptor {
             honor_client_desktop_size: consumed.honor_client_desktop_size,
             client_keyboard_layout: consumed.client_keyboard_layout,
             client_multitransport: consumed.client_multitransport,
+            advertise_extended_client_data: consumed.advertise_extended_client_data,
+            // Reactivation skips LicensingExchange, so nothing is re-emitted;
+            // carry both so the fields stay consistent.
+            multitransport_offer: consumed.multitransport_offer,
+            multitransport_offered: consumed.multitransport_offered,
+            message_channel_id: consumed.message_channel_id,
         })
     }
 
@@ -218,6 +293,7 @@ impl Acceptor {
                 credentials: self.received_credentials.take(),
                 keyboard_layout: self.client_keyboard_layout,
                 multitransport_flags: self.client_multitransport,
+                multitransport_offered: self.multitransport_offered,
             }),
             previous_state => {
                 self.state = previous_state;
@@ -409,10 +485,14 @@ impl Sequence for Acceptor {
                         requested_protocol,
                     ));
                 };
-                let connection_confirm = nego::ConnectionConfirm::Response {
-                    flags: nego::ResponseFlags::empty(),
-                    protocol,
-                };
+                // (vendored) Advertise EXTENDED_CLIENT_DATA_SUPPORTED when asked,
+                // so the client sends its optional GCC blocks (CS_MULTITRANSPORT
+                // et al.). mstsc omits ALL of them without this flag.
+                let mut flags = nego::ResponseFlags::empty();
+                if self.advertise_extended_client_data {
+                    flags |= nego::ResponseFlags::EXTENDED_CLIENT_DATA_SUPPORTED;
+                }
+                let connection_confirm = nego::ConnectionConfirm::Response { flags, protocol };
 
                 debug!(message = ?connection_confirm, "Send");
 
@@ -487,6 +567,11 @@ impl Sequence for Acceptor {
                     .as_ref()
                     .map(|m| m.flags)
                     .unwrap_or_else(gcc::MultiTransportFlags::empty);
+
+                debug!(
+                    multitransport_flags = ?self.client_multitransport,
+                    "client multitransport support captured from GCC"
+                );
 
                 // (vendored) Adopt the client's requested desktop size from
                 // its Client Core Data before the server's Demand Active is
@@ -570,11 +655,36 @@ impl Sequence for Acceptor {
                 let skip_channel_join = early_capability
                     .is_some_and(|client| client.contains(gcc::ClientEarlyCapabilityFlags::SUPPORT_SKIP_CHANNELJOIN));
 
+                // (vendored) Advertise reliable UDP multitransport + soft-sync
+                // in `SC_MULTITRANSPORT` when the server enabled the extended
+                // client data path (which it does only when a multitransport
+                // provider is installed). Lossy (`UDP_FECL`) is a later phase.
+                let multitransport = self.advertise_extended_client_data.then_some(
+                    gcc::MultiTransportFlags::TRANSPORT_TYPE_UDP_FECR
+                        | gcc::MultiTransportFlags::SOFT_SYNC_TCP_TO_UDP,
+                );
+
+                // (vendored) Allocate a message channel (the next id after the
+                // virtual channels) when offering multitransport — the Initiate
+                // Request rides it. Same gate as `SC_MULTITRANSPORT`: the client
+                // sends `CS_MCS_MSGCHANNEL` only because we set
+                // EXTENDED_CLIENT_DATA_SUPPORTED, so granting one back is in-contract.
+                let message_channel_id = if self.advertise_extended_client_data {
+                    let count = u16::try_from(channel_ids.len()).expect("channel count fits u16");
+                    let id = self.io_channel_id.saturating_add(1).saturating_add(count);
+                    self.message_channel_id = Some(id);
+                    Some(id)
+                } else {
+                    None
+                };
+
                 let server_blocks = create_gcc_blocks(
                     self.io_channel_id,
                     channel_ids.clone(),
                     requested_protocol,
                     skip_channel_join,
+                    multitransport,
+                    message_channel_id,
                 );
 
                 let settings_response = mcs::ConnectResponse {
@@ -598,7 +708,13 @@ impl Sequence for Acceptor {
                         connection: if skip_channel_join {
                             ChannelConnectionSequence::skip_channel_join(self.user_channel_id)
                         } else {
-                            ChannelConnectionSequence::new(self.user_channel_id, self.io_channel_id, channel_ids)
+                            // The message channel (if any) is joined like the
+                            // others when the client doesn't skip channel joins.
+                            let mut join_ids = channel_ids;
+                            if let Some(id) = message_channel_id {
+                                join_ids.push(id);
+                            }
+                            ChannelConnectionSequence::new(self.user_channel_id, self.io_channel_id, join_ids)
                         },
                     },
                 )
@@ -697,8 +813,52 @@ impl Sequence for Acceptor {
 
                 debug!(message = ?license, "Send");
 
-                let written =
+                let mut written =
                     util::encode_send_data_indication(self.user_channel_id, self.io_channel_id, &license, output)?;
+
+                // (vendored) Emit the Server Initiate Multitransport Request HERE
+                // — after licensing, before Demand Active. This is the only window
+                // clients honor it in (FreeRDP's MULTITRANSPORT_BOOTSTRAPPING_REQUEST
+                // state; mstsc the same). Sent later (post-finalization) the client
+                // is ACTIVE and misreads it as a share-control PDU, tearing down.
+                if let Some(offer) = self.multitransport_offer {
+                    let needed = match offer.protocol {
+                        rdp::multitransport::RequestedProtocol::UdpFecR => {
+                            gcc::MultiTransportFlags::TRANSPORT_TYPE_UDP_FECR
+                        }
+                        rdp::multitransport::RequestedProtocol::UdpFecL => {
+                            gcc::MultiTransportFlags::TRANSPORT_TYPE_UDP_FECL
+                        }
+                    };
+                    if self.client_multitransport.contains(needed) {
+                        let request = rdp::multitransport::MultitransportRequestPdu {
+                            security_header: rdp::headers::BasicSecurityHeader {
+                                flags: rdp::headers::BasicSecurityHeaderFlags::TRANSPORT_REQ,
+                            },
+                            request_id: offer.request_id,
+                            requested_protocol: offer.protocol,
+                            security_cookie: offer.cookie,
+                        };
+                        // Ride the message channel if one was granted (clients
+                        // route the bootstrap PDU by channel id); fall back to the
+                        // I/O channel only if somehow no message channel exists.
+                        let mt_channel = self.message_channel_id.unwrap_or(self.io_channel_id);
+                        debug!(channel_id = mt_channel, message = ?request, "Send Server Initiate Multitransport Request");
+                        written = written.saturating_add(util::encode_send_data_indication(
+                            self.user_channel_id,
+                            mt_channel,
+                            &request,
+                            output,
+                        )?);
+                        self.multitransport_offered = Some(offer);
+                    } else {
+                        debug!(
+                            client_flags = ?self.client_multitransport,
+                            ?needed,
+                            "not sending multitransport request: client didn't advertise the requested transport"
+                        );
+                    }
+                }
 
                 self.saved_for_reactivation = AcceptorState::CapabilitiesSendServer {
                     early_capability,
@@ -791,6 +951,18 @@ impl Sequence for Acceptor {
                 };
                 match message {
                     mcs::McsMessage::SendDataRequest(data) => {
+                        // (vendored) Skip message-channel PDUs (autodetect /
+                        // multitransport response) that ride a channel != io once a
+                        // message channel is granted; only io-channel ShareControl
+                        // PDUs (Confirm Active) belong here. Stay put for the next.
+                        if data.channel_id != self.io_channel_id {
+                            debug!(
+                                channel_id = data.channel_id,
+                                "Skipping non-io-channel PDU during capabilities-wait"
+                            );
+                            self.state = prev_state;
+                            return Ok(Written::Nothing);
+                        }
                         let capabilities_confirm = decode::<rdp::headers::ShareControlHeader>(data.user_data.as_ref())
                             .map_err(ConnectorError::decode);
                         let capabilities_confirm = match capabilities_confirm {
@@ -872,6 +1044,8 @@ fn create_gcc_blocks(
     channel_ids: Vec<u16>,
     requested: SecurityProtocol,
     skip_channel_join: bool,
+    multitransport: Option<gcc::MultiTransportFlags>,
+    message_channel_id: Option<u16>,
 ) -> gcc::ServerGccBlocks {
     gcc::ServerGccBlocks {
         core: gcc::ServerCoreData {
@@ -887,7 +1061,19 @@ fn create_gcc_blocks(
             channel_ids,
             io_channel,
         },
-        message_channel: None,
-        multi_transport_channel: None,
+        // (vendored) Grant a message channel (`SC_MCS_MSGCHANNEL`) when offering
+        // UDP multitransport: clients route the Server Initiate Multitransport
+        // Request (and connect-time autodetect) by channel id and ignore it on
+        // the I/O channel once they've sent `CS_MCS_MSGCHANNEL`. `None` on the
+        // default (non-multitransport) path keeps the handshake byte-identical.
+        message_channel: message_channel_id.map(|id| gcc::ServerMessageChannelData {
+            mcs_message_channel_id: id,
+        }),
+        // (vendored) Echo `SC_MULTITRANSPORT` advertising the server's supported
+        // UDP transports when a multitransport provider is installed. mstsc
+        // validates an incoming Initiate Multitransport Request against this
+        // advertisement; without it, the otherwise well-formed request is
+        // out-of-contract and mstsc raises a protocol error + disconnects.
+        multi_transport_channel: multitransport.map(|flags| gcc::MultiTransportChannelData { flags }),
     }
 }

--- a/vendor/ironrdp-acceptor/src/finalization.rs
+++ b/vendor/ironrdp-acceptor/src/finalization.rs
@@ -79,6 +79,22 @@ impl Sequence for FinalizationSequence {
     }
 
     fn step(&mut self, input: &[u8], output: &mut WriteBuf) -> ConnectorResult<Written> {
+        // (vendored) When a message channel is granted (for UDP multitransport /
+        // autodetect), the client interleaves PDUs on that channel — e.g. its
+        // Client Initiate Multitransport Response (E_ABORT when it can't bring up
+        // UDP) — with the io-channel finalization PDUs. Those are NOT ShareControl
+        // PDUs; the wait-states below would mis-decode them ("invalid pdu_type")
+        // and tear the session down. In any input-driven (wait) state, skip a PDU
+        // that isn't on the io channel and stay put to read the next one.
+        if self.next_pdu_hint().is_some() {
+            if let Some(channel_id) = peek_channel_id(input) {
+                if channel_id != self.io_channel_id {
+                    debug!(channel_id, "Skipping non-io-channel PDU during finalization");
+                    return Ok(Written::Nothing);
+                }
+            }
+        }
+
         let (written, next_state) = match core::mem::take(&mut self.state) {
             FinalizationState::WaitSynchronize => {
                 let synchronize = decode_share_control(input);
@@ -221,6 +237,16 @@ fn create_control_confirm(user_id: u16) -> rdp::headers::ShareDataPdu {
 
 fn create_font_map() -> rdp::headers::ShareDataPdu {
     rdp::headers::ShareDataPdu::FontMap(rdp::finalization_messages::FontPdu::default())
+}
+
+/// (vendored) Peek the MCS channel id of an inbound `SendDataRequest` frame, if
+/// it is one. Used to skip message-channel PDUs (autodetect / multitransport
+/// response) during finalization. Returns `None` if the frame isn't a
+/// `SendDataRequest` (the caller then falls through to the normal decode).
+fn peek_channel_id(input: &[u8]) -> Option<u16> {
+    ironrdp_core::decode::<X224<ironrdp_pdu::mcs::SendDataRequest<'_>>>(input)
+        .ok()
+        .map(|p| p.0.channel_id)
 }
 
 fn decode_share_control(input: &[u8]) -> ConnectorResult<rdp::headers::ShareControlHeader> {

--- a/vendor/ironrdp-acceptor/src/lib.rs
+++ b/vendor/ironrdp-acceptor/src/lib.rs
@@ -18,7 +18,7 @@ pub use ironrdp_connector::DesktopSize;
 use ironrdp_pdu::nego;
 
 pub use self::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
-pub use self::connection::{Acceptor, AcceptorResult, AcceptorState};
+pub use self::connection::{Acceptor, AcceptorResult, AcceptorState, MultitransportOffer};
 pub use self::finalization::{FinalizationSequence, FinalizationState};
 use crate::credssp::resolve_generator;
 

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -245,6 +245,10 @@ AND released — #1276 landing is NOT sufficient.
     (from acceptor divergence (3)). `handle_io_channel_data` tries `ShareControl`
     decode first and, on failure, decodes a `MultitransportResponsePdu`
     (re-validates the `TRANSPORT_RSP` flag) → `handle_multitransport_response`.
+    **(SUPERSEDED in M3c: this post-finalization, IO-channel send was rejected by
+    real clients — emission moved into the acceptor's `LicensingExchange` on the
+    message channel; see the M3c note below. `maybe_offer_multitransport` and the
+    `handle_io_channel_data` response-decode branch were removed.)**
     **M1 has NO UDP listener**: the client's out-of-band UDP attempt times out
     and it reports `E_ABORT`, and the session continues on TCP unchanged — this
     proves the negotiation/framing contract + graceful fallback before any
@@ -274,12 +278,39 @@ AND released — #1276 landing is NOT sufficient.
     `test = false`): bind to `127.0.0.1:0`, send a real captured client SYN, assert
     the MTU-padded SYN+ACK fields. Cross-platform (pure tokio/std), so Linux CI
     runs it.
-    **M3c (added 2026-06-25): wired into the accept path.** macrdp's `main.rs` now
-    binds the listener on the same address/port as TCP at startup when
-    `--enable-udp-multitransport` is set (single-process path; `--fork-workers`
-    warns + falls back — the persistent UDP socket would belong to the supervisor,
-    deferred). The only server-crate change here is that `maybe_offer_multitransport`
-    now logs the issued 16-byte security cookie (hex) at `debug`, so it can be
-    correlated with the listener's logged client SYNEX `cookieHash` to derive the
-    hash formula from a live run (cookie validation is still soft). The session
-    still runs over TCP (no TLS/EMT tunnel or migration yet).
+    **M3c (added 2026-06-25): wired into the accept path + offer moved to the
+    acceptor; VERIFIED on real mstsc.** Two parts:
+    1. macrdp's `main.rs` binds the listener on the same address/port as TCP at
+       startup when `--enable-udp-multitransport` is set (single-process path;
+       `--fork-workers` warns + falls back — the persistent UDP socket would
+       belong to the supervisor, deferred).
+    2. The negotiation offer + emission **moved out of the server crate into the
+       acceptor** (acceptor divergence (3) M3c) because the M1 post-finalization
+       IO-channel send was rejected by real clients. `run_connection` now, when a
+       `MultitransportProvider` is installed, calls
+       `acceptor.set_advertise_extended_client_data(true)` +
+       `acceptor.set_multitransport_offer(Some(new_offer(...)))`; the acceptor
+       advertises EXTENDED_CLIENT_DATA, echoes SC_MULTITRANSPORT, grants
+       SC_MCS_MSGCHANNEL, and emits the Initiate Request on the message channel
+       after licensing (before Demand Active). `client_accepted` reads
+       `result.multitransport_offered` to build the per-connection
+       `MigrationState`. `new_offer(protocol) -> MultitransportOffer` (in
+       `multitransport/mod.rs`) issues the process-monotonic `request_id` + a
+       16-byte cookie. The old `maybe_offer_multitransport` method and the
+       `handle_io_channel_data` response-decode branch were deleted.
+    **VERIFIED end-to-end on real mstsc (Win11, over WiFi LAN) 2026-06-25:** mstsc
+    connects cleanly (the earlier protocol-error/white-screen is gone — fixed by
+    the acceptor finalize channel-skip), sends a real RDPEUDP **SYN** to the
+    listener, we answer SYN+ACK, the handshake **establishes**, and mstsc starts
+    pushing `ACK | DATA` datagrams (its MS-RDPEMT TLS handshake; we don't carry it
+    up yet, so it retransmits w/ CWR — expected). Session renders over TCP
+    throughout. FreeRDP also reaches ACTIVE + renders (it consumes the offer but
+    sends no UDP — graceful fallback). **Cookie finding:** mstsc negotiates RDPEUDP
+    **V2** — the 16-byte SYN `cookieHash` is V3/RDPEUDP2-only, so at V2 there is no
+    SYN cookie to capture; the security cookie rides the MS-RDPEMT
+    `RDP_TUNNEL_CREATEREQUEST` (behind TLS), making strict cookie binding an M4
+    concern. Also de-risks M4: mstsc's reliable transport here is plain RDPEUDP
+    **v2** carrying TLS (FecFlags ACK|DATA), NOT EUDP2 — so the v1 state machine is
+    the correct codepath and the EUDP2 wire-format spike may be off mstsc's
+    critical path for the reliable channel. The session still runs over TCP (no
+    TLS/EMT tunnel or migration yet — M4).

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -126,6 +126,16 @@ async fn run_recv_loop(socket: Arc<UdpSocket>, cfg: ListenerConfig) {
         let now_ms = start.elapsed().as_millis() as u64;
         let data = &buf[..len];
 
+        // Per-datagram receipt trace: confirms a real client's UDP actually
+        // reaches the socket (the core M3 question) and shows how we classify
+        // it, so a SYN that fails to decode is still visible rather than silent.
+        debug!(
+            %peer_addr,
+            len,
+            fec_flags = ?Datagram::peek_fec_flags(data),
+            "RDPEUDP datagram received"
+        );
+
         // Log the client's SYN cookie hash + negotiated version (cookie check is
         // soft in M3b — this is the data the future strict-validation work needs).
         if is_syn_family(data) {

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -23,7 +23,10 @@
 
 pub mod listener;
 
+use core::sync::atomic::{AtomicU32, Ordering};
+
 use anyhow::Result;
+use ironrdp_acceptor::MultitransportOffer;
 use ironrdp_core::encode_vec;
 use ironrdp_pdu::mcs::SendDataIndication;
 use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
@@ -72,6 +75,28 @@ pub fn encode_initiate_request(
         user_data,
     };
     Ok(encode_vec(&X224(mcs_pdu))?)
+}
+
+/// Build a fresh [`MultitransportOffer`] for one connection: a process-wide
+/// monotonic `request_id` plus a 16-byte security cookie. The acceptor sends it
+/// as the Server Initiate Multitransport Request after licensing (before Demand
+/// Active); the client echoes `request_id` + `cookie` back over the UDP flow.
+///
+/// The cookie is a deterministic placeholder for now — validation is soft (the
+/// listener logs the client's SYNEX `cookieHash` so the hash formula can be
+/// derived from a live capture). TODO: switch to a CSPRNG once binding is strict.
+pub(crate) fn new_offer(protocol: RequestedProtocol) -> MultitransportOffer {
+    static MT_REQUEST_ID: AtomicU32 = AtomicU32::new(1);
+    let request_id = MT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    let mut cookie = [0u8; 16];
+    for (i, b) in cookie.iter_mut().enumerate() {
+        *b = (request_id.wrapping_mul(2_654_435_761).wrapping_add(i as u32) & 0xff) as u8;
+    }
+    MultitransportOffer {
+        request_id,
+        protocol,
+        cookie,
+    }
 }
 
 /// Per-connection negotiation state for an in-flight multitransport request:

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -623,6 +623,20 @@ impl RdpServer {
         // size from Client Core Data before Demand Active goes out.
         acceptor.set_honor_client_desktop_size(self.honor_client_desktop_size);
 
+        // (vendored, feature=multitransport) When offering UDP multitransport:
+        // (1) advertise EXTENDED_CLIENT_DATA_SUPPORTED so the client actually
+        // sends its CS_MULTITRANSPORT GCC block — mstsc omits all optional GCC
+        // blocks unless the server sets this X.224 flag; and (2) hand the acceptor
+        // the offer so it emits the Server Initiate Multitransport Request at the
+        // ONLY point clients honor it — after licensing, before Demand Active.
+        // (Sending it post-finalization, once the client is ACTIVE, makes both
+        // mstsc and FreeRDP misparse it as a share-control PDU and disconnect.)
+        #[cfg(feature = "multitransport")]
+        if let Some(provider) = self.multitransport.as_ref() {
+            acceptor.set_advertise_extended_client_data(true);
+            acceptor.set_multitransport_offer(Some(crate::multitransport::new_offer(provider.requested_protocol())));
+        }
+
         self.attach_channels(&mut acceptor);
 
         let res = ironrdp_acceptor::accept_begin(framed, &mut acceptor)
@@ -1319,78 +1333,6 @@ impl RdpServer {
         state
     }
 
-    /// (vendored, feature=multitransport) Send a Server Initiate Multitransport
-    /// Request (MS-RDPEMT) on the IO channel when a provider is installed and the
-    /// client advertised matching UDP support + soft-sync. M1 has no UDP
-    /// listener, so this only proves the negotiation/framing contract and the
-    /// graceful `E_ABORT` fallback; the session stays on TCP.
-    #[cfg(feature = "multitransport")]
-    async fn maybe_offer_multitransport<W>(
-        &mut self,
-        writer: &mut Framed<W>,
-        io_channel_id: u16,
-        user_channel_id: u16,
-        client_flags: ironrdp_pdu::gcc::MultiTransportFlags,
-    ) -> Result<()>
-    where
-        W: FramedWrite,
-    {
-        use ironrdp_pdu::gcc::MultiTransportFlags;
-        use ironrdp_pdu::rdp::multitransport::RequestedProtocol;
-
-        let Some(provider) = self.multitransport.as_ref() else {
-            return Ok(());
-        };
-        let protocol = provider.requested_protocol();
-        let needed = match protocol {
-            RequestedProtocol::UdpFecR => MultiTransportFlags::TRANSPORT_TYPE_UDP_FECR,
-            RequestedProtocol::UdpFecL => MultiTransportFlags::TRANSPORT_TYPE_UDP_FECL,
-        };
-        if !client_flags.contains(needed) || !client_flags.contains(MultiTransportFlags::SOFT_SYNC_TCP_TO_UDP) {
-            debug!(
-                ?protocol,
-                ?client_flags,
-                "not offering multitransport: client lacks the requested UDP transport + soft-sync"
-            );
-            return Ok(());
-        }
-
-        // `request_id` is a process-wide counter; the 16-byte cookie will bind
-        // the future UDP flow to this TCP session. M1 has no listener, so the
-        // cookie is never validated — a deterministic placeholder is fine here.
-        // TODO(M3): generate the cookie from a CSPRNG once the listener exists.
-        static MT_REQUEST_ID: AtomicU32 = AtomicU32::new(1);
-        let request_id = MT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
-        let mut cookie = [0u8; 16];
-        for (i, b) in cookie.iter_mut().enumerate() {
-            *b = (request_id.wrapping_mul(2_654_435_761).wrapping_add(i as u32) & 0xff) as u8;
-        }
-
-        let data = crate::multitransport::encode_initiate_request(
-            request_id,
-            protocol,
-            cookie,
-            io_channel_id,
-            user_channel_id,
-        )?;
-        writer.write_all(&data).await?;
-        self.multitransport_migration = Some(crate::multitransport::MigrationState {
-            request_id,
-            cookie,
-            protocol,
-        });
-        // Log the issued cookie (hex) so it can be correlated with the UDP
-        // listener's logged client SYNEX `cookieHash` to derive the hash formula
-        // from a live run (cookie validation is still soft — see M3 in the plan).
-        debug!(
-            request_id,
-            ?protocol,
-            cookie = %cookie.iter().map(|b| format!("{b:02x}")).collect::<String>(),
-            "sent Server Initiate Multitransport Request"
-        );
-        Ok(())
-    }
-
     /// (vendored, feature=multitransport) Handle the client's Initiate
     /// Multitransport Response. M1 has no UDP transport, so this only logs the
     /// outcome and clears the in-flight request; the session stays on TCP.
@@ -1474,20 +1416,29 @@ impl RdpServer {
             }
         }
 
-        // (vendored, feature=multitransport) Offer an auxiliary UDP transport
-        // (MS-RDPEMT) when a provider is installed and the client advertised
-        // matching support. Initial accept only (not a reactivation resize).
-        // M1: negotiation only — no UDP listener, so the client's UDP attempt
-        // times out and it reports E_ABORT; the session continues on TCP.
+        // (vendored, feature=multitransport) The acceptor has already emitted the
+        // Server Initiate Multitransport Request (after licensing, before Demand
+        // Active — the only window clients honor it). Here we just record what it
+        // sent so the client's Multitransport Response can be matched and the
+        // inbound UDP flow bound to this session. Initial accept only.
         #[cfg(feature = "multitransport")]
         if !result.reactivation {
-            self.maybe_offer_multitransport(
-                writer,
-                result.io_channel_id,
-                result.user_channel_id,
-                result.multitransport_flags,
-            )
-            .await?;
+            if let Some(offer) = result.multitransport_offered {
+                self.multitransport_migration = Some(crate::multitransport::MigrationState {
+                    request_id: offer.request_id,
+                    cookie: offer.cookie,
+                    protocol: offer.protocol,
+                });
+                debug!(
+                    request_id = offer.request_id,
+                    protocol = ?offer.protocol,
+                    soft_sync = result
+                        .multitransport_flags
+                        .contains(ironrdp_pdu::gcc::MultiTransportFlags::SOFT_SYNC_TCP_TO_UDP),
+                    cookie = %offer.cookie.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+                    "Server Initiate Multitransport Request was sent by the acceptor"
+                );
+            }
         }
 
         let mut update_codecs = UpdateEncoderCodecs::new();


### PR DESCRIPTION
## What

Makes a real RDPEUDP SYN from a Windows client actually reach the UDP listener and complete the handshake. The earlier M1/M3c offer shape (send the Server Initiate Multitransport Request from the server crate, *post-finalization*, on the I/O channel) was rejected by real clients. This moves the whole offer into the **acceptor** (where it can land in the only window clients honor) and fixes the finalization decode.

Behind the existing `multitransport` feature + `--enable-udp-multitransport` (default OFF) — the standard build is byte-identical.

## Changes (acceptor divergence (3) M3c, all gated on the offer being set)

- Advertise `EXTENDED_CLIENT_DATA_SUPPORTED` in the X.224 Negotiation Response — without it mstsc omits every optional GCC client block (CS_MULTITRANSPORT / CS_MCS_MSGCHANNEL / CS_MONITOR).
- Echo **SC_MULTITRANSPORT** and grant **SC_MCS_MSGCHANNEL** (msg channel id = io + count + 1, e.g. 1008) in the GCC Connect Response.
- Emit the **Server Initiate Multitransport Request** in `LicensingExchange` — after the licensing PDU, before Demand Active, **on the message channel** (the only window clients honor it; they route the bootstrap by `messageChannelId` — FreeRDP logs `expected messageChannelId=1008, got 1003` otherwise).
- **Finalization channel-skip** (`finalization.rs` + `CapabilitiesWaitConfirm`): once a message channel exists, the client interleaves PDUs on it (its Client Initiate Multitransport Response) with the io-channel finalization PDUs. Both decode sites blindly decoded the next `SendDataRequest` as a `ShareControlHeader` → `invalid pdu_type` teardown during `accept_finalize`. Skip any `SendDataRequest` whose `channel_id` ≠ the io channel and stay in state. (Also strictly more correct than before — the wait-states used to swallow a decode error *and advance*, which would desync.)
- Server: `run_connection` wires `set_advertise_extended_client_data` + `set_multitransport_offer(new_offer(...))`; `client_accepted` reads `result.multitransport_offered` for the `MigrationState`. Removed the now-dead `maybe_offer_multitransport` and the `handle_io_channel_data` response branch.

## Verified live (real mstsc, Win11, WiFi LAN, non-loopback)

mstsc connects cleanly (the earlier protocol-error / white-screen is gone), sends a real RDPEUDP **SYN**, we answer SYN+ACK, the handshake **establishes**, and mstsc starts pushing `ACK | DATA` (its MS-RDPEMT TLS handshake). Session renders over TCP throughout. FreeRDP also reaches ACTIVE and renders (consumes the offer, sends no UDP = graceful fallback).

### Findings
- mstsc negotiates RDPEUDP **V2** (plain, not EUDP2) carrying TLS → the v1 state machine is the correct codepath; the EUDP2 wire-format spike may be off mstsc's critical path for the reliable channel.
- `cookie_hash=none` is **correct**, not a bug: the 16-byte SYN `cookieHash` is V3/RDPEUDP2-only. At V2 the security cookie isn't in the SYN — it rides the MS-RDPEMT `RDP_TUNNEL_CREATEREQUEST` (behind TLS), so strict cookie binding is an M4 concern.

## Tests
`cargo fmt` + `clippy -D warnings` clean; 65 macrdp tests (incl. the loopback listener test + the conn_test TCP-regression suite) and 34 standalone `ironrdp-rdpeudp` tests green.

## Next
M4 — rustls over the v2 reliable stream + the MS-RDPEMT tunnel PDUs (`RDP_TUNNEL_CREATEREQUEST`/`RESPONSE` + Soft-Sync), spiked against this same mstsc; then M5 (migrate EGFX to UDP).