### PR TITLE
feat(multitransport): M5b-1 — RDP_TUNNEL_DATA + Soft-Sync wire codecs

### DIFF
--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,27 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **M5b-1 (done — data-path wire codecs, 2026-06-26; integration pending):** the
+  pure, spec-verified codecs the EGFX-over-UDP data path needs, ahead of the
+  (larger) server integration — same codecs-before-wiring pattern as M2. Two adds:
+  - `emt.rs`: `encode_tunnel_data(higher_layer)` / `tunnel_data_payload(pdu)` —
+    RDP_TUNNEL_DATA (MS-RDPEMT 2.2.2.3, action 0x2): just a `TunnelHeader{DATA}` +
+    the HigherLayerData (which, post-switch, is the **same DRDYNVC DATA PDU** that
+    would otherwise ride the main connection — only the wrapper differs).
+  - **new `softsync.rs`**: the **MS-RDPEDYC Soft-Sync** PDUs. KEY ARCHITECTURE
+    FINDING: Soft-Sync is RDPEDYC (drdynvc), NOT RDPEMT — both PDUs travel over the
+    **DRDYNVC static channel on the MAIN (TCP) connection**, not the UDP tunnel;
+    only the channel *data* after the switch rides the tunnel. `SoftSyncRequest`
+    (Cmd 0x08; first byte = Cmd<<4; Pad; Length [counts Length+Flags+
+    NumberOfTunnels+lists]; Flags TCP_FLUSHED=0x01|CHANNEL_LIST_PRESENT=0x02;
+    NumberOfTunnels u16; then DYNVC_SOFT_SYNC_CHANNEL_LISTs of TunnelType u32 +
+    NumberOfDVCs u16 + u32 channel ids) + `decode_soft_sync_response` (Cmd 0x09;
+    Pad; **NumberOfTunnels is u32 here — 2-byte in request, asymmetric**;
+    TunnelsToSwitch u32 each). LE throughout. `switch_to_udpfecr(channel_ids)`
+    convenience. Byte-exact unit tests vs the spec field tables. 46 crate tests.
+  Integration (send the request over drdynvc, the Initiate-Response gate, the
+  server→listener handoff + recv-loop bidi refactor, route EGFX) is the next,
+  bigger step — see ironrdp-server CLAUDE.md (12) M5 plan.
 - **M4c (done — MS-RDPEMT tunnel established on real mstsc, 2026-06-25):** new
   `src/emt.rs` — the MS-RDPEMT *tunnel* PDU codecs (a different protocol from the
   RDPEUDP transport below it; rides the TLS-secured reliable stream). **MS-RDPEMT

--- a/vendor/ironrdp-rdpeudp/src/emt.rs
+++ b/vendor/ironrdp-rdpeudp/src/emt.rs
@@ -241,6 +241,43 @@ impl Encode for TunnelCreateResponse {
     }
 }
 
