### PR TITLE
feat(multitransport): M4b — rustls server TLS over the RDPEUDP reliable stream

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1072,7 +1072,7 @@ fn generate_and_persist(
     Ok((vec![cert_der], key_der))
 }
 
-fn make_tls_acceptor(cert_dir: &Path) -> Result<(TlsAcceptor, Vec<u8>)> {
+fn make_tls_acceptor(cert_dir: &Path) -> Result<(TlsAcceptor, Vec<u8>, Arc<ServerConfig>)> {
     let cert_path = cert_dir.join("cert.pem");
     let key_path = cert_dir.join("key.pem");
 
@@ -1102,11 +1102,16 @@ fn make_tls_acceptor(cert_dir: &Path) -> Result<(TlsAcceptor, Vec<u8>)> {
         .raw_bytes()
         .to_vec();
 
-    let config = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(certs, key)
-        .context("build rustls ServerConfig")?;
-    Ok((TlsAcceptor::from(Arc::new(config)), spki_der))
+    let config = Arc::new(
+        ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .context("build rustls ServerConfig")?,
+    );
+    // The same cert/config also secures the auxiliary UDP multitransport (MS-RDPEMT
+    // over TLS) — the client trusts it via the main connection's TOFU. Returned so
+    // the UDP listener can reuse it without re-loading the cert.
+    Ok((TlsAcceptor::from(Arc::clone(&config)), spki_der, config))
 }
 
 /// Spawn the session-transition watcher used by `--detach-primary`
@@ -1768,7 +1773,7 @@ async fn async_main() -> Result<()> {
         Some(p) => p,
         None => default_cert_dir()?,
     };
-    let (tls, spki_der) = make_tls_acceptor(&cert_dir)?;
+    let (tls, spki_der, udp_tls_config) = make_tls_acceptor(&cert_dir)?;
 
     // Resolve desktop dimensions + geometry. Three paths:
     //   - virtual display: width/height are already enforced as required
@@ -2117,7 +2122,13 @@ async fn async_main() -> Result<()> {
             server_isn_seed: isn_seed,
             ..Default::default()
         };
-        match ironrdp_server::UdpMultitransportListener::bind(args.bind, cfg).await {
+        match ironrdp_server::UdpMultitransportListener::bind(
+            args.bind,
+            cfg,
+            Some(udp_tls_config.clone()),
+        )
+        .await
+        {
             Ok(listener) => {
                 info!(
                     addr = %args.bind,

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -97,7 +97,8 @@ mod tests {
         ];
 
         let cfg = ListenerConfig::default();
-        let listener = UdpMultitransportListener::bind("127.0.0.1:0".parse().unwrap(), cfg)
+        // No TLS config: this test only exercises the SYN→SYN+ACK handshake.
+        let listener = UdpMultitransportListener::bind("127.0.0.1:0".parse().unwrap(), cfg, None)
             .await
             .expect("bind listener");
         let server_addr = listener.local_addr();

--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,19 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **M4b decode fix (done — verified on real mstsc, 2026-06-25):** `Datagram::decode`
+  now **skips the 4-byte RDPUDP_ACK_OF_ACKVECTOR_HEADER** (`snAckOfAcksSeqNum`) that
+  sits between the ack vector and the source payload when the `ACK_OF_ACKS` flag is
+  set. Real mstsc sets this flag periodically once a session is up; without the
+  skip those 4 bytes were folded into the reliable byte-stream (`delivered` jumped
+  50→54 on exactly those packets), which corrupted the TLS records riding the
+  stream — observed live as rustls `received corrupt message of type
+  InvalidContentType` mid-session, right after the first ACK_OF_ACKS packet. We
+  don't act on the ack-of-acks value (cumulative-ACK only); we just consume it so
+  the source-payload offset stays right. The encoder still never *produces* the
+  section. Regression test `data_packet_with_ack_of_acks_skips_the_section`
+  hand-assembles such a packet and asserts the payload doesn't absorb the 4 bytes.
+  35 crate tests.
 - **M4a (done — reliable data path verified on real mstsc, 2026-06-25):** the
   reliability SM now actually carries the client's reliable byte-stream end to
   end. Two fixes, both forced by real mstsc (the in-memory two-instance test was

--- a/vendor/ironrdp-rdpeudp/src/datagram.rs
+++ b/vendor/ironrdp-rdpeudp/src/datagram.rs
@@ -4,15 +4,17 @@
 //!
 //! This is the wire layer the reliability state machine ([`crate::state`]) emits
 //! and consumes. It deliberately models only what that machine needs (SYN /
-//! SYN+ACK / data / ack), not every optional MS-RDPEUDP section (ACK-of-acks and
-//! FEC payloads are not produced). The RDPEUDP2 (`0x0101`) data framing is a
-//! separate, spike-gated codec — see the crate docs.
+//! SYN+ACK / data / ack); it never *produces* the optional FEC or ACK-of-acks
+//! sections. On decode it *skips* an inbound RDPUDP_ACK_OF_ACKVECTOR_HEADER
+//! (real mstsc sets it periodically) so the source payload after it stays
+//! aligned. The RDPEUDP2 (`0x0101`) data framing is a separate, spike-gated
+//! codec — see the crate docs.
 //!
 //! [`pdu`]: crate::pdu
 //! [`FecFlags`]: crate::pdu::FecFlags
 
 use ironrdp_core::{
-    decode_cursor, encode_cursor, DecodeResult, EncodeResult, ReadCursor, WriteCursor,
+    decode_cursor, encode_cursor, ensure_size, DecodeResult, EncodeResult, ReadCursor, WriteCursor,
 };
 
 use crate::pdu::{
@@ -208,6 +210,17 @@ impl Datagram {
             None
         };
 
+        // An RDPUDP_ACK_OF_ACKVECTOR_HEADER (single u32 snAckOfAcksSeqNum, 4
+        // bytes) sits between the ack vector and the source payload when the
+        // ACK_OF_ACKS flag is set. We don't act on it (cumulative-ACK only), but
+        // it MUST be skipped or the source-payload offset is wrong — real mstsc
+        // sets this periodically, and folding the 4 bytes into the reliable
+        // stream corrupts the TLS record framing (InvalidContentType).
+        if flags.contains(FecFlags::ACK_OF_ACKS) && !flags.contains(FecFlags::SYN) {
+            ensure_size!(in: cursor, size: 4);
+            let _sn_ack_of_acks = cursor.read_u32_be();
+        }
+
         // For a SYN datagram the trailing bytes are SYN sections, not a source
         // payload; for a data datagram they are the source header + payload.
         let (source, syn, correlation, syn_ex) = if flags.contains(FecFlags::SYN) {
@@ -301,6 +314,41 @@ mod tests {
         let back = Datagram::decode(&bytes).unwrap();
         assert_eq!(back, d);
         assert_eq!(back.source.unwrap().payload, b"hello rdpeudp");
+    }
+
+    /// Real mstsc periodically sets the ACK_OF_ACKS flag on a data packet, which
+    /// inserts a 4-byte RDPUDP_ACK_OF_ACKVECTOR_HEADER between the ack vector and
+    /// the source payload. The decoder must skip it, or those 4 bytes are folded
+    /// into the reliable byte-stream and corrupt the TLS records riding it
+    /// (observed live as rustls `InvalidContentType` mid-session).
+    #[test]
+    fn data_packet_with_ack_of_acks_skips_the_section() {
+        #[rustfmt::skip]
+        let bytes: Vec<u8> = vec![
+            // RDPUDP_FEC_HEADER
+            0x00, 0x00, 0x00, 0x29, // snSourceAck = 41
+            0x00, 0x40,             // uReceiveWindowSize = 64
+            0x01, 0x0c,             // uFlags = ACK | DATA | ACK_OF_ACKS (0x010c)
+            // RDPUDP_ACK_VECTOR_HEADER (empty, padded to 4 bytes)
+            0x00, 0x00,             // uAckVectorSize = 0
+            0x00, 0x00,             // zero-padding to the 4-byte boundary
+            // RDPUDP_ACK_OF_ACKVECTOR_HEADER (snAckOfAcksSeqNum) — must be skipped
+            0xde, 0xad, 0xbe, 0xef,
+            // RDPUDP_SOURCE_PAYLOAD_HEADER
+            0x00, 0x00, 0x00, 0x2a, // snCoded = 42
+            0x00, 0x00, 0x00, 0x2a, // snSourceStart = 42
+            // payload
+            b'h', b'e', b'l', b'l', b'o',
+        ];
+
+        let dg = Datagram::decode(&bytes).unwrap();
+        assert!(dg.ack_vector.is_some());
+        let src = dg.source.expect("source payload present");
+        assert_eq!(src.header.sn_coded, 42);
+        assert_eq!(
+            src.payload, b"hello",
+            "the 4-byte ack-of-acks section must NOT leak into the payload"
+        );
     }
 
     #[test]

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -325,3 +325,25 @@ AND released — #1276 landing is NOT sufficient.
     mstsc stops retransmitting and idles on `ACK|ACK_DELAYED` keepalives, waiting
     for our TLS ServerHello. No TLS/EMT yet (M4b/M4c); listener still not bound to
     the per-connection cookie/MigrationState.
+    **M4b (added 2026-06-25): rustls server TLS over the reliable stream — verified
+    on real mstsc.** The listener now drives a per-`Peer` `rustls::ServerConnection`
+    (`Peer::tls`, created lazily on first reliable data) over the SM's reliable
+    byte-stream: each delivered chunk is fed to `read_tls` + `process_new_packets`
+    in a loop (until the cursor drains), `tls.reader()` is drained so the decrypted
+    plaintext can't stall record processing, and any `write_tls` output is
+    `enqueue`d back through the SM (reliable, MTU-fragmented via a new
+    `send_datagrams` helper used for both SM and TLS output). The rustls
+    `ServerConfig` is the **same cert/config as the main TCP connection** — passed
+    into `UdpMultitransportListener::bind(addr, cfg, tls_config: Option<Arc<ServerConfig>>)`
+    from `main.rs` (`make_tls_acceptor` now also returns the `Arc<ServerConfig>`);
+    the client trusts it via the main connection's TOFU. Result on real mstsc: the
+    TLS handshake **completes** (`MS-RDPEMT TLS handshake complete`) and mstsc then
+    streams encrypted tunnel PDUs which decrypt cleanly (logged as `MS-RDPEMT
+    decrypted tunnel bytes received plaintext_len=28`, repeating ~every 200 ms — its
+    `RDP_TUNNEL_CREATEREQUEST` retransmitted while it waits for our `CREATERESPONSE`
+    = M4c). The decisive interop fix was in `ironrdp-rdpeudp` (skip the inbound
+    ACK_OF_ACKS section — see its CLAUDE.md M4b): mstsc sets that flag periodically
+    once up, and folding its 4 bytes into the stream corrupted the TLS records
+    (`InvalidContentType`). The `tls_config: None` path (the loopback handshake
+    test) is unchanged. Still no EMT tunnel parsing / cookie binding / migration
+    (M4c/M5); the 28-byte plaintext is logged, not yet parsed.

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -28,6 +28,7 @@
 
 use std::collections::HashMap;
 use std::io;
+use std::io::Read as _;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -36,7 +37,8 @@ use ironrdp_rdpeudp::pdu::FecFlags;
 use ironrdp_rdpeudp::state::{Config, RdpeudpState, Role};
 use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
-use tracing::{debug, trace};
+use tokio_rustls::rustls::{ServerConfig, ServerConnection};
+use tracing::{debug, trace, warn};
 
 /// Configuration for the UDP multitransport listener.
 #[derive(Debug, Clone, Copy)]
@@ -64,17 +66,25 @@ impl Default for ListenerConfig {
     }
 }
 
-/// A per-peer handshake/transport session: the reliability SM plus the
-/// reassembled inbound reliable byte-stream (M4a).
+/// A per-peer handshake/transport session: the reliability SM, the reassembled
+/// inbound reliable byte-stream, and (M4b) the server-side TLS connection that
+/// secures the MS-RDPEMT tunnel riding that stream.
 struct Peer {
     sm: RdpeudpState,
     /// The client's reliable application stream, reassembled in order from the
     /// SM's `delivered` output. After the handshake this carries the client's
-    /// MS-RDPEMT-over-TLS bytes (its TLS ClientHello first). M4a only accumulates
-    /// + logs it; M4b feeds it into a rustls server, M4c into the EMT tunnel.
+    /// MS-RDPEMT-over-TLS bytes (its TLS ClientHello first). Kept for the
+    /// ClientHello sniff log; the bytes themselves feed `tls`.
     inbound: Vec<u8>,
     /// Whether we've already logged the TLS ClientHello sniff (avoid log spam).
     tls_hello_logged: bool,
+    /// The MS-RDPEMT TLS server connection (M4b), created lazily on the first
+    /// reliable data when a TLS config is configured. `read_tls`/`write_tls` are
+    /// driven sans-I/O off the reliable byte-stream. `None` until then, or when
+    /// the listener has no TLS config (the handshake-only / test path).
+    tls: Option<ServerConnection>,
+    /// Whether we've logged TLS-handshake completion (avoid log spam).
+    tls_done_logged: bool,
 }
 
 /// A running UDP multitransport listener. The receive loop runs on a spawned
@@ -88,12 +98,20 @@ impl UdpMultitransportListener {
     /// Bind a UDP socket and start serving the RDPEUDP handshake on a background
     /// task. `addr` is typically the same address/port as the TCP RDP listener
     /// (the client reuses the server address for the UDP flow), or `:0` in tests.
-    pub async fn bind(addr: SocketAddr, cfg: ListenerConfig) -> io::Result<Self> {
+    ///
+    /// `tls_config` is the rustls server config that secures the MS-RDPEMT tunnel
+    /// (M4b) — pass the SAME cert as the main TCP connection. `None` runs the
+    /// handshake-only path (no TLS), used by the loopback handshake test.
+    pub async fn bind(
+        addr: SocketAddr,
+        cfg: ListenerConfig,
+        tls_config: Option<Arc<ServerConfig>>,
+    ) -> io::Result<Self> {
         let socket = UdpSocket::bind(addr).await?;
         let local_addr = socket.local_addr()?;
         let socket = Arc::new(socket);
-        debug!(%local_addr, ?cfg, "RDPEUDP multitransport listener bound");
-        let task = tokio::spawn(run_recv_loop(Arc::clone(&socket), cfg));
+        debug!(%local_addr, ?cfg, tls = tls_config.is_some(), "RDPEUDP multitransport listener bound");
+        let task = tokio::spawn(run_recv_loop(Arc::clone(&socket), cfg, tls_config));
         Ok(Self { local_addr, task })
     }
 
@@ -115,7 +133,25 @@ fn is_syn_family(bytes: &[u8]) -> bool {
     Datagram::peek_fec_flags(bytes).is_some_and(|f| f.contains(FecFlags::SYN))
 }
 
-async fn run_recv_loop(socket: Arc<UdpSocket>, cfg: ListenerConfig) {
+/// Send every datagram the SM produced, zero-padding SYN-family packets to the
+/// MTU (MS-RDPEUDP path-MTU validation). A send error is per-datagram (UDP), so
+/// log and keep going.
+async fn send_datagrams(socket: &UdpSocket, peer_addr: SocketAddr, to_send: Vec<Vec<u8>>, mtu: u16) {
+    for mut dg in to_send {
+        if is_syn_family(&dg) && dg.len() < mtu as usize {
+            dg.resize(mtu as usize, 0);
+        }
+        if let Err(e) = socket.send_to(&dg, peer_addr).await {
+            trace!(error = %e, %peer_addr, "udp send_to error");
+        }
+    }
+}
+
+async fn run_recv_loop(
+    socket: Arc<UdpSocket>,
+    cfg: ListenerConfig,
+    tls_config: Option<Arc<ServerConfig>>,
+) {
     let mut peers: HashMap<SocketAddr, Peer> = HashMap::new();
     let mut session_counter: u32 = 0;
     let start = tokio::time::Instant::now();
@@ -182,20 +218,15 @@ async fn run_recv_loop(socket: Arc<UdpSocket>, cfg: ListenerConfig) {
                 ),
                 inbound: Vec::new(),
                 tls_hello_logged: false,
+                tls: None,
+                tls_done_logged: false,
             }
         });
 
         let was_established = peer.sm.is_established();
         let had_data = Datagram::peek_fec_flags(data).is_some_and(|f| f.contains(FecFlags::DATA));
         let out = peer.sm.step(now_ms, Some(data));
-        for mut dg in out.to_send {
-            if is_syn_family(&dg) && dg.len() < cfg.mtu as usize {
-                dg.resize(cfg.mtu as usize, 0); // path-MTU validation padding
-            }
-            if let Err(e) = socket.send_to(&dg, peer_addr).await {
-                trace!(error = %e, %peer_addr, "udp send_to error");
-            }
-        }
+        send_datagrams(&socket, peer_addr, out.to_send, cfg.mtu).await;
 
         if !was_established && peer.sm.is_established() {
             debug!(
@@ -229,8 +260,82 @@ async fn run_recv_loop(socket: Arc<UdpSocket>, cfg: ListenerConfig) {
                 peer.tls_hello_logged = true;
                 debug!(
                     %peer_addr,
-                    "RDPEUDP reliable stream carries a TLS ClientHello (MS-RDPEMT handshake starting; TLS + tunnel are M4b/M4c)"
+                    "RDPEUDP reliable stream carries a TLS ClientHello (MS-RDPEMT handshake starting)"
                 );
+            }
+
+            // M4b: drive the MS-RDPEMT server-side TLS handshake over the reliable
+            // stream. Feed the just-delivered bytes into rustls, then ship whatever
+            // TLS output it produces back through the SM (reliable, fragmented to
+            // the MTU). Plaintext tunnel bytes (the EMT PDUs after the handshake)
+            // are M4c. No-op when the listener has no TLS config (test path).
+            if let Some(tls_cfg) = tls_config.as_ref() {
+                if peer.tls.is_none() {
+                    match ServerConnection::new(Arc::clone(tls_cfg)) {
+                        Ok(conn) => peer.tls = Some(conn),
+                        Err(e) => warn!(%peer_addr, error = %e, "failed to create MS-RDPEMT TLS server"),
+                    }
+                }
+                let mut tls_out = Vec::new();
+                let mut plaintext = Vec::new();
+                let mut handshake_done = false;
+                if let Some(tls) = peer.tls.as_mut() {
+                    let mut tls_err = false;
+                    for chunk in &out.delivered {
+                        // Feed the reliable byte-stream into rustls. `read_tls`
+                        // returns Ok(0) once the cursor is drained (or its internal
+                        // buffer is full); loop until then so a chunk carrying more
+                        // than one TLS record is fully consumed.
+                        let mut rd = io::Cursor::new(chunk.as_slice());
+                        loop {
+                            match tls.read_tls(&mut rd) {
+                                Ok(0) => break,
+                                Ok(_) => {}
+                                Err(_) => {
+                                    tls_err = true;
+                                    break;
+                                }
+                            }
+                            if let Err(e) = tls.process_new_packets() {
+                                warn!(%peer_addr, error = %e, "MS-RDPEMT TLS error");
+                                tls_err = true;
+                                break;
+                            }
+                            // Drain decrypted application data (the MS-RDPEMT tunnel
+                            // PDUs — parsed in M4c) so rustls's plaintext buffer
+                            // can't fill and stall record processing. The trailing
+                            // WouldBlock once the buffer empties is expected.
+                            let _ = tls.reader().read_to_end(&mut plaintext);
+                        }
+                        if tls_err {
+                            break;
+                        }
+                    }
+                    while tls.wants_write() {
+                        if tls.write_tls(&mut tls_out).is_err() {
+                            break;
+                        }
+                    }
+                    handshake_done = !tls_err && !tls.is_handshaking();
+                }
+                if !tls_out.is_empty() {
+                    let o = peer.sm.enqueue(now_ms, &tls_out);
+                    send_datagrams(&socket, peer_addr, o.to_send, cfg.mtu).await;
+                }
+                if handshake_done && !peer.tls_done_logged {
+                    peer.tls_done_logged = true;
+                    debug!(
+                        %peer_addr,
+                        "MS-RDPEMT TLS handshake complete (tunnel CREATEREQUEST + cookie are M4c)"
+                    );
+                }
+                if !plaintext.is_empty() {
+                    debug!(
+                        %peer_addr,
+                        plaintext_len = plaintext.len(),
+                        "MS-RDPEMT decrypted tunnel bytes received (parsing is M4c)"
+                    );
+                }
             }
         } else if had_data {
             // A DATA datagram that produced no delivery means our receive sequence


### PR DESCRIPTION
## What

M4b of the RDP UDP multitransport effort (MS-RDPEMT/RDPEUDP): layer macrdp's **existing rustls** over the reliable UDP byte-stream and complete the MS-RDPEMT server-side TLS handshake against a real client. No DTLS, no new crypto dependency.

- **listener** (`vendor/ironrdp-server/src/multitransport/listener.rs`): each peer lazily gets a `rustls::ServerConnection` on first reliable data. Delivered chunks are fed through `read_tls` + `process_new_packets` (looping until the cursor drains), `tls.reader()` is drained so decrypted plaintext can't stall record processing, and `write_tls` output is `enqueue`d back through the reliability SM (reliable, MTU-fragmented via a new `send_datagrams` helper shared by SM and TLS output). The TLS server reuses the **main connection's cert/config** (the client trusts it via TOFU): `bind()` now takes `Option<Arc<ServerConfig>>`, and `make_tls_acceptor` also returns the `Arc<ServerConfig>`.
- **rdpeudp** (`vendor/ironrdp-rdpeudp/src/datagram.rs`): `Datagram::decode` now skips the 4-byte `RDPUDP_ACK_OF_ACKVECTOR_HEADER` when `ACK_OF_ACKS` is set. This was the decisive interop fix — real mstsc sets that flag periodically once a session is up, and folding its 4 bytes into the reliable stream corrupted the TLS records riding it (observed live as rustls `InvalidContentType` right after the first such packet). Regression test added.

## Verification

Verified on **real mstsc over WiFi LAN** (non-loopback): the TLS handshake completes (`MS-RDPEMT TLS handshake complete`) and mstsc then streams encrypted tunnel PDUs (its `RDP_TUNNEL_CREATEREQUEST`, 28 bytes plaintext, retransmitted while it waits for our `CREATERESPONSE`) which decrypt cleanly — no `InvalidContentType`. The session renders normally over TCP the whole time (graceful fallback intact).

- 35 `ironrdp-rdpeudp` tests (incl. the new ack-of-acks decode test).
- Loopback listener test (`tls_config: None`) unchanged.
- `cargo clippy --all-targets -D warnings` clean; fmt clean.

## Scope / next

Tunnel-PDU parsing (`RDP_TUNNEL_CREATEREQUEST`/`CREATERESPONSE` + Soft-Sync), cookie binding, and channel migration are **M4c/M5**. The 28-byte decrypted plaintext is logged, not yet parsed. All gated behind the `multitransport` feature + `--enable-udp-multitransport` (default OFF).