### PR TITLE
feat(multitransport): M4c — establish the MS-RDPEMT tunnel over UDP

### DIFF
--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,24 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **M4c (done — MS-RDPEMT tunnel established on real mstsc, 2026-06-25):** new
+  `src/emt.rs` — the MS-RDPEMT *tunnel* PDU codecs (a different protocol from the
+  RDPEUDP transport below it; rides the TLS-secured reliable stream). **MS-RDPEMT
+  is little-endian** (an RDP byte-stream protocol like MS-RDPBCGR), *unlike*
+  RDPEUDP's big-endian — the one endianness exception in this crate. Models the
+  handshake PDUs macrdp needs: `TunnelHeader` (Action low-nibble | Flags
+  high-nibble, LE PayloadLength, HeaderLength; full PDU = HeaderLength +
+  PayloadLength), `TunnelCreateRequest::decode` (client→server: RequestID +
+  Reserved + 16-byte SecurityCookie = 24-byte payload; the 28-byte plaintext real
+  mstsc sends), `TunnelCreateResponse::ok().to_vec()` (server→client, HrResponse
+  = S_OK), and stream-framing helpers `peek_pdu_len` / `peek_action` (frame a PDU
+  from a partial buffer by reading just the 4 fixed header bytes — avoids the
+  sub-header decode's need-more-bytes-vs-malformed ambiguity). The server's
+  listener drives these (see ironrdp-server CLAUDE.md M4c). 40 crate tests (+5).
+  Verified live: mstsc's CREATEREQUEST (request_id=2, the issued cookie echoed
+  back) is answered with CREATERESPONSE(S_OK); mstsc ACKs, stops retransmitting,
+  and the tunnel idles on keepalives — established. RDP_TUNNEL_DATA (channel
+  migration) is M5.
 - **M4b decode fix (done — verified on real mstsc, 2026-06-25):** `Datagram::decode`
   now **skips the 4-byte RDPUDP_ACK_OF_ACKVECTOR_HEADER** (`snAckOfAcksSeqNum`) that
   sits between the ack vector and the source payload when the `ACK_OF_ACKS` flag is