+/// Wrap `higher_layer_data` in an RDP_TUNNEL_DATA PDU (MS-RDPEMT 2.2.2.3) ready
+/// to write into the tunnel's TLS. After Soft-Sync, the server carries migrated
+/// dynamic-channel traffic this way: `HigherLayerData` is the **same DRDYNVC PDU**
+/// (e.g. a DYNVC DATA carrying an EGFX message) that would otherwise ride the
+/// main connection's drdynvc SVC — only the transport wrapper differs.
+pub fn encode_tunnel_data(higher_layer_data: &[u8]) -> Vec<u8> {
+    let header = TunnelHeader::simple(
+        action::DATA,
+        u16::try_from(higher_layer_data.len()).unwrap_or(u16::MAX),
+    );
+    let mut out = vec![0u8; TunnelHeader::FIXED_PART_SIZE + higher_layer_data.len()];
+    {
+        let mut dst = WriteCursor::new(&mut out);
+        // Infallible: the buffer is sized exactly for the fixed header.
+        let _ = header.encode(&mut dst);
+    }
+    out[TunnelHeader::FIXED_PART_SIZE..].copy_from_slice(higher_layer_data);
+    out
+}
+
+/// Extract the `HigherLayerData` of an inbound RDP_TUNNEL_DATA PDU (the bytes
+/// after the variable-length [`TunnelHeader`]). Used when the client sends
+/// migrated dynamic-channel data back over the tunnel. Returns a borrowed slice
+/// into `pdu`. Errors if the header is malformed or the buffer is short.
+pub fn tunnel_data_payload(pdu: &[u8]) -> DecodeResult<&[u8]> {
+    let mut src = ReadCursor::new(pdu);
+    let header = TunnelHeader::decode(&mut src)?;
+    // `TunnelHeader::decode` consumes exactly `header_length` bytes (4 fixed +
+    // sub-headers), so the payload starts there.
+    let start = usize::from(header.header_length);
+    let end = start
+        .checked_add(usize::from(header.payload_length))
+        .filter(|&e| e <= pdu.len())
+        .ok_or_else(|| invalid_field_err!("PayloadLength", "exceeds buffer"))?;
+    Ok(&pdu[start..end])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -297,6 +334,26 @@ mod tests {
             b
         };
         assert!(TunnelCreateRequest::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn tunnel_data_wraps_and_unwraps_higher_layer() {
+        let payload = b"a drdynvc DATA pdu carrying EGFX";
+        let pdu = encode_tunnel_data(payload);
+        // action|flags=0x02 (DATA), payloadLength=LE len, headerLength=4.
+        assert_eq!(pdu[0], action::DATA);
+        assert_eq!(u16::from_le_bytes([pdu[1], pdu[2]]) as usize, payload.len());
+        assert_eq!(pdu[3], TunnelHeader::FIXED_PART_SIZE as u8);
+        assert_eq!(&pdu[4..], payload);
+        // Round-trips back to the same HigherLayerData.
+        assert_eq!(tunnel_data_payload(&pdu).unwrap(), payload);
+    }
+
+    #[test]
+    fn tunnel_data_payload_rejects_overlong_length() {
+        // headerLength=4, payloadLength=99 but only 2 payload bytes present.
+        let bad = [action::DATA, 0x63, 0x00, 0x04, 0xaa, 0xbb];
+        assert!(tunnel_data_payload(&bad).is_err());
     }
 
     #[test]

--- a/vendor/ironrdp-rdpeudp/src/lib.rs
+++ b/vendor/ironrdp-rdpeudp/src/lib.rs
@@ -29,4 +29,5 @@ pub mod datagram;
 pub mod emt;
 pub mod eudp2;
 pub mod pdu;
+pub mod softsync;
 pub mod state;

--- a/vendor/ironrdp-rdpeudp/src/softsync.rs
+++ b/vendor/ironrdp-rdpeudp/src/softsync.rs
@@ -1,0 +1,207 @@
+//! MS-RDPEDYC **Soft-Sync** PDUs — the drdynvc-level negotiation that moves
+//! dynamic virtual channels (e.g. EGFX) from the main TCP connection onto a
+//! multitransport tunnel.
+//!
+//! Soft-Sync is technically part of MS-RDPEDYC (the dynamic-VC protocol), not
+//! MS-RDPEUDP/MS-RDPEMT, but it's the piece that makes the UDP multitransport
+//! tunnel actually carry channel data, so its small codec lives alongside the
+//! rest of the sans-I/O multitransport wire types. **Both PDUs travel over the
+//! DRDYNVC static channel on the MAIN (TCP) RDP connection**, NOT over the UDP
+//! tunnel — only the channel *data* (after the switch) rides the tunnel as
+//! [`crate::emt::encode_tunnel_data`].
+//!
+//! Flow (server perspective): after the tunnel is created (and the client's
+//! Initiate Multitransport Response has arrived), the server sends a
+//! [`SoftSyncRequest`] over drdynvc listing which DVCs move to which tunnel; the
+//! client replies with a Soft-Sync Response ([`decode_soft_sync_response`]) and
+//! both ends then read/write those DVCs' data on the tunnel.
+//!
+//! **Little-endian** (an RDP byte-stream protocol). Section references are to
+//! [MS-RDPEDYC] 2.2.5 + 3.1.5.1.1.
+//!
+//! [MS-RDPEDYC]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/
+
+use ironrdp_core::{invalid_field_err, DecodeResult, ReadCursor};
+
+/// DRDYNVC `Cmd` (high 4 bits of the first byte) for a Soft-Sync Request.
+pub const CMD_SOFT_SYNC_REQUEST: u8 = 0x08;
+/// DRDYNVC `Cmd` (high 4 bits of the first byte) for a Soft-Sync Response.
+pub const CMD_SOFT_SYNC_RESPONSE: u8 = 0x09;
+
+/// `SOFT_SYNC_TCP_FLUSHED` — no more data for the listed DVCs over TCP. MUST be
+/// set in a request.
+pub const SOFT_SYNC_TCP_FLUSHED: u16 = 0x01;
+/// `SOFT_SYNC_CHANNEL_LIST_PRESENT` — one or more channel lists follow.
+pub const SOFT_SYNC_CHANNEL_LIST_PRESENT: u16 = 0x02;
+
+/// `TUNNELTYPE_UDPFECR` — the reliable-UDP multitransport tunnel.
+pub const TUNNELTYPE_UDPFECR: u32 = 0x0000_0001;
+/// `TUNNELTYPE_UDPFECL` — the lossy-UDP multitransport tunnel.
+pub const TUNNELTYPE_UDPFECL: u32 = 0x0000_0003;
+
+/// DYNVC_SOFT_SYNC_CHANNEL_LIST (MS-RDPEDYC 3.1.5.1.1) — the DVCs that will have
+/// their data written by the server on one tunnel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncChannelList {
+    /// `TunnelType` — e.g. [`TUNNELTYPE_UDPFECR`].
+    pub tunnel_type: u32,
+    /// `ListOfDVCIds` — the drdynvc channel ids that move to this tunnel.
+    pub channel_ids: Vec<u32>,
+}
+
+impl SoftSyncChannelList {
+    fn encoded_len(&self) -> usize {
+        4 + 2 + self.channel_ids.len() * 4 // TunnelType + NumberOfDVCs + ids
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.tunnel_type.to_le_bytes());
+        out.extend_from_slice(&(self.channel_ids.len() as u16).to_le_bytes());
+        for id in &self.channel_ids {
+            out.extend_from_slice(&id.to_le_bytes());
+        }
+    }
+}
+
+/// DYNVC_SOFT_SYNC_REQUEST (MS-RDPEDYC 2.2.5.1) — server→client over drdynvc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncRequest {
+    /// One channel list per tunnel the server will write DVC data on.
+    pub channel_lists: Vec<SoftSyncChannelList>,
+}
+
+impl SoftSyncRequest {
+    /// A request that moves `channel_ids` onto the reliable-UDP tunnel. Sets
+    /// `SOFT_SYNC_TCP_FLUSHED` (required) and, when there are channels,
+    /// `SOFT_SYNC_CHANNEL_LIST_PRESENT`.
+    pub fn switch_to_udpfecr(channel_ids: Vec<u32>) -> Self {
+        Self {
+            channel_lists: vec![SoftSyncChannelList {
+                tunnel_type: TUNNELTYPE_UDPFECR,
+                channel_ids,
+            }],
+        }
+    }
+
+    /// Encode ready to write onto the drdynvc SVC.
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut flags = SOFT_SYNC_TCP_FLUSHED;
+        if self.channel_lists.iter().any(|l| !l.channel_ids.is_empty()) {
+            flags |= SOFT_SYNC_CHANNEL_LIST_PRESENT;
+        }
+        let lists_len: usize = self.channel_lists.iter().map(|l| l.encoded_len()).sum();
+        // Length counts Length(4) + Flags(2) + NumberOfTunnels(2) + lists.
+        let length = (4 + 2 + 2 + lists_len) as u32;
+
+        let mut out = Vec::with_capacity(2 + length as usize);
+        out.push(CMD_SOFT_SYNC_REQUEST << 4); // cbId=0, Sp=0, Cmd high nibble
+        out.push(0x00); // Pad
+        out.extend_from_slice(&length.to_le_bytes());
+        out.extend_from_slice(&flags.to_le_bytes());
+        out.extend_from_slice(&(self.channel_lists.len() as u16).to_le_bytes());
+        for list in &self.channel_lists {
+            list.encode_into(&mut out);
+        }
+        out
+    }
+}
+
+/// DYNVC_SOFT_SYNC_RESPONSE (MS-RDPEDYC 2.2.5.2) — client→server over drdynvc.
+/// Lists the tunnel types the client will write DVC data on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncResponse {
+    /// `TunnelsToSwitch` — the tunnel types (e.g. [`TUNNELTYPE_UDPFECR`]).
+    pub tunnels: Vec<u32>,
+}
+
+/// Decode a DYNVC_SOFT_SYNC_RESPONSE from a drdynvc PDU. Validates the `Cmd`
+/// nibble (`0x09`). Note `NumberOfTunnels` is **4 bytes** here (it's 2 bytes in
+/// the request — an asymmetry in the spec).
+pub fn decode_soft_sync_response(buf: &[u8]) -> DecodeResult<SoftSyncResponse> {
+    let mut src = ReadCursor::new(buf);
+    if src.len() < 2 + 4 {
+        return Err(invalid_field_err!("DYNVC_SOFT_SYNC_RESPONSE", "too short"));
+    }
+    let b0 = src.read_u8();
+    let cmd = (b0 >> 4) & 0x0f;
+    if cmd != CMD_SOFT_SYNC_RESPONSE {
+        return Err(invalid_field_err!("Cmd", "not a Soft-Sync Response"));
+    }
+    let _pad = src.read_u8();
+    let number_of_tunnels = src.read_u32();
+    let avail = (src.len() / 4) as u32;
+    if number_of_tunnels > avail {
+        return Err(invalid_field_err!(
+            "NumberOfTunnels",
+            "exceeds available bytes"
+        ));
+    }
+    let mut tunnels = Vec::with_capacity(number_of_tunnels as usize);
+    for _ in 0..number_of_tunnels {
+        tunnels.push(src.read_u32());
+    }
+    Ok(SoftSyncResponse { tunnels })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_switch_to_udpfecr_encodes_spec_bytes() {
+        // One channel list, channel id 0x0007, moving to UDPFECR.
+        let req = SoftSyncRequest::switch_to_udpfecr(vec![0x0007]);
+        let bytes = req.to_vec();
+        #[rustfmt::skip]
+        let expected = vec![
+            0x80,                   // cbId=0|Sp=0|Cmd=0x08 (Soft-Sync Request)
+            0x00,                   // Pad
+            0x12, 0x00, 0x00, 0x00, // Length = 18 = 4 + 2 + 2 + (4+2+4)
+            0x03, 0x00,             // Flags = TCP_FLUSHED|CHANNEL_LIST_PRESENT
+            0x01, 0x00,             // NumberOfTunnels = 1
+            0x01, 0x00, 0x00, 0x00, // TunnelType = TUNNELTYPE_UDPFECR
+            0x01, 0x00,             // NumberOfDVCs = 1
+            0x07, 0x00, 0x00, 0x00, // ListOfDVCIds[0] = 7
+        ];
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn request_with_no_channels_omits_list_present_flag() {
+        let req = SoftSyncRequest {
+            channel_lists: vec![SoftSyncChannelList {
+                tunnel_type: TUNNELTYPE_UDPFECR,
+                channel_ids: vec![],
+            }],
+        };
+        let bytes = req.to_vec();
+        // Flags at offset 6..8 — only TCP_FLUSHED (0x01), no LIST_PRESENT.
+        assert_eq!(
+            u16::from_le_bytes([bytes[6], bytes[7]]),
+            SOFT_SYNC_TCP_FLUSHED
+        );
+    }
+
+    #[test]
+    fn response_decodes_one_tunnel() {
+        #[rustfmt::skip]
+        let bytes = [
+            0x90,                   // Cmd=0x09 (Soft-Sync Response)
+            0x00,                   // Pad
+            0x01, 0x00, 0x00, 0x00, // NumberOfTunnels = 1 (4 bytes!)
+            0x01, 0x00, 0x00, 0x00, // TunnelsToSwitch[0] = UDPFECR
+        ];
+        let resp = decode_soft_sync_response(&bytes).unwrap();
+        assert_eq!(resp.tunnels, vec![TUNNELTYPE_UDPFECR]);
+    }
+
+    #[test]
+    fn response_rejects_wrong_cmd_and_overlong_count() {
+        let wrong_cmd = [0x80, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+        assert!(decode_soft_sync_response(&wrong_cmd).is_err());
+
+        // NumberOfTunnels=9 but no tunnel bytes present.
+        let overlong = [0x90, 0x00, 0x09, 0x00, 0x00, 0x00];
+        assert!(decode_soft_sync_response(&overlong).is_err());
+    }
+}


### PR DESCRIPTION
## What

The pure, spec-verified wire codecs the EGFX-over-UDP data path needs, landed ahead of the larger server integration (the same codecs-before-wiring pattern as M2). **No behavior change** — nothing calls these on the live path yet.

The research behind this PR uncovered the key M5 architecture fact: **Soft-Sync is MS-RDPEDYC (drdynvc), not MS-RDPEMT.** Both Soft-Sync PDUs travel over the **DRDYNVC static channel on the main TCP connection**; only the channel *data*, after the switch, rides the UDP tunnel (as `RDP_TUNNEL_DATA`).

- **`emt.rs`**: `encode_tunnel_data` / `tunnel_data_payload` — `RDP_TUNNEL_DATA` (MS-RDPEMT 2.2.2.3, action `0x2`). `HigherLayerData` is the same DRDYNVC DATA PDU that would otherwise ride the main connection — only the wrapper differs.
- **new `softsync.rs`**: the MS-RDPEDYC Soft-Sync PDUs. `SoftSyncRequest` (Cmd `0x08`; `SOFT_SYNC_TCP_FLUSHED`|`SOFT_SYNC_CHANNEL_LIST_PRESENT`; `DYNVC_SOFT_SYNC_CHANNEL_LIST`s of `TunnelType` + channel ids) + `decode_soft_sync_response` (Cmd `0x09`; `NumberOfTunnels` is `u32` here vs `u16` in the request — a spec asymmetry). LE throughout; byte-exact tests against the spec field tables.

## Verification

- 46 `ironrdp-rdpeudp` tests (+6: tunnel-data wrap/unwrap + reject-overlong, Soft-Sync request encode + no-channels-flag, response decode + reject-wrong-cmd).
- macrdp builds; clippy `-D warnings` clean on the crate; fmt clean.

## Next (the integration — bigger)

Wiring these in needs: (1) read the client's Initiate Multitransport Response on msg-channel 1008 as the Soft-Sync gate (currently skipped); (2) a seam to send the Soft-Sync Request over the drdynvc SVC on TCP + the EGFX channel id; (3) the server→listener handoff + a `recv_loop` `select!` refactor for bidirectional tunnel I/O; (4) route `ServerEvent::Egfx` as `RDP_TUNNEL_DATA` over the tunnel. All gated behind the `multitransport` feature + `--enable-udp-multitransport` (default OFF).