### PR TITLE
feat(multitransport): M5a — strict cookie binding (CSPRNG + registry)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,6 +1711,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "getrandom 0.2.17",
  "ironrdp-acceptor",
  "ironrdp-ainput",
  "ironrdp-async",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2122,10 +2122,15 @@ async fn async_main() -> Result<()> {
             server_isn_seed: isn_seed,
             ..Default::default()
         };
+        // M5a: a shared cookie registry binds an inbound UDP tunnel to a real TCP
+        // session. The server registers each issued cookie here; the listener
+        // accepts a tunnel CREATEREQUEST only if its echoed cookie matches.
+        let cookie_registry = ironrdp_server::CookieRegistry::new();
         match ironrdp_server::UdpMultitransportListener::bind(
             args.bind,
             cfg,
             Some(udp_tls_config.clone()),
+            Some(cookie_registry.clone()),
         )
         .await
         {
@@ -2137,6 +2142,7 @@ async fn async_main() -> Result<()> {
                 );
                 server
                     .set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));
+                server.set_multitransport_cookie_registry(Some(cookie_registry));
                 Some(listener)
             }
             Err(e) => {

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -34,7 +34,35 @@ mod tests {
     use ironrdp_pdu::mcs::McsMessage;
     use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, RequestedProtocol};
     use ironrdp_pdu::x224::X224;
-    use ironrdp_server::encode_initiate_request;
+    use ironrdp_server::{encode_initiate_request, CookieRegistry};
+
+    // M5a: the cookie registry binds an inbound UDP tunnel to a real TCP session.
+    // Its security property is one-time use — a registered cookie is accepted by
+    // `take` exactly once (so a forged/replayed CREATEREQUEST can't open a second
+    // tunnel), and an unregistered cookie is never accepted. The registry lives in
+    // the vendored (test = false) server crate, so its behavior is tested here.
+    #[test]
+    fn cookie_registry_take_is_one_time_and_rejects_unknown() {
+        let reg = CookieRegistry::new();
+        let cookie = [0xABu8; 16];
+        let other = [0x11u8; 16];
+
+        // Unknown cookie is rejected.
+        assert!(!reg.take(&other), "unregistered cookie must not bind");
+
+        // Registered cookie binds exactly once, then is consumed.
+        reg.insert(cookie);
+        assert!(reg.take(&cookie), "registered cookie must bind once");
+        assert!(
+            !reg.take(&cookie),
+            "a consumed cookie must not bind again (replay protection)"
+        );
+
+        // Explicit removal (teardown / eviction) also clears it.
+        reg.insert(other);
+        reg.remove(&other);
+        assert!(!reg.take(&other), "removed cookie must not bind");
+    }
 
     // The Initiate Multitransport Request the server sends in M1 is the one bit
     // of new on-wire behavior that no real loopback client exercises (mstsc /
@@ -97,10 +125,12 @@ mod tests {
         ];
 
         let cfg = ListenerConfig::default();
-        // No TLS config: this test only exercises the SYN→SYN+ACK handshake.
-        let listener = UdpMultitransportListener::bind("127.0.0.1:0".parse().unwrap(), cfg, None)
-            .await
-            .expect("bind listener");
+        // No TLS config and no cookie registry: this test only exercises the
+        // SYN→SYN+ACK handshake (soft cookie binding).
+        let listener =
+            UdpMultitransportListener::bind("127.0.0.1:0".parse().unwrap(), cfg, None, None)
+                .await
+                .expect("bind listener");
         let server_addr = listener.local_addr();
 
         let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -367,3 +367,25 @@ AND released — #1276 landing is NOT sufficient.
     prerequisite** (M5 is when channel data actually rides the tunnel, so
     hijack-resistance starts to matter; nothing rides it yet). RDP_TUNNEL_DATA
     (action 0x2) is logged "not handled yet (channel migration is M5)" and skipped.
+    **M5a (added 2026-06-25): strict cookie binding — verified on real mstsc.**
+    The tunnel is now bound to a real, current TCP session so a forged/replayed
+    cookie can't open one (the security prerequisite before any data rides the
+    tunnel in M5b/c). New `CookieRegistry` (multitransport/mod.rs, re-exported):
+    a shared `Arc<Mutex<HashSet<[u8;16]>>>` with insert / remove / `take`
+    (atomic check-and-consume = one-time use). `new_offer` now generates the
+    16-byte cookie via **getrandom (CSPRNG)** instead of the predictable
+    request_id-derived pattern (getrandom added under the `multitransport`
+    feature; it's already in the tree via rustls so no real build-graph cost).
+    `RdpServer` gained `multitransport_cookies: Option<CookieRegistry>` +
+    `set_multitransport_cookie_registry`; the offer site registers the issued
+    cookie (and evicts the previous connection's, so TCP-fallback connections
+    leave at most ~one stale entry per live RdpServer). The listener's `bind`
+    gained a `cookie_registry: Option<CookieRegistry>` param threaded to
+    `handle_emt_tunnel`, which `take`s the CREATEREQUEST's echoed cookie before
+    replying — on a miss it logs "cookie not recognized — rejecting tunnel" and
+    sends nothing (client times out the UDP attempt, stays on TCP). `None`
+    registry = soft binding (accept any cookie — the handshake-only test path).
+    main.rs creates one registry and hands the same clone to both `bind` and the
+    server. Verified on real mstsc: random cookie `f76fdf2b…`, "bound to session",
+    tunnel establishes. One-time-use logic unit-tested in the macrdp crate
+    (`cookie_registry_take_is_one_time_and_rejects_unknown`).

--- a/vendor/ironrdp-server/Cargo.toml
+++ b/vendor/ironrdp-server/Cargo.toml
@@ -30,7 +30,7 @@ egfx = ["dep:ironrdp-egfx"]
 # the standard build is byte-identical. M1 performs the negotiation handshake;
 # M3 adds the UDP listener + RDPEUDP SYN/SYN+ACK handshake (pulls in the
 # sans-I/O ironrdp-rdpeudp crate for the wire codecs + reliability SM).
-multitransport = ["dep:ironrdp-rdpeudp"]
+multitransport = ["dep:ironrdp-rdpeudp", "dep:getrandom"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at any time.
@@ -63,6 +63,7 @@ ironrdp-rdpdr = "0.5" # public (vendored — server-direction RDPDR)
 # [patch.crates-io] is ignored in the macrdp build, where ironrdp-core resolves
 # via the root patch to the same git rev.
 ironrdp-rdpeudp = { path = "../ironrdp-rdpeudp", optional = true }
+getrandom = { version = "0.2", optional = true } # multitransport: CSPRNG cookie
 tracing = { version = "0.1", features = ["log"] }
 x509-cert = { version = "0.2.5", optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }

--- a/vendor/ironrdp-server/src/lib.rs
+++ b/vendor/ironrdp-server/src/lib.rs
@@ -38,7 +38,7 @@ pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "multitransport")]
 pub use multitransport::listener::{ListenerConfig, UdpMultitransportListener};
 #[cfg(feature = "multitransport")]
