### PR TITLE
feat(multitransport): M4a — reliable UDP data path delivered + acked (verified on mstsc)

### DIFF
--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,29 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **M4a (done — reliable data path verified on real mstsc, 2026-06-25):** the
+  reliability SM now actually carries the client's reliable byte-stream end to
+  end. Two fixes, both forced by real mstsc (the in-memory two-instance test was
+  self-consistent and hid them):
+  1. **The SYN consumes one sequence number.** The first *source* packet is
+     `initial_seq + 1`, not `initial_seq` — symmetric on both ends (`send_next`
+     init `+1`; `recv_next` on the peer's SYN `+1`). Matches real Windows (a
+     server SYN+ACK acks `client_ISN` for the SYN alone; the client's first data
+     is `client_ISN + 1`). Without it the receiver was off by one and buffered
+     every data packet forever (mstsc retransmitted with CWR; `recv_next`
+     accessor added so the listener could log the exact `client_seq vs expected`).
+  2. **Outbound ACKs MUST carry a populated `RDPUDP_ACK_VECTOR_HEADER`.** The
+     "send the vector empty for now" deferral was wrong for interop: mstsc
+     ignores an empty-vector ACK and retransmits forever. `ack_vector()` builds a
+     `Received` run (≤63 per element, bounded by the recv window) from
+     `snSourceAck` backward over the in-order source-packet run; threaded through
+     the pure ACK and the data-piggybacked ACKs (`encode_data` gained an
+     `ack_vector` param; `empty_ack()` removed). Selective NACK runs for
+     out-of-order gaps remain a later refinement. Verified live: mstsc's TLS
+     ClientHello (one 444-byte source packet) is delivered + acked, mstsc stops
+     retransmitting and idles on `ACK|ACK_DELAYED` keepalives, waiting for the
+     server's TLS ServerHello (M4b). 34 crate tests still green (the symmetric
+     `+1` keeps the two-instance test self-consistent).
 - **M3b (done — UDP listener, in `ironrdp-server`):** this crate became a real
   dependency of `vendor/ironrdp-server` for the first time (path dep, gated by its
   `multitransport` feature; revs already aligned so `ironrdp-core` unifies). The

--- a/vendor/ironrdp-rdpeudp/src/state.rs
+++ b/vendor/ironrdp-rdpeudp/src/state.rs
@@ -12,8 +12,10 @@
 //! - Reliable, in-order, de-duplicated delivery: the receiver buffers
 //!   out-of-order datagrams and delivers contiguous runs; the sender uses the
 //!   **cumulative** ACK (`snSourceAck`) to release in-flight packets and
-//!   retransmits the unacked window on RTO. (Selective retransmit via the ACK
-//!   *vector* is a later optimization — the vector is sent empty for now.)
+//!   retransmits the unacked window on RTO. Outbound ACKs carry a populated
+//!   `RDPUDP_ACK_VECTOR_HEADER` marking the in-order run `Received` — required
+//!   for mstsc to retire datagrams (an empty vector is ignored). Selective NACK
+//!   runs for out-of-order gaps are a later refinement.
 //! - Fixed send window bounded by the peer's `uReceiveWindowSize`. No congestion
 //!   control / FEC yet.
 //!
@@ -23,7 +25,9 @@
 use std::collections::{BTreeMap, VecDeque};
 
 use crate::datagram::{Datagram, SourcePacket};
-use crate::pdu::{AckVectorHeader, SourcePayloadHeader, UdpVersion};
+use crate::pdu::{
+    AckVectorElement, AckVectorHeader, SourcePayloadHeader, UdpVersion, VectorElementState,
+};
 
 /// Which end of the connection this instance is. macrdp (the RDP server) is the
 /// passive [`Role::Server`]; [`Role::Client`] exists so two instances can be