--- a/vendor/ironrdp-rdpeudp/src/emt.rs
+++ b/vendor/ironrdp-rdpeudp/src/emt.rs
@@ -1,0 +1,321 @@
+//! MS-RDPEMT tunnel PDU wire structures (the multitransport "tunnel" that rides
+//! the secured reliable RDPEUDP stream — TLS for `UdpFecR`).
+//!
+//! This is a *different* protocol from MS-RDPEUDP (the reliability/transport
+//! layer below it): once the reliable byte-stream is up and TLS-secured, the
+//! client and server exchange MS-RDPEMT tunnel PDUs **inside** that TLS channel
+//! to create the tunnel, bind it to the TCP session via the security cookie, and
+//! (later) carry migrated dynamic-channel data.
+//!
+//! **Unlike MS-RDPEUDP (big-endian), MS-RDPEMT multi-byte fields are
+//! little-endian** — it's an RDP byte-stream protocol like MS-RDPBCGR. Section
+//! references are to [MS-RDPEMT].
+//!
+//! Only the handshake PDUs macrdp needs are modelled: decode
+//! [`TunnelCreateRequest`] (client→server) and encode [`TunnelCreateResponse`]
+//! (server→client). `RDP_TUNNEL_DATA` (channel migration) is M5.
+//!
+//! [MS-RDPEMT]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/
+
+use ironrdp_core::{
+    ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeResult, Encode,
+    EncodeResult, ReadCursor, WriteCursor,
+};
+
+/// `Action` field of [`TunnelHeader`] (MS-RDPEMT 2.2.1.1, low 4 bits of the
+/// first byte) — RDPTUNNEL_ACTION_*.
+pub mod action {
+    /// RDPTUNNEL_ACTION_CREATEREQUEST — client→server, create the tunnel.
+    pub const CREATE_REQUEST: u8 = 0x0;
+    /// RDPTUNNEL_ACTION_CREATERESPONSE — server→client, tunnel result.
+    pub const CREATE_RESPONSE: u8 = 0x1;
+    /// RDPTUNNEL_ACTION_DATA — channel data carried over the tunnel (M5).
+    pub const DATA: u8 = 0x2;
+}
+
+/// `HrResponse` success value (`S_OK`) for [`TunnelCreateResponse`].
+pub const HR_S_OK: u32 = 0x0000_0000;
+
+/// RDP_TUNNEL_HEADER (MS-RDPEMT 2.2.1.1) — prefixes every tunnel PDU.
+///
+/// On the wire: 1 byte = `Action` (low 4 bits) | `Flags` (high 4 bits), then a
+/// little-endian `PayloadLength` (u16), then `HeaderLength` (u8), then
+/// `HeaderLength - 4` bytes of optional sub-headers. The full PDU on the wire is
+/// `HeaderLength + PayloadLength` bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TunnelHeader {
+    /// `Action` — one of [`action`].
+    pub action: u8,
+    /// `Flags` — RDPTUNNEL_FLAG_* (high nibble; unused by the handshake).
+    pub flags: u8,
+    /// `PayloadLength` — bytes of payload following the (variable-length) header.
+    pub payload_length: u16,
+    /// `HeaderLength` — total header size including any sub-headers (min 4).
+    pub header_length: u8,
+}
+
+impl TunnelHeader {
+    const NAME: &'static str = "RDP_TUNNEL_HEADER";
+    /// Action(+Flags) byte + PayloadLength(2) + HeaderLength(1).
+    pub const FIXED_PART_SIZE: usize = 4;
+
+    /// Total on-wire size of the whole tunnel PDU (header incl. sub-headers +
+    /// payload). `None` if `header_length` is below the fixed minimum (malformed).
+    pub fn total_len(&self) -> Option<usize> {
+        if usize::from(self.header_length) < Self::FIXED_PART_SIZE {
+            return None;
+        }
+        Some(usize::from(self.header_length) + usize::from(self.payload_length))
+    }
+
+    /// Header for a PDU with no sub-headers carrying `payload_length` bytes.
+    pub fn simple(action: u8, payload_length: u16) -> Self {
+        Self {
+            action,
+            flags: 0,
+            payload_length,
+            header_length: Self::FIXED_PART_SIZE as u8,
+        }
+    }
+}
+
+impl Encode for TunnelHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u8((self.action & 0x0f) | ((self.flags & 0x0f) << 4));
+        dst.write_u16(self.payload_length);
+        dst.write_u8(self.header_length);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for TunnelHeader {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let b0 = src.read_u8();
+        let payload_length = src.read_u16();
+        let header_length = src.read_u8();
+        if usize::from(header_length) < Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!(
+                "HeaderLength",
+                "below the 4-byte minimum"
+            ));
+        }
+        // Skip any sub-headers (HeaderLength - 4). We don't model them yet.
+        let sub_len = usize::from(header_length) - Self::FIXED_PART_SIZE;
+        ensure_size!(in: src, size: sub_len);
+        let _ = src.read_slice(sub_len);
+        Ok(Self {
+            action: b0 & 0x0f,
+            flags: (b0 >> 4) & 0x0f,
+            payload_length,
+            header_length,
+        })
+    }
+}
+
+/// Frame a tunnel PDU from a (possibly partial) buffer: peek just the fixed
+/// 4-byte header and return the **total on-wire length** of the PDU it starts
+/// (`HeaderLength + PayloadLength`). `None` if fewer than 4 bytes are buffered
+/// (wait for more) or the header is malformed (`HeaderLength < 4`). Lets a
+/// stream reader detect when a whole PDU is present before decoding it, without
+/// the sub-header decode ambiguity (need-more-bytes vs malformed).
+pub fn peek_pdu_len(buf: &[u8]) -> Option<usize> {
+    if buf.len() < TunnelHeader::FIXED_PART_SIZE {
+        return None;
+    }
+    let payload_length = u16::from_le_bytes([buf[1], buf[2]]);
+    let header_length = buf[3];
+    if usize::from(header_length) < TunnelHeader::FIXED_PART_SIZE {
+        return None;
+    }
+    Some(usize::from(header_length) + usize::from(payload_length))
+}
+
+/// The `Action` of a buffered tunnel PDU (low 4 bits of the first byte), or
+/// `None` if the buffer is empty.
+pub fn peek_action(buf: &[u8]) -> Option<u8> {
+    buf.first().map(|b| b & 0x0f)
+}
+
+/// RDP_TUNNEL_CREATEREQUEST (MS-RDPEMT 2.2.2.1) — client→server. Binds the UDP
+/// tunnel to the main TCP session: `request_id` + `security_cookie` echo the
+/// server's Initiate Multitransport Request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TunnelCreateRequest {
+    /// `RequestID` — matches the Initiate Multitransport Request's request id.
+    pub request_id: u32,
+    /// `SecurityCookie` — the 16-byte cookie from that request.
+    pub security_cookie: [u8; 16],
+}
+
+impl TunnelCreateRequest {
+    /// RequestID(4) + Reserved(4) + SecurityCookie(16).
+    pub const PAYLOAD_SIZE: usize = 24;
+
+    /// Decode from the **TLS-decrypted plaintext**, validating the tunnel header
+    /// action. Returns the request plus the number of bytes consumed (the full
+    /// PDU length), so a caller can parse back-to-back PDUs from a buffer.
+    pub fn decode(buf: &[u8]) -> DecodeResult<(Self, usize)> {
+        let mut src = ReadCursor::new(buf);
+        let header = TunnelHeader::decode(&mut src)?;
+        if header.action != action::CREATE_REQUEST {
+            return Err(invalid_field_err!("Action", "not a CREATEREQUEST"));
+        }
+        if usize::from(header.payload_length) < Self::PAYLOAD_SIZE {
+            return Err(invalid_field_err!(
+                "PayloadLength",
+                "too short for CREATEREQUEST"
+            ));
+        }
+        ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
+        let request_id = src.read_u32();
+        let _reserved = src.read_u32();
+        let security_cookie = src.read_array::<16>();
+        let consumed = header
+            .total_len()
+            .ok_or_else(|| invalid_field_err!("HeaderLength", "malformed"))?;
+        Ok((
+            Self {
+                request_id,
+                security_cookie,
+            },
+            consumed,
+        ))
+    }
+}
+
+/// RDP_TUNNEL_CREATERESPONSE (MS-RDPEMT 2.2.2.2) — server→client. `hr_response`
+/// is an HRESULT; [`HR_S_OK`] accepts the tunnel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TunnelCreateResponse {
+    pub hr_response: u32,
+}
+
+impl TunnelCreateResponse {
+    const NAME: &'static str = "RDP_TUNNEL_CREATERESPONSE";
+    /// HrResponse(4).
+    pub const PAYLOAD_SIZE: usize = 4;
+
+    /// A success (`S_OK`) response.
+    pub fn ok() -> Self {
+        Self {
+            hr_response: HR_S_OK,
+        }
+    }
+
+    /// Encode to bytes ready to write into the TLS tunnel.
+    pub fn to_vec(&self) -> Vec<u8> {
+        let total = TunnelHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+        let mut out = vec![0u8; total];
+        let mut dst = WriteCursor::new(&mut out);
+        // Infallible: the buffer is sized exactly.
+        let _ = self.encode(&mut dst);
+        out
+    }
+}
+
+impl Encode for TunnelCreateResponse {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let header = TunnelHeader::simple(action::CREATE_RESPONSE, Self::PAYLOAD_SIZE as u16);
+        header.encode(dst)?;
+        ensure_size!(in: dst, size: Self::PAYLOAD_SIZE);
+        dst.write_u32(self.hr_response);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        TunnelHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_request_decodes_with_expected_fields() {
+        // RDP_TUNNEL_HEADER: action=0 (CREATEREQUEST), payloadLen=24 (LE), hdrLen=4
+        // then RequestID(4 LE) + Reserved(4) + SecurityCookie(16). 28 bytes total —
+        // exactly what real mstsc sends over the TLS tunnel (plaintext_len=28).
+        #[rustfmt::skip]
+        let bytes: [u8; 28] = [
+            0x00, 0x18, 0x00, 0x04, // action|flags=0x00, payloadLength=0x0018=24, headerLength=4
+            0x2a, 0x00, 0x00, 0x00, // RequestID = 42 (LE)
+            0x00, 0x00, 0x00, 0x00, // Reserved
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, // SecurityCookie
+        ];
+        let (req, consumed) = TunnelCreateRequest::decode(&bytes).unwrap();
+        assert_eq!(consumed, 28);
+        assert_eq!(req.request_id, 42);
+        assert_eq!(
+            req.security_cookie,
+            [
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+                0x0f, 0x10
+            ]
+        );
+    }
+
+    #[test]
+    fn create_request_skips_subheaders() {
+        // headerLength=8 → 4 bytes of sub-headers before the payload.
+        #[rustfmt::skip]
+        let bytes: [u8; 32] = [
+            0x00, 0x18, 0x00, 0x08, // headerLength=8 (4 bytes of sub-headers follow)
+            0xaa, 0xbb, 0xcc, 0xdd, // sub-header bytes (ignored)
+            0x07, 0x00, 0x00, 0x00, // RequestID = 7
+            0x00, 0x00, 0x00, 0x00, // Reserved
+            0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+        ];
+        let (req, consumed) = TunnelCreateRequest::decode(&bytes).unwrap();
+        assert_eq!(consumed, 32);
+        assert_eq!(req.request_id, 7);
+    }
+
+    #[test]
+    fn create_request_rejects_wrong_action() {
+        let bytes: [u8; 28] = {
+            let mut b = [0u8; 28];
+            b[0] = action::CREATE_RESPONSE; // wrong action
+            b[1] = 0x18;
+            b[3] = 0x04;
+            b
+        };
+        assert!(TunnelCreateRequest::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn create_response_encodes_s_ok() {
+        let bytes = TunnelCreateResponse::ok().to_vec();
+        // action|flags=0x01 (CREATERESPONSE), payloadLength=4 (LE), headerLength=4,
+        // HrResponse=0 (S_OK).
+        assert_eq!(bytes, vec![0x01, 0x04, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn create_response_round_trips_through_request_shape() {
+        // The header our response emits must itself decode as a well-formed
+        // tunnel header with the CREATERESPONSE action.
+        let bytes = TunnelCreateResponse::ok().to_vec();
+        let mut src = ReadCursor::new(&bytes);
+        let header = TunnelHeader::decode(&mut src).unwrap();
+        assert_eq!(header.action, action::CREATE_RESPONSE);
+        assert_eq!(header.payload_length, 4);
+        assert_eq!(header.total_len(), Some(8));
+    }
+}

--- a/vendor/ironrdp-rdpeudp/src/lib.rs
+++ b/vendor/ironrdp-rdpeudp/src/lib.rs
@@ -26,6 +26,7 @@
 //! `to_be_bytes`/`from_be_bytes`), confirmed against the spec's capture example.
 
 pub mod datagram;
+pub mod emt;
 pub mod eudp2;
 pub mod pdu;
 pub mod state;

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -347,3 +347,23 @@ AND released — #1276 landing is NOT sufficient.
     (`InvalidContentType`). The `tls_config: None` path (the loopback handshake
     test) is unchanged. Still no EMT tunnel parsing / cookie binding / migration
     (M4c/M5); the 28-byte plaintext is logged, not yet parsed.
+    **M4c (added 2026-06-25): MS-RDPEMT tunnel established — verified on real
+    mstsc.** The listener now parses the decrypted tunnel PDUs and answers the
+    handshake. Each `Peer` accumulates TLS-decrypted plaintext (`emt_inbound`);
+    `handle_emt_tunnel` frames complete tunnel PDUs (via `ironrdp_rdpeudp::emt`'s
+    `peek_pdu_len`) and, on the client's `RDP_TUNNEL_CREATEREQUEST`, writes a
+    `RDP_TUNNEL_CREATERESPONSE(S_OK)` into the TLS connection — whose encrypted
+    bytes the existing `write_tls` drain ships back through the SM. Gated by
+    `Peer::tunnel_created` so the client's retransmits (it resends the request
+    until it sees the response) are answered exactly once. The TLS block now
+    destructures `Peer` into disjoint field borrows so the rustls feed/write runs
+    alongside the EMT buffer/state. Result on real mstsc: CREATEREQUEST
+    (request_id=2, the issued cookie echoed back verbatim) → our CREATERESPONSE →
+    mstsc ACKs, **stops retransmitting**, tunnel idles on `ACK|ACK_DELAYED`
+    keepalives = established. **Cookie binding is still SOFT** (logged + verified
+    by eye to match the issued offer; we reply S_OK regardless) — strict
+    enforcement needs a shared (request_id, cookie) registry between the
+    offer-issuing acceptor path and the process-global listener, which is an **M5
+    prerequisite** (M5 is when channel data actually rides the tunnel, so
+    hijack-resistance starts to matter; nothing rides it yet). RDP_TUNNEL_DATA
+    (action 0x2) is logged "not handled yet (channel migration is M5)" and skipped.

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -29,6 +29,7 @@
 use std::collections::HashMap;
 use std::io;
 use std::io::Read as _;
+use std::io::Write as _;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -85,6 +86,14 @@ struct Peer {
     tls: Option<ServerConnection>,
     /// Whether we've logged TLS-handshake completion (avoid log spam).
     tls_done_logged: bool,
+    /// TLS-decrypted plaintext awaiting MS-RDPEMT tunnel-PDU parsing (M4c). The
+    /// client's `RDP_TUNNEL_CREATEREQUEST` arrives here once TLS is up; complete
+    /// tunnel PDUs are consumed from the front.
+    emt_inbound: Vec<u8>,
+    /// Whether we've answered the tunnel `CREATEREQUEST` with a `CREATERESPONSE`
+    /// (M4c). The client retransmits the request until it sees the response, so
+    /// we reply once and then ignore the retransmits.
+    tunnel_created: bool,
 }
 
 /// A running UDP multitransport listener. The receive loop runs on a spawned
@@ -143,6 +152,68 @@ async fn send_datagrams(socket: &UdpSocket, peer_addr: SocketAddr, to_send: Vec<
         }
         if let Err(e) = socket.send_to(&dg, peer_addr).await {
             trace!(error = %e, %peer_addr, "udp send_to error");
+        }
+    }
+}
+
+/// Parse complete MS-RDPEMT tunnel PDUs from the TLS-decrypted plaintext and, on
+/// the client's `RDP_TUNNEL_CREATEREQUEST`, write a `CREATERESPONSE(S_OK)` into
+/// the TLS connection (its encrypted bytes are picked up by the caller's
+/// `write_tls` drain). Consumes parsed PDUs from the front of `buf`; leaves a
+/// partial trailing PDU buffered for the next call. The client retransmits the
+/// request until it sees the response, so we reply once (gated by
+/// `tunnel_created`) and drop the retransmits. RDP_TUNNEL_DATA (channel
+/// migration) is M5 — logged and skipped for now.
+fn handle_emt_tunnel(
+    peer_addr: SocketAddr,
+    tls: &mut ServerConnection,
+    buf: &mut Vec<u8>,
+    tunnel_created: &mut bool,
+) {
+    use ironrdp_rdpeudp::emt::{self, TunnelCreateRequest, TunnelCreateResponse};
+
+    while let Some(total) = emt::peek_pdu_len(buf) {
+        if buf.len() < total {
+            break; // wait for the rest of this PDU
+        }
+        let pdu: Vec<u8> = buf.drain(..total).collect();
+
+        match emt::peek_action(&pdu) {
+            Some(emt::action::CREATE_REQUEST) => match TunnelCreateRequest::decode(&pdu) {
+                Ok((req, _)) => {
+                    if !*tunnel_created {
+                        let cookie = req
+                            .security_cookie
+                            .iter()
+                            .map(|b| format!("{b:02x}"))
+                            .collect::<String>();
+                        debug!(
+                            %peer_addr,
+                            request_id = req.request_id,
+                            %cookie,
+                            "MS-RDPEMT tunnel CREATEREQUEST received — replying CREATERESPONSE(S_OK)"
+                        );
+                        let resp = TunnelCreateResponse::ok().to_vec();
+                        if tls.writer().write_all(&resp).is_ok() {
+                            *tunnel_created = true;
+                        } else {
+                            warn!(%peer_addr, "failed to write MS-RDPEMT CREATERESPONSE into TLS");
+                        }
+                    }
+                }
+                Err(e) => warn!(%peer_addr, error = %e, "malformed MS-RDPEMT CREATEREQUEST"),
+            },
+            Some(other) => {
+                // RDP_TUNNEL_DATA (action 0x2) and friends carry migrated channel
+                // data — M5. Skip until then.
+                debug!(
+                    %peer_addr,
+                    action = other,
+                    len = total,
+                    "MS-RDPEMT tunnel PDU not handled yet (channel migration is M5)"
+                );
+            }
+            None => break,
         }
     }
 }
@@ -220,6 +291,8 @@ async fn run_recv_loop(
                 tls_hello_logged: false,
                 tls: None,
                 tls_done_logged: false,
+                emt_inbound: Vec::new(),
+                tunnel_created: false,
             }
         });
 
@@ -264,11 +337,12 @@ async fn run_recv_loop(
                 );
             }
 
-            // M4b: drive the MS-RDPEMT server-side TLS handshake over the reliable
-            // stream. Feed the just-delivered bytes into rustls, then ship whatever
-            // TLS output it produces back through the SM (reliable, fragmented to
-            // the MTU). Plaintext tunnel bytes (the EMT PDUs after the handshake)
-            // are M4c. No-op when the listener has no TLS config (test path).
+            // M4b/M4c: drive the MS-RDPEMT server-side TLS handshake over the
+            // reliable stream, then handle the tunnel PDUs inside it. Feed the
+            // just-delivered bytes into rustls, parse any decrypted tunnel PDUs
+            // (M4c: answer CREATEREQUEST with CREATERESPONSE), and ship whatever
+            // TLS output that produces back through the SM (reliable, fragmented
+            // to the MTU). No-op when the listener has no TLS config (test path).
             if let Some(tls_cfg) = tls_config.as_ref() {
                 if peer.tls.is_none() {
                     match ServerConnection::new(Arc::clone(tls_cfg)) {
@@ -276,10 +350,20 @@ async fn run_recv_loop(
                         Err(e) => warn!(%peer_addr, error = %e, "failed to create MS-RDPEMT TLS server"),
                     }
                 }
+                // Disjoint field borrows so the TLS feed/write can run alongside
+                // the EMT tunnel buffer + state.
+                let Peer {
+                    sm,
+                    tls: tls_opt,
+                    tls_done_logged,
+                    emt_inbound,
+                    tunnel_created,
+                    ..
+                } = peer;
+
                 let mut tls_out = Vec::new();
-                let mut plaintext = Vec::new();
                 let mut handshake_done = false;
-                if let Some(tls) = peer.tls.as_mut() {
+                if let Some(tls) = tls_opt.as_mut() {
                     let mut tls_err = false;
                     for chunk in &out.delivered {
                         // Feed the reliable byte-stream into rustls. `read_tls`
@@ -302,15 +386,22 @@ async fn run_recv_loop(
                                 break;
                             }
                             // Drain decrypted application data (the MS-RDPEMT tunnel
-                            // PDUs — parsed in M4c) so rustls's plaintext buffer
-                            // can't fill and stall record processing. The trailing
-                            // WouldBlock once the buffer empties is expected.
-                            let _ = tls.reader().read_to_end(&mut plaintext);
+                            // PDUs) so rustls's plaintext buffer can't fill and
+                            // stall record processing; accumulate it for parsing.
+                            // The trailing WouldBlock once the buffer empties is
+                            // expected.
+                            let _ = tls.reader().read_to_end(emt_inbound);
                         }
                         if tls_err {
                             break;
                         }
                     }
+
+                    // M4c: answer the client's RDP_TUNNEL_CREATEREQUEST. Writing the
+                    // response into the TLS connection here means the wants_write
+                    // drain below picks up its encrypted bytes.
+                    handle_emt_tunnel(peer_addr, tls, emt_inbound, tunnel_created);
+
                     while tls.wants_write() {
                         if tls.write_tls(&mut tls_out).is_err() {
                             break;
@@ -319,22 +410,12 @@ async fn run_recv_loop(
                     handshake_done = !tls_err && !tls.is_handshaking();
                 }
                 if !tls_out.is_empty() {
-                    let o = peer.sm.enqueue(now_ms, &tls_out);
+                    let o = sm.enqueue(now_ms, &tls_out);
                     send_datagrams(&socket, peer_addr, o.to_send, cfg.mtu).await;
                 }
-                if handshake_done && !peer.tls_done_logged {
-                    peer.tls_done_logged = true;
-                    debug!(
-                        %peer_addr,
-                        "MS-RDPEMT TLS handshake complete (tunnel CREATEREQUEST + cookie are M4c)"
-                    );
-                }
-                if !plaintext.is_empty() {
-                    debug!(
-                        %peer_addr,
-                        plaintext_len = plaintext.len(),
-                        "MS-RDPEMT decrypted tunnel bytes received (parsing is M4c)"
-                    );
+                if handshake_done && !*tls_done_logged {
+                    *tls_done_logged = true;
+                    debug!(%peer_addr, "MS-RDPEMT TLS handshake complete");
                 }
             }
         } else if had_data {


### PR DESCRIPTION
## What

M4c of the RDP UDP multitransport effort: parse the decrypted **MS-RDPEMT tunnel** PDUs and answer the handshake, so the tunnel reaches **established** against a real client over the TLS-secured reliable UDP stream (M4b).

- **rdpeudp**: new `src/emt.rs` — the MS-RDPEMT tunnel PDU codecs. `TunnelHeader` (Action low-nibble | Flags high-nibble, LE PayloadLength, HeaderLength; full PDU = HeaderLength + PayloadLength), `TunnelCreateRequest::decode` (client→server: RequestID + Reserved + 16-byte SecurityCookie), `TunnelCreateResponse::ok()` (server→client, HrResponse = S_OK), and `peek_pdu_len`/`peek_action` stream-framing helpers (frame a PDU from a partial buffer via the 4 fixed header bytes). **MS-RDPEMT is little-endian** — an RDP byte-stream protocol like MS-RDPBCGR, unlike RDPEUDP's big-endian.
- **listener**: each `Peer` accumulates TLS-decrypted plaintext (`emt_inbound`); `handle_emt_tunnel` frames complete tunnel PDUs and, on `RDP_TUNNEL_CREATEREQUEST`, writes a `CREATERESPONSE(S_OK)` into the TLS connection (its encrypted bytes ship via the existing `write_tls` drain). Gated by `tunnel_created` so the client's retransmits are answered once. The TLS block destructures `Peer` into disjoint field borrows so the rustls feed/write runs alongside the EMT buffer/state.

## Verification

Verified on **real mstsc over WiFi LAN**: the client's CREATEREQUEST (`request_id=2`, the issued cookie `bcdefghijklmnopq` echoed back verbatim) is answered with `CREATERESPONSE(S_OK)`; mstsc ACKs, **stops retransmitting**, and the tunnel idles on `ACK | ACK_DELAYED` keepalives — established. The session renders over TCP throughout.

- 40 `ironrdp-rdpeudp` tests (+5 emt).
- Loopback listener test (`tls_config: None`) unchanged.
- `cargo clippy --all-targets -D warnings` clean; fmt clean.

## Scope / next

**Cookie binding is still soft** (logged + reply S_OK regardless). Strict enforcement needs a shared `(request_id, cookie)` registry between the offer-issuing acceptor path and the process-global listener — an **M5 prerequisite** (M5 is when channel data actually rides the tunnel, so hijack-resistance starts to matter; nothing rides it yet). `RDP_TUNNEL_DATA` (channel migration) is logged + skipped until M5.

**M5** migrates the EGFX channel onto the tunnel (`SharedWriter` → `TransportRouter`). All gated behind the `multitransport` feature + `--enable-udp-multitransport` (default OFF).