-pub use multitransport::{MultitransportProvider, encode_initiate_request};
+pub use multitransport::{CookieRegistry, MultitransportProvider, encode_initiate_request};
 pub use rdpdr::{
     AnnouncedDevice, DirEntry, RdpdrBackendFactory, RdpdrHandle, RdpdrServer, RdpdrServerFactory, RdpdrServerHandler,
     RdpdrServerMessage, RdpdrStatus, SCARD_EJECT_CARD, SCARD_LEAVE_CARD, SCARD_RESET_CARD, SCARD_SHARE_DIRECT,

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -36,6 +36,8 @@ use std::sync::Arc;
 use ironrdp_rdpeudp::datagram::Datagram;
 use ironrdp_rdpeudp::pdu::FecFlags;
 use ironrdp_rdpeudp::state::{Config, RdpeudpState, Role};
+
+use crate::multitransport::CookieRegistry;
 use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
 use tokio_rustls::rustls::{ServerConfig, ServerConnection};
@@ -111,16 +113,34 @@ impl UdpMultitransportListener {
     /// `tls_config` is the rustls server config that secures the MS-RDPEMT tunnel
     /// (M4b) — pass the SAME cert as the main TCP connection. `None` runs the
     /// handshake-only path (no TLS), used by the loopback handshake test.
+    ///
+    /// `cookie_registry` (M5a) is the shared set of issued multitransport cookies
+    /// (the same one handed to
+    /// [`RdpServer::set_multitransport_cookie_registry`](crate::RdpServer::set_multitransport_cookie_registry)).
+    /// When set, an inbound tunnel `CREATEREQUEST` is accepted only if its echoed
+    /// cookie is registered (binding the UDP flow to a real TCP session, one-time
+    /// use). `None` leaves binding soft (accept any cookie — handshake-test path).
     pub async fn bind(
         addr: SocketAddr,
         cfg: ListenerConfig,
         tls_config: Option<Arc<ServerConfig>>,
+        cookie_registry: Option<CookieRegistry>,
     ) -> io::Result<Self> {
         let socket = UdpSocket::bind(addr).await?;
         let local_addr = socket.local_addr()?;
         let socket = Arc::new(socket);
-        debug!(%local_addr, ?cfg, tls = tls_config.is_some(), "RDPEUDP multitransport listener bound");
-        let task = tokio::spawn(run_recv_loop(Arc::clone(&socket), cfg, tls_config));
+        debug!(
+            %local_addr, ?cfg,
+            tls = tls_config.is_some(),
+            cookie_binding = cookie_registry.is_some(),
+            "RDPEUDP multitransport listener bound"
+        );
+        let task = tokio::spawn(run_recv_loop(
+            Arc::clone(&socket),
+            cfg,
+            tls_config,
+            cookie_registry,
+        ));
         Ok(Self { local_addr, task })
     }
 
@@ -164,11 +184,18 @@ async fn send_datagrams(socket: &UdpSocket, peer_addr: SocketAddr, to_send: Vec<
 /// request until it sees the response, so we reply once (gated by
 /// `tunnel_created`) and drop the retransmits. RDP_TUNNEL_DATA (channel
 /// migration) is M5 — logged and skipped for now.
+///
+/// `cookie_registry` (M5a) binds the tunnel to a real TCP session: when present,
+/// the CREATEREQUEST's echoed cookie must be one the server issued (and not yet
+/// consumed). A forged / replayed / stale cookie is rejected (no response → the
+/// client's UDP attempt times out and it stays on TCP). `None` accepts any
+/// cookie (the soft pre-M5a behavior, used by the handshake-only test path).
 fn handle_emt_tunnel(
     peer_addr: SocketAddr,
     tls: &mut ServerConnection,
     buf: &mut Vec<u8>,
     tunnel_created: &mut bool,
+    cookie_registry: Option<&CookieRegistry>,
 ) {
     use ironrdp_rdpeudp::emt::{self, TunnelCreateRequest, TunnelCreateResponse};
 
@@ -187,11 +214,26 @@ fn handle_emt_tunnel(
                             .iter()
                             .map(|b| format!("{b:02x}"))
                             .collect::<String>();
+                        // M5a: bind to a real TCP session. `take` is atomic
+                        // check-and-consume, so a cookie is one-time use.
+                        let bound = match cookie_registry {
+                            Some(reg) => reg.take(&req.security_cookie),
+                            None => true, // soft binding (test path)
+                        };
+                        if !bound {
+                            warn!(
+                                %peer_addr,
+                                request_id = req.request_id,
+                                %cookie,
+                                "MS-RDPEMT tunnel CREATEREQUEST cookie not recognized — rejecting tunnel (client stays on TCP)"
+                            );
+                            continue;
+                        }
                         debug!(
                             %peer_addr,
                             request_id = req.request_id,
                             %cookie,
-                            "MS-RDPEMT tunnel CREATEREQUEST received — replying CREATERESPONSE(S_OK)"
+                            "MS-RDPEMT tunnel CREATEREQUEST bound to session — replying CREATERESPONSE(S_OK)"
                         );
                         let resp = TunnelCreateResponse::ok().to_vec();
                         if tls.writer().write_all(&resp).is_ok() {
@@ -222,6 +264,7 @@ async fn run_recv_loop(
     socket: Arc<UdpSocket>,
     cfg: ListenerConfig,
     tls_config: Option<Arc<ServerConfig>>,
+    cookie_registry: Option<CookieRegistry>,
 ) {
     let mut peers: HashMap<SocketAddr, Peer> = HashMap::new();
     let mut session_counter: u32 = 0;
@@ -399,8 +442,15 @@ async fn run_recv_loop(
 
                     // M4c: answer the client's RDP_TUNNEL_CREATEREQUEST. Writing the
                     // response into the TLS connection here means the wants_write
-                    // drain below picks up its encrypted bytes.
-                    handle_emt_tunnel(peer_addr, tls, emt_inbound, tunnel_created);
+                    // drain below picks up its encrypted bytes. M5a: bind the
+                    // tunnel to a real TCP session via the cookie registry.
+                    handle_emt_tunnel(
+                        peer_addr,
+                        tls,
+                        emt_inbound,
+                        tunnel_created,
+                        cookie_registry.as_ref(),
+                    );
 
                     while tls.wants_write() {
                         if tls.write_tls(&mut tls_out).is_err() {

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -24,6 +24,8 @@
 pub mod listener;
 
 use core::sync::atomic::{AtomicU32, Ordering};
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use ironrdp_acceptor::MultitransportOffer;
@@ -77,20 +79,72 @@ pub fn encode_initiate_request(
     Ok(encode_vec(&X224(mcs_pdu))?)
 }
 
+/// A shared set of multitransport security cookies the server has issued and not
+/// yet consumed/torn down. The per-connection offer path
+/// ([`RdpServer`](crate::RdpServer)) registers the cookie it puts in its
+/// Initiate Multitransport Request; the process-global UDP
+/// [`listener`](crate::multitransport::listener) checks an inbound tunnel
+/// `RDP_TUNNEL_CREATEREQUEST`'s echoed cookie against it before accepting the
+/// tunnel — **binding the UDP flow to a real, current TCP session** so a forged
+/// or replayed cookie can't open a tunnel. Cookies are one-time: the listener
+/// removes a cookie when it accepts the tunnel, and the offer path evicts the
+/// previous connection's (unconsumed) cookie before registering a new one.
+#[derive(Clone, Default)]
+pub struct CookieRegistry(Arc<Mutex<HashSet<[u8; 16]>>>);
+
+impl CookieRegistry {
+    /// A fresh, empty registry. Create one in `main` and share it (clone) with
+    /// both the [`RdpServer`](crate::RdpServer) and the UDP listener.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an issued cookie as valid.
+    pub fn insert(&self, cookie: [u8; 16]) {
+        if let Ok(mut set) = self.0.lock() {
+            set.insert(cookie);
+        }
+    }
+
+    /// Drop a cookie (consumed on tunnel bind, or evicted on teardown).
+    pub fn remove(&self, cookie: &[u8; 16]) {
+        if let Ok(mut set) = self.0.lock() {
+            set.remove(cookie);
+        }
+    }
+
+    /// Atomically check-and-consume a cookie: returns `true` (and removes it) if
+    /// it was registered. One-time use — a retransmitted/replayed CREATEREQUEST
+    /// with the same cookie won't bind a second tunnel.
+    pub fn take(&self, cookie: &[u8; 16]) -> bool {
+        match self.0.lock() {
+            Ok(mut set) => set.remove(cookie),
+            Err(_) => false,
+        }
+    }
+}
+
 /// Build a fresh [`MultitransportOffer`] for one connection: a process-wide
-/// monotonic `request_id` plus a 16-byte security cookie. The acceptor sends it
-/// as the Server Initiate Multitransport Request after licensing (before Demand
-/// Active); the client echoes `request_id` + `cookie` back over the UDP flow.
-///
-/// The cookie is a deterministic placeholder for now — validation is soft (the
-/// listener logs the client's SYNEX `cookieHash` so the hash formula can be
-/// derived from a live capture). TODO: switch to a CSPRNG once binding is strict.
+/// monotonic `request_id` plus a **cryptographically-random** 16-byte security
+/// cookie. The acceptor sends it as the Server Initiate Multitransport Request
+/// after licensing (before Demand Active); the client echoes `request_id` +
+/// `cookie` back inside the UDP tunnel's `RDP_TUNNEL_CREATEREQUEST`, where the
+/// listener matches it against the [`CookieRegistry`] to bind the flow. The
+/// cookie is CSPRNG-generated (not derivable from `request_id`) so it can't be
+/// forged by an attacker who can see the predictable request id.
 pub(crate) fn new_offer(protocol: RequestedProtocol) -> MultitransportOffer {
     static MT_REQUEST_ID: AtomicU32 = AtomicU32::new(1);
     let request_id = MT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
     let mut cookie = [0u8; 16];
-    for (i, b) in cookie.iter_mut().enumerate() {
-        *b = (request_id.wrapping_mul(2_654_435_761).wrapping_add(i as u32) & 0xff) as u8;
+    if let Err(e) = getrandom::getrandom(&mut cookie) {
+        // The system RNG failing is catastrophic and near-impossible; fall back
+        // to a non-secret derived value so we don't panic the whole server. The
+        // tunnel binding still works (registry match); only unpredictability is
+        // lost in this degenerate case.
+        tracing::error!(error = %e, "system RNG failed for multitransport cookie; using a weak fallback");
+        for (i, b) in cookie.iter_mut().enumerate() {
+            *b = (request_id.wrapping_mul(2_654_435_761).wrapping_add(i as u32) & 0xff) as u8;
+        }
     }
     MultitransportOffer {
         request_id,

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -343,6 +343,13 @@ pub struct RdpServer {
     /// `MultitransportResponsePdu`. Reset every connection in `client_accepted`.
     #[cfg(feature = "multitransport")]
     multitransport_migration: Option<crate::multitransport::MigrationState>,
+    /// (vendored) Shared registry of issued multitransport security cookies. When
+    /// set, the offer path registers each cookie here so the process-global UDP
+    /// listener can bind an inbound tunnel to a real TCP session (reject forged /
+    /// replayed cookies). `None` leaves binding soft (the listener accepts any
+    /// CREATEREQUEST). Set once via `set_multitransport_cookie_registry`.
+    #[cfg(feature = "multitransport")]
+    multitransport_cookies: Option<crate::multitransport::CookieRegistry>,
 }
 
 #[derive(Debug)]
@@ -445,6 +452,8 @@ impl RdpServer {
             multitransport: None,
             #[cfg(feature = "multitransport")]
             multitransport_migration: None,
+            #[cfg(feature = "multitransport")]
+            multitransport_cookies: None,
         }
     }
 
@@ -512,6 +521,19 @@ impl RdpServer {
         provider: Option<Box<dyn crate::multitransport::MultitransportProvider>>,
     ) {
         self.multitransport = provider;
+    }
+
+    /// (vendored) Install the shared multitransport [`CookieRegistry`](crate::CookieRegistry)
+    /// so issued cookies are registered for the UDP listener to bind against.
+    /// Pass the **same** registry that was handed to
+    /// [`UdpMultitransportListener::bind`](crate::UdpMultitransportListener::bind).
+    /// Must be called before any client connects.
+    #[cfg(feature = "multitransport")]
+    pub fn set_multitransport_cookie_registry(
+        &mut self,
+        registry: Option<crate::multitransport::CookieRegistry>,
+    ) {
+        self.multitransport_cookies = registry;
     }
 
     /// Returns the shared ECHO server handle for runtime probe requests and RTT measurements.
@@ -633,8 +655,20 @@ impl RdpServer {
         // mstsc and FreeRDP misparse it as a share-control PDU and disconnect.)
         #[cfg(feature = "multitransport")]
         if let Some(provider) = self.multitransport.as_ref() {
+            let offer = crate::multitransport::new_offer(provider.requested_protocol());
+            // Register this connection's cookie so the UDP listener can bind an
+            // inbound tunnel to it. Evict the previous connection's cookie first
+            // (the listener consumes a cookie on a successful bind, so a leftover
+            // here is from a connection that fell back to TCP — bound to ~one
+            // entry per live RdpServer instance).
+            if let Some(registry) = self.multitransport_cookies.as_ref() {
+                if let Some(prev) = self.multitransport_migration.as_ref() {
+                    registry.remove(&prev.cookie);
+                }
+                registry.insert(offer.cookie);
+            }
             acceptor.set_advertise_extended_client_data(true);
-            acceptor.set_multitransport_offer(Some(crate::multitransport::new_offer(provider.requested_protocol())));
+            acceptor.set_multitransport_offer(Some(offer));
         }
 
         self.attach_channels(&mut acceptor);


### PR DESCRIPTION
## What

The first step of M5: **bind an inbound UDP multitransport tunnel to a real, current TCP session**, so a forged or replayed security cookie can't open one. This is the security prerequisite before any channel data rides the tunnel (M5b/c) — until now the cookie was a predictable `request_id`-derived pattern and the listener accepted any `CREATEREQUEST`.

- **`CookieRegistry`** (`multitransport/mod.rs`, re-exported): a shared set of issued cookies with `insert` / `remove` / `take` (atomic check-and-consume = one-time use, replay-safe).
- **CSPRNG cookie**: `new_offer` now generates the 16-byte cookie via `getrandom` instead of `request_id * k`. (`getrandom` added under the `multitransport` feature; already in-tree via rustls, so no real build-graph cost.)
- **server**: `RdpServer` gains `multitransport_cookies` + `set_multitransport_cookie_registry`; the offer site registers the issued cookie and evicts the previous connection's (TCP-fallback connections leave ≤1 stale entry per live `RdpServer`).
- **listener**: `bind()` takes an `Option<CookieRegistry>`, threaded to `handle_emt_tunnel`, which `take()`s the `CREATEREQUEST`'s echoed cookie before replying. On a miss it rejects (no reply → the client times out the UDP attempt and stays on TCP). A `None` registry = soft binding (the handshake-only test path).
- **main.rs**: creates one registry, hands the same clone to `bind()` and the server.

## Verification

Verified on **real mstsc over WiFi LAN**: `cookie_binding=true`, the issued cookie is now random CSPRNG hex (`f76fdf2b…`), `CREATEREQUEST bound to session → CREATERESPONSE(S_OK)`, mstsc ACKs and the tunnel establishes; the session renders over TCP throughout. The round-trip confirms the server's registry `insert` matches the listener's `take` against a real client.

- One-time-use / reject-unknown logic unit-tested in the macrdp crate (`cookie_registry_take_is_one_time_and_rejects_unknown`) since the vendored server is `test = false`.
- 40 `ironrdp-rdpeudp` tests + loopback listener test unchanged.
- clippy `-D warnings` clean; fmt clean.

## Next

M5b/c: the data path — author `RDP_TUNNEL_DATA`, wire the server→listener handoff for the bound tunnel, Soft-Sync the EGFX dynamic channel onto UDP, and route `ServerEvent::Egfx` over the tunnel (`SharedWriter` → `TransportRouter`, the one hot-path touch; passthrough to TCP when no migration). All gated behind the `multitransport` feature + `--enable-udp-multitransport` (default OFF).