@@ -130,7 +134,13 @@ impl RdpeudpState {
             peer_recv_window: 1,
             peer_isn: 0,
             negotiated_version: UdpVersion::V2,
-            send_next: cfg.initial_seq,
+            // The SYN consumes one sequence number (it carries `initial_seq` as its
+            // own seq), so the first *source* packet is `initial_seq + 1`. This
+            // matches real Windows: a server SYN+ACK acks `client_ISN` for the SYN
+            // alone, and the client's first data is `client_ISN + 1`. (Verified
+            // against mstsc — without the +1 the receiver is off by one and buffers
+            // every data packet forever; see `recv_next` init on the SYN below.)
+            send_next: cfg.initial_seq.wrapping_add(1),
             out_queue: VecDeque::new(),
             unacked: VecDeque::new(),
             syn_last_sent_ms: 0,
@@ -149,6 +159,13 @@ impl RdpeudpState {
     /// means the data path should use RDPEUDP2 framing after the handshake.
     pub fn negotiated_version(&self) -> UdpVersion {
         self.negotiated_version
+    }
+
+    /// The next in-order source sequence number the receiver expects. Exposed for
+    /// diagnostics (the listener logs it against an incoming data packet's seq to
+    /// pin the post-handshake sequence convention against real clients).
+    pub fn recv_next(&self) -> u32 {
+        self.recv_next
     }
 
     /// Client: emit the initial SYN. Server: no-op (it waits for the SYN).
@@ -195,7 +212,9 @@ impl RdpeudpState {
                 self.negotiated_version = ex.udp_version;
             }
             if !self.have_peer_seq {
-                self.recv_next = syn.initial_seq;
+                // The peer's SYN occupies `initial_seq`; its first source packet is
+                // `initial_seq + 1` (the SYN consumes a sequence number, like TCP).
+                self.recv_next = syn.initial_seq.wrapping_add(1);
                 self.have_peer_seq = true;
             }
             match self.role {
@@ -277,6 +296,10 @@ impl RdpeudpState {
             return;
         }
 
+        // One selective-ACK vector for every datagram emitted this pump (the
+        // receive state doesn't change while we only send), piggybacked on data
+        // and used for the trailing pure ACK.
+        let ack_vector = self.ack_vector();
         let mut sent_data = false;
 
         // Retransmit unacked packets whose RTO elapsed.
@@ -289,6 +312,7 @@ impl RdpeudpState {
                     self.cfg.recv_window,
                     entry.seq,
                     &entry.payload,
+                    ack_vector.clone(),
                 ));
                 sent_data = true;
             }
@@ -309,6 +333,7 @@ impl RdpeudpState {
                 self.cfg.recv_window,
                 seq,
                 &payload,
+                ack_vector.clone(),
             ));
             self.unacked.push_back(Unacked {
                 seq,
@@ -321,7 +346,7 @@ impl RdpeudpState {
         // Any owed ACK was piggybacked on data; otherwise send a pure ACK.
         if self.need_ack && !sent_data {
             out.to_send.push(
-                Datagram::ack(self.ack_num(), self.cfg.recv_window, empty_ack())
+                Datagram::ack(self.ack_num(), self.cfg.recv_window, ack_vector)
                     .encode()
                     .expect("encode ack"),
             );
@@ -339,6 +364,39 @@ impl RdpeudpState {
         } else {
             -1
         }
+    }
+
+    /// Build the selective-ACK vector for an outbound ACK. MS-RDPEUDP 2.2.2.7: the
+    /// first element describes the datagram at `snSourceAck` (= `recv_next - 1`)
+    /// and subsequent runs go to *decreasing* sequence numbers. We deliver strictly
+    /// in order, so the contiguous source-packet run ending at `snSourceAck` — back
+    /// to the first source packet (`peer_isn + 1`; the SYN at `peer_isn` is acked by
+    /// `snSourceAck` itself, not the source vector) — is all `Received`, emitted as
+    /// run-length elements (≤63 each), bounded by our advertised receive window.
+    ///
+    /// A real (non-empty) vector is REQUIRED for mstsc to retire the datagram —
+    /// with an empty vector mstsc ignores the ACK and retransmits forever (verified
+    /// live). Selective NACK runs (gaps in `reorder`) are a later refinement; while
+    /// the stream stays in order this exact vector is correct.
+    fn ack_vector(&self) -> AckVectorHeader {
+        if !self.have_peer_seq {
+            return AckVectorHeader { elements: vec![] };
+        }
+        let mut count = self
+            .recv_next
+            .wrapping_sub(self.peer_isn)
+            .saturating_sub(1)
+            .min(u32::from(self.cfg.recv_window));
+        let mut elements = Vec::new();
+        while count > 0 {
+            let run = count.min(63) as u8;
+            elements.push(AckVectorElement {
+                state: VectorElementState::Received,
+                run_length: run,
+            });
+            count -= u32::from(run);
+        }
+        AckVectorHeader { elements }
     }
 
     fn encode_syn(&self) -> Vec<u8> {
@@ -372,12 +430,8 @@ impl RdpeudpState {
     }
 }
 
-/// FEC header (8) + ACK vector (4, empty) + source payload header (8).
+/// FEC header (8) + ACK vector (4, min) + source payload header (8).
 const HEADERS_OVERHEAD: usize = 8 + 4 + 8;
-
-fn empty_ack() -> AckVectorHeader {
-    AckVectorHeader { elements: vec![] }
-}
 
 fn encode_data(
     recv_next: u32,
@@ -385,6 +439,7 @@ fn encode_data(
     recv_window: u16,
     seq: u32,
     payload: &[u8],
+    ack_vector: AckVectorHeader,
 ) -> Vec<u8> {
     let ack = if have_peer_seq {
         recv_next.wrapping_sub(1) as i32
@@ -394,7 +449,7 @@ fn encode_data(
     Datagram::data(
         ack,
         recv_window,
-        empty_ack(),
+        ack_vector,
         SourcePacket {
             header: SourcePayloadHeader {
                 sn_coded: seq,

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -314,3 +314,14 @@ AND released — #1276 landing is NOT sufficient.
     the correct codepath and the EUDP2 wire-format spike may be off mstsc's
     critical path for the reliable channel. The session still runs over TCP (no
     TLS/EMT tunnel or migration yet — M4).
+    **M4a (added 2026-06-25): reliable data path — verified on real mstsc.** The
+    listener now consumes the SM's `delivered` output: each `Peer` accumulates the
+    reassembled reliable byte-stream (`Peer::inbound`) and logs it (+ a TLS
+    ClientHello sniff). Getting mstsc's reliable stream to actually flow needed two
+    fixes in `ironrdp-rdpeudp` (see its CLAUDE.md M4a): the SYN consumes a sequence
+    number (first source packet = `initial_seq + 1`), and outbound ACKs must carry
+    a populated `RDPUDP_ACK_VECTOR_HEADER` (an empty vector is ignored by mstsc →
+    infinite retransmit). Result: mstsc's TLS ClientHello is delivered + acked,
+    mstsc stops retransmitting and idles on `ACK|ACK_DELAYED` keepalives, waiting
+    for our TLS ServerHello. No TLS/EMT yet (M4b/M4c); listener still not bound to
+    the per-connection cookie/MigrationState.

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -64,9 +64,17 @@ impl Default for ListenerConfig {
     }
 }
 
-/// A per-peer handshake/transport session: just the reliability SM for now.
+/// A per-peer handshake/transport session: the reliability SM plus the
+/// reassembled inbound reliable byte-stream (M4a).
 struct Peer {
     sm: RdpeudpState,
+    /// The client's reliable application stream, reassembled in order from the
+    /// SM's `delivered` output. After the handshake this carries the client's
+    /// MS-RDPEMT-over-TLS bytes (its TLS ClientHello first). M4a only accumulates
+    /// + logs it; M4b feeds it into a rustls server, M4c into the EMT tunnel.
+    inbound: Vec<u8>,
+    /// Whether we've already logged the TLS ClientHello sniff (avoid log spam).
+    tls_hello_logged: bool,
 }
 
 /// A running UDP multitransport listener. The receive loop runs on a spawned
@@ -172,10 +180,13 @@ async fn run_recv_loop(socket: Arc<UdpSocket>, cfg: ListenerConfig) {
                         rto_ms: cfg.rto_ms,
                     },
                 ),
+                inbound: Vec::new(),
+                tls_hello_logged: false,
             }
         });
 
         let was_established = peer.sm.is_established();
+        let had_data = Datagram::peek_fec_flags(data).is_some_and(|f| f.contains(FecFlags::DATA));
         let out = peer.sm.step(now_ms, Some(data));
         for mut dg in out.to_send {
             if is_syn_family(&dg) && dg.len() < cfg.mtu as usize {
@@ -191,6 +202,51 @@ async fn run_recv_loop(socket: Arc<UdpSocket>, cfg: ListenerConfig) {
                 %peer_addr,
                 version = ?peer.sm.negotiated_version(),
                 "RDPEUDP handshake established"
+            );
+        }
+
+        // M4a: accumulate the reassembled reliable byte-stream the SM delivered.
+        // This is the foundation the TLS server (M4b) + EMT tunnel (M4c) consume.
+        let delivered: usize = out.delivered.iter().map(Vec::len).sum();
+        if delivered > 0 {
+            for chunk in &out.delivered {
+                peer.inbound.extend_from_slice(chunk);
+            }
+            debug!(
+                %peer_addr,
+                delivered,
+                total = peer.inbound.len(),
+                "RDPEUDP reliable data delivered"
+            );
+            // Sniff for a TLS ClientHello (handshake record 0x16, version 0x03xx)
+            // — confirms the client is starting the MS-RDPEMT-over-TLS handshake
+            // and that our v1 receive path reassembled mstsc's V2 stream correctly.
+            if !peer.tls_hello_logged
+                && peer.inbound.len() >= 3
+                && peer.inbound[0] == 0x16
+                && peer.inbound[1] == 0x03
+            {
+                peer.tls_hello_logged = true;
+                debug!(
+                    %peer_addr,
+                    "RDPEUDP reliable stream carries a TLS ClientHello (MS-RDPEMT handshake starting; TLS + tunnel are M4b/M4c)"
+                );
+            }
+        } else if had_data {
+            // A DATA datagram that produced no delivery means our receive sequence
+            // didn't line up with the client's data seq — the client will keep
+            // retransmitting (CWR). Log the client's source seq vs the expected
+            // `recv_next` so the convention can be pinned against real mstsc (a
+            // gap of exactly 1 is the SYN-consumes-a-seq off-by-one; a wild value
+            // means the source-payload decode landed at the wrong offset instead).
+            let client_seq = Datagram::decode(data)
+                .ok()
+                .and_then(|dg| dg.source.map(|s| s.header.sn_source_start));
+            debug!(
+                %peer_addr,
+                ?client_seq,
+                expected = peer.sm.recv_next(),
+                "RDPEUDP DATA datagram delivered nothing (receive-sequence mismatch)"
             );
         }
     }


### PR DESCRIPTION
## What

First step of M4: make the RDPEUDP reliability SM actually carry the client's reliable byte-stream end to end. The listener now consumes the SM's `delivered` output and reassembles it per peer (`Peer::inbound`), logging it plus a TLS ClientHello sniff. Behind the existing `multitransport` feature + `--enable-udp-multitransport` (default OFF).

## The two fixes (both surfaced only against real mstsc)

The in-memory two-instance test was *self-consistent*, so it hid both:

1. **The SYN consumes one sequence number.** The first source packet is `initial_seq + 1`, not `initial_seq` — symmetric on both ends (`send_next` init `+1`; `recv_next` on the peer's SYN `+1`). Matches real Windows: a server SYN+ACK acks `client_ISN` for the SYN alone, and the client's first data is `client_ISN + 1`. Without it the receiver was off by one and buffered every data packet forever (mstsc retransmitted with CWR).
2. **Outbound ACKs must carry a populated `RDPUDP_ACK_VECTOR_HEADER`.** The "empty vector for now" deferral broke interop — mstsc ignores an empty-vector ACK and retransmits forever. `ack_vector()` builds a `Received` run from `snSourceAck` backward over the in-order source-packet run (≤63 per element, bounded by the recv window), threaded through the pure ACK and the data-piggybacked ACKs (`encode_data` gained an `ack_vector` param; `empty_ack` removed). Selective NACK runs for out-of-order gaps remain a later refinement.

Also added `RdpeudpState::recv_next()` so the listener can log `client_seq vs expected` when a data packet delivers nothing (the diagnostic that pinned the off-by-one).

## Verified live on real mstsc (Win11, WiFi LAN)

The TLS ClientHello (one 444-byte source packet) is delivered + acked; mstsc **stops retransmitting** and idles on `ACK | ACK_DELAYED` keepalives, waiting for the server's TLS ServerHello (that's M4b). Before the fixes it retransmitted the same packet forever.

## Tests
`fmt` + `clippy -D warnings` clean; 65 macrdp tests + 34 standalone `ironrdp-rdpeudp` tests green (the symmetric `+1` keeps the two-instance test self-consistent).

## Next
M4b — rustls server TLS over this reliable stream (reusing macrdp's cert): answer mstsc's ClientHello with a ServerHello and complete the handshake. Then M4c (MS-RDPEMT tunnel + cookie).