### PR TITLE
M5c step 1+2: Soft-Sync gate + send (safe spike)

### DIFF
--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -43,6 +43,8 @@ mod tests {
     // the vendored (test = false) server crate, so its behavior is tested here.
     #[test]
     fn cookie_registry_take_is_one_time_and_rejects_unknown() {
+        use std::sync::atomic::Ordering;
+
         let reg = CookieRegistry::new();
         let cookie = [0xABu8; 16];
         let other = [0x11u8; 16];
@@ -50,16 +52,22 @@ mod tests {
         // Unknown cookie is rejected.
         assert!(!reg.take(&other), "unregistered cookie must not bind");
 
-        // Registered cookie binds exactly once, then is consumed.
-        reg.insert(cookie);
+        // Registered cookie binds exactly once, then is consumed — and the bind
+        // flips the tunnel-bound flag the offer path keeps (M5c).
+        let flag = reg.register(cookie);
+        assert!(!flag.load(Ordering::Relaxed), "flag starts unset");
         assert!(reg.take(&cookie), "registered cookie must bind once");
+        assert!(
+            flag.load(Ordering::Relaxed),
+            "binding the cookie sets its tunnel-bound flag"
+        );
         assert!(
             !reg.take(&cookie),
             "a consumed cookie must not bind again (replay protection)"
         );
 
         // Explicit removal (teardown / eviction) also clears it.
-        reg.insert(other);
+        reg.register(other);
         reg.remove(&other);
         assert!(!reg.take(&other), "removed cookie must not bind");
     }
@@ -122,6 +130,27 @@ mod tests {
             0x01, 0x00, 0x00, 0x00, // TunnelType = TUNNELTYPE_UDPFECR
             0x01, 0x00,             // NumberOfDVCs = 1
             0x07, 0x00, 0x00, 0x00, // ListOfDVCIds[0] = 0x0007
+        ];
+        assert_eq!(bytes, expected);
+    }
+
+    // The M5c "safe spike": an empty channel list (flush TCP, migrate nothing) —
+    // no list is emitted, NumberOfTunnels = 0, CHANNEL_LIST_PRESENT unset.
+    #[test]
+    fn soft_sync_request_empty_list_encodes_flush_only() {
+        use ironrdp_core::encode_vec;
+        use ironrdp_dvc::pdu::{DrdynvcServerPdu, SoftSyncRequestPdu};
+
+        let pdu = DrdynvcServerPdu::SoftSyncRequest(SoftSyncRequestPdu::switch_to_udpfecr(vec![]));
+        let bytes = encode_vec(&pdu).unwrap();
+
+        #[rustfmt::skip]
+        let expected: [u8; 10] = [
+            0x80,                   // Header: Cmd=SoftSyncRequest(0x08)<<4
+            0x00,                   // Pad
+            0x08, 0x00, 0x00, 0x00, // Length = 8 (Length+Flags+NumberOfTunnels, no lists)
+            0x01, 0x00,             // Flags = TCP_FLUSHED only (no CHANNEL_LIST_PRESENT)
+            0x00, 0x00,             // NumberOfTunnels = 0
         ];
         assert_eq!(bytes, expected);
     }

--- a/vendor/ironrdp-dvc/CLAUDE.md
+++ b/vendor/ironrdp-dvc/CLAUDE.md
@@ -61,7 +61,9 @@ since the lib is `test = false`.
       DYNVC_SOFT_SYNC_REQUEST (Header byte `Cmd<<4`; Pad u8; `Length` u32 counting
       Length+Flags+NumberOfTunnels+lists; Flags u16; NumberOfTunnels **u16**;
       then the lists). `switch_to_udpfecr(channel_ids)` convenience builds the
-      common "move these DVCs to the reliable tunnel" request. Wired into
+      common "move these DVCs to the reliable tunnel" request — an **empty**
+      `channel_ids` is a valid "flush TCP, migrate nothing" probe (no list,
+      NumberOfTunnels=0, CHANNEL_LIST_PRESENT unset), the M5c safe spike. Wired into
       `DrdynvcServerPdu::SoftSyncRequest` (Encode/name/size only — the server
       never *decodes* its own request, so no `DrdynvcServerPdu::decode` arm).
     - `SoftSyncResponsePdu { header, tunnels: Vec<u32> }` — client→server

--- a/vendor/ironrdp-dvc/src/pdu.rs
+++ b/vendor/ironrdp-dvc/src/pdu.rs
@@ -725,18 +725,27 @@ pub struct SoftSyncRequestPdu {
 
 impl SoftSyncRequestPdu {
     /// A request moving `channel_ids` onto the reliable-UDP tunnel.
+    ///
+    /// An **empty** `channel_ids` is a valid "flush TCP, migrate nothing" probe:
+    /// no channel list is emitted (`NumberOfTunnels` = 0, `CHANNEL_LIST_PRESENT`
+    /// unset), which is the safe spike used to confirm the send path + the
+    /// client's response decode without actually migrating any DVC.
     pub fn switch_to_udpfecr(channel_ids: Vec<DynamicChannelId>) -> Self {
-        let mut flags = SOFT_SYNC_TCP_FLUSHED;
-        if !channel_ids.is_empty() {
-            flags |= SOFT_SYNC_CHANNEL_LIST_PRESENT;
-        }
+        let (flags, channel_lists) = if channel_ids.is_empty() {
+            (SOFT_SYNC_TCP_FLUSHED, vec![])
+        } else {
+            (
+                SOFT_SYNC_TCP_FLUSHED | SOFT_SYNC_CHANNEL_LIST_PRESENT,
+                vec![SoftSyncChannelList {
+                    tunnel_type: TUNNELTYPE_UDPFECR,
+                    channel_ids,
+                }],
+            )
+        };
         Self {
             header: Header::new(0, 0, Cmd::SoftSyncRequest),
             flags,
-            channel_lists: vec![SoftSyncChannelList {
-                tunnel_type: TUNNELTYPE_UDPFECR,
-                channel_ids,
-            }],
+            channel_lists,
         }
     }
 

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -389,3 +389,45 @@ AND released — #1276 landing is NOT sufficient.
     server. Verified on real mstsc: random cookie `f76fdf2b…`, "bound to session",
     tunnel establishes. One-time-use logic unit-tested in the macrdp crate
     (`cookie_registry_take_is_one_time_and_rejects_unknown`).
+    **M5b-2 (merged 2026-06-26, PR #34): server-side MS-RDPEDYC Soft-Sync codec.**
+    Vendored `ironrdp-dvc` (4th fork) gained `SoftSyncRequestPdu`/
+    `SoftSyncResponsePdu` + the `DrdynvcClientPdu::SoftSyncResponse` decode arm so
+    the client's Soft-Sync reply no longer tears the session down. No behavior
+    change here yet (codec only). See `vendor/ironrdp-dvc/CLAUDE.md`.
+    **M5c step 1+2 (added 2026-06-26): Soft-Sync gate + send (SAFE SPIKE — empty
+    channel list) — VERIFIED on real mstsc.** KEY FINDING (from the first live
+    run): **mstsc signals multitransport success by *creating the UDP tunnel*, NOT
+    by an Initiate Multitransport Response over TCP.** A TCP Initiate Response only
+    comes on *failure* (E_ABORT). So the success gate has to come from the
+    listener, not a message-channel PDU. Two pieces:
+    1. **Gate (listener-driven).** `MigrationState` gained `soft_sync_sent: bool`.
+       `CookieRegistry` now maps each cookie → a shared **tunnel-bound flag**
+       (`Arc<AtomicBool>`); the offer path keeps the flag (`RdpServer::
+       udp_tunnel_bound`), and the listener flips it `true` inside `take()` when it
+       binds the matching tunnel (cookie match). In the **EGFX dispatch arm**
+       (`ServerEvent::Egfx`, after shipping a frame), `maybe_soft_sync_on_egfx`
+       checks the flag: once the tunnel is bound AND EGFX is shipping (its DVC
+       channel is open, client fully in DVC mode), it sends the Soft-Sync request
+       exactly once (`soft_sync_sent` guard). This couples the trigger to the right
+       moment (tunnel up + EGFX live), which is also where the real migration will
+       hook. A SECONDARY TCP gate (`maybe_handle_multitransport_response` in
+       `handle_x224`'s `else` branch — message channel) still handles a client that
+       *does* send an Initiate Response (E_ABORT → stay on TCP; S_OK → also send),
+       but mstsc never exercises it. (The M1 `handle_io_channel_data` IO-channel
+       response-decode branch is legacy/dead for real clients, left harmless.)
+    2. **Send.** `send_soft_sync_request` ships a `DYNVC_SOFT_SYNC_REQUEST` as a
+       top-level `SvcMessage` on the drdynvc static channel (NOT sub-channel DATA —
+       so `SvcMessage::from(DrdynvcServerPdu::SoftSyncRequest(..))`, not
+       `encode_dvc_messages`). **Safe spike:** the request carries an EMPTY channel
+       list (`switch_to_udpfecr(vec![])` → TCP_FLUSHED only, NumberOfTunnels=0), so
+       it migrates nothing and video keeps flowing over TCP — it only proves the
+       send path + the client's Soft-Sync Response decode (M5b-2) without risk.
+    **Verified on real mstsc 2026-06-26:** "UDP tunnel bound + EGFX active —
+    Soft-Sync gate open" → "Sent DYNVC_SOFT_SYNC_REQUEST" → mstsc replied with a
+    `DYNVC_SOFT_SYNC_RESPONSE` (`tunnels: []`, decoded cleanly by the vendored
+    ironrdp-dvc — the M5b-2 fix proven on the wire) → **EGFX + audio kept flowing,
+    session ended only on the user's graceful disconnect.** The real migration
+    (list the EGFX channel id + the server→listener data handoff + route EGFX over
+    the tunnel as RDP_TUNNEL_DATA) is the next step. Watch
+    `RUST_LOG=...ironrdp_server::server=debug,ironrdp_dvc=debug` for the gate /
+    send / "Got DVC Soft-Sync Response" lines.

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -23,8 +23,8 @@
 
 pub mod listener;
 
-use core::sync::atomic::{AtomicU32, Ordering};
-use std::collections::HashSet;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
@@ -90,7 +90,7 @@ pub fn encode_initiate_request(
 /// removes a cookie when it accepts the tunnel, and the offer path evicts the
 /// previous connection's (unconsumed) cookie before registering a new one.
 #[derive(Clone, Default)]
-pub struct CookieRegistry(Arc<Mutex<HashSet<[u8; 16]>>>);
+pub struct CookieRegistry(Arc<Mutex<HashMap<[u8; 16], Arc<AtomicBool>>>>);
 
 impl CookieRegistry {
     /// A fresh, empty registry. Create one in `main` and share it (clone) with
@@ -99,27 +99,40 @@ impl CookieRegistry {
         Self::default()
     }
 
-    /// Register an issued cookie as valid.
-    pub fn insert(&self, cookie: [u8; 16]) {
-        if let Ok(mut set) = self.0.lock() {
-            set.insert(cookie);
+    /// Register an issued cookie as valid and return its **tunnel-bound flag**:
+    /// the listener sets it `true` when it binds the matching tunnel (M5c), and
+    /// the offer-issuing [`RdpServer`](crate::RdpServer) reads it to know the UDP
+    /// multitransport connection is up (the cue to send the Soft-Sync request).
+    pub fn register(&self, cookie: [u8; 16]) -> Arc<AtomicBool> {
+        let flag = Arc::new(AtomicBool::new(false));
+        if let Ok(mut map) = self.0.lock() {
+            map.insert(cookie, Arc::clone(&flag));
         }
+        flag
     }
 
-    /// Drop a cookie (consumed on tunnel bind, or evicted on teardown).
+    /// Drop a cookie (evicted on teardown / TCP fallback).
     pub fn remove(&self, cookie: &[u8; 16]) {
-        if let Ok(mut set) = self.0.lock() {
-            set.remove(cookie);
+        if let Ok(mut map) = self.0.lock() {
+            map.remove(cookie);
         }
     }
 
-    /// Atomically check-and-consume a cookie: returns `true` (and removes it) if
-    /// it was registered. One-time use — a retransmitted/replayed CREATEREQUEST
-    /// with the same cookie won't bind a second tunnel.
+    /// Atomically check-and-consume a cookie: returns `true` (and removes it,
+    /// **setting its tunnel-bound flag**) if it was registered. One-time use — a
+    /// retransmitted/replayed CREATEREQUEST with the same cookie won't bind a
+    /// second tunnel.
     pub fn take(&self, cookie: &[u8; 16]) -> bool {
-        match self.0.lock() {
-            Ok(mut set) => set.remove(cookie),
-            Err(_) => false,
+        let removed = match self.0.lock() {
+            Ok(mut map) => map.remove(cookie),
+            Err(_) => None,
+        };
+        match removed {
+            Some(flag) => {
+                flag.store(true, Ordering::Relaxed);
+                true
+            }
+            None => false,
         }
     }
 }
@@ -166,4 +179,8 @@ pub(crate) struct MigrationState {
     #[allow(dead_code)]
     pub cookie: [u8; 16],
     pub protocol: RequestedProtocol,
+    /// (M5c) Set once we've sent the `DYNVC_SOFT_SYNC_REQUEST` for this
+    /// connection, so a retransmitted Initiate Multitransport Response (or any
+    /// other message-channel PDU) doesn't make us re-send it.
+    pub soft_sync_sent: bool,
 }

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -350,6 +350,14 @@ pub struct RdpServer {
     /// CREATEREQUEST). Set once via `set_multitransport_cookie_registry`.
     #[cfg(feature = "multitransport")]
     multitransport_cookies: Option<crate::multitransport::CookieRegistry>,
+    /// (M5c) Shared per-connection flag the UDP listener sets `true` when it binds
+    /// this connection's tunnel (cookie match). The TCP side reads it to know the
+    /// UDP multitransport connection is up — the trigger to send the Soft-Sync
+    /// request that moves EGFX onto the tunnel. mstsc signals multitransport
+    /// success by *creating the tunnel*, NOT by an Initiate Response over TCP, so
+    /// this listener→server flag (not a message-channel PDU) is the real gate.
+    #[cfg(feature = "multitransport")]
+    udp_tunnel_bound: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
 
 #[derive(Debug)]
@@ -454,6 +462,8 @@ impl RdpServer {
             multitransport_migration: None,
             #[cfg(feature = "multitransport")]
             multitransport_cookies: None,
+            #[cfg(feature = "multitransport")]
+            udp_tunnel_bound: None,
         }
     }
 
@@ -665,7 +675,9 @@ impl RdpServer {
                 if let Some(prev) = self.multitransport_migration.as_ref() {
                     registry.remove(&prev.cookie);
                 }
-                registry.insert(offer.cookie);
+                // Keep the tunnel-bound flag: the listener flips it on a cookie
+                // match, and the EGFX dispatch path reads it to fire Soft-Sync.
+                self.udp_tunnel_bound = Some(registry.register(offer.cookie));
             }
             acceptor.set_advertise_extended_client_data(true);
             acceptor.set_multitransport_offer(Some(offer));
@@ -1127,6 +1139,11 @@ impl RdpServer {
                             .context("DRDYNVC channel not found")?;
                         let data = server_encode_svc_messages(messages, drdynvc_channel_id, user_channel_id)?;
                         writer.write_all(&data).await?;
+                        // (M5c) Now that EGFX is actively shipping (its DVC channel
+                        // is open) AND the UDP tunnel is bound, fire the Soft-Sync
+                        // request once — the cue to migrate EGFX onto the tunnel.
+                        #[cfg(feature = "multitransport")]
+                        self.maybe_soft_sync_on_egfx(writer, user_channel_id).await?;
                     }
                 },
                 ServerEvent::AutoDetectRttRequest => {
@@ -1407,6 +1424,124 @@ impl RdpServer {
         }
     }
 
+    /// (M5c) Try to interpret a message-channel PDU as the client's Initiate
+    /// Multitransport Response. Returns `true` if it WAS one (handled — caller
+    /// should not warn "Unexpected channel"). On `S_OK` — the UDP multitransport
+    /// connection (incl. our MS-RDPEMT tunnel) is established — this opens the
+    /// Soft-Sync gate and sends the `DYNVC_SOFT_SYNC_REQUEST` exactly once.
+    #[cfg(feature = "multitransport")]
+    async fn maybe_handle_multitransport_response(
+        &mut self,
+        writer: &mut impl FramedWrite,
+        user_data: &[u8],
+        user_channel_id: u16,
+    ) -> Result<bool> {
+        use ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu;
+
+        // The response is a BasicSecurityHeader-wrapped PDU (decode re-validates
+        // the TRANSPORT_RSP flag). If it doesn't decode, this wasn't a response —
+        // let the caller fall through to its "Unexpected channel" warning.
+        let Ok(resp) = decode::<MultitransportResponsePdu>(user_data) else {
+            return Ok(false);
+        };
+
+        let Some(state) = self.multitransport_migration.as_mut() else {
+            warn!(
+                request_id = resp.request_id,
+                "Initiate Multitransport Response with no request in flight; ignoring"
+            );
+            return Ok(true);
+        };
+        if state.request_id != resp.request_id {
+            warn!(
+                got = resp.request_id,
+                in_flight = state.request_id,
+                "Initiate Multitransport Response request_id mismatch; ignoring"
+            );
+            return Ok(true);
+        }
+        if !resp.is_success() {
+            debug!(
+                request_id = resp.request_id,
+                hr = format_args!("{:#010x}", resp.hr_response),
+                "Initiate Multitransport Response: client could not establish UDP; staying on TCP"
+            );
+            self.multitransport_migration = None;
+            return Ok(true);
+        }
+        if state.soft_sync_sent {
+            debug!(
+                request_id = resp.request_id,
+                "Initiate Multitransport Response S_OK (Soft-Sync already sent); ignoring retransmit"
+            );
+            return Ok(true);
+        }
+        state.soft_sync_sent = true;
+        debug!(
+            request_id = resp.request_id,
+            "Initiate Multitransport Response S_OK — Soft-Sync gate open"
+        );
+        self.send_soft_sync_request(writer, user_channel_id).await?;
+        Ok(true)
+    }
+
+    /// (M5c) Called from the EGFX dispatch path. If the UDP tunnel is bound (the
+    /// listener flipped our shared flag on a cookie match) and we haven't sent the
+    /// Soft-Sync yet, send it now — EGFX shipping means its DVC channel is open and
+    /// the client is fully in DVC mode, the right moment to begin the migration.
+    /// This (not a TCP Initiate Response) is the real success gate: mstsc signals
+    /// multitransport success by creating the tunnel, never by a TCP response.
+    #[cfg(feature = "multitransport")]
+    async fn maybe_soft_sync_on_egfx(
+        &mut self,
+        writer: &mut impl FramedWrite,
+        user_channel_id: u16,
+    ) -> Result<()> {
+        let bound = self
+            .udp_tunnel_bound
+            .as_ref()
+            .is_some_and(|f| f.load(Ordering::Relaxed));
+        if !bound {
+            return Ok(());
+        }
+        let Some(state) = self.multitransport_migration.as_mut() else {
+            return Ok(());
+        };
+        if state.soft_sync_sent {
+            return Ok(());
+        }
+        state.soft_sync_sent = true;
+        debug!("UDP tunnel bound + EGFX active — Soft-Sync gate open");
+        self.send_soft_sync_request(writer, user_channel_id).await
+    }
+
+    /// (M5c) Send a `DYNVC_SOFT_SYNC_REQUEST` over the DRDYNVC static channel on
+    /// TCP. **Safe spike:** an EMPTY channel list (TCP_FLUSHED only) — it
+    /// exercises the send path and the client's Soft-Sync Response decode without
+    /// actually migrating any DVC, so video keeps flowing over TCP. The real
+    /// migration (listing the EGFX channel id) layers on once this is proven.
+    #[cfg(feature = "multitransport")]
+    async fn send_soft_sync_request(
+        &mut self,
+        writer: &mut impl FramedWrite,
+        user_channel_id: u16,
+    ) -> Result<()> {
+        let Some(drdynvc_channel_id) = self.get_channel_id_by_type::<dvc::DrdynvcServer>() else {
+            warn!("No DRDYNVC channel; cannot send Soft-Sync request");
+            return Ok(());
+        };
+
+        let req = dvc::pdu::SoftSyncRequestPdu::switch_to_udpfecr(Vec::new());
+        let pdu = dvc::pdu::DrdynvcServerPdu::SoftSyncRequest(req);
+        // Soft-Sync is a top-level DRDYNVC PDU (not sub-channel DATA), so it ships
+        // as a plain SvcMessage on the drdynvc static channel.
+        let msg = ironrdp_svc::SvcMessage::from(pdu).with_flags(ChannelFlags::SHOW_PROTOCOL);
+        let data = server_encode_svc_messages(vec![msg], drdynvc_channel_id, user_channel_id)?;
+        writer.write_all(&data).await?;
+        debug!("Sent DYNVC_SOFT_SYNC_REQUEST (M5c safe spike: empty channel list)");
+        Ok(())
+    }
+
     async fn client_accepted<R, W>(
         &mut self,
         reader: &mut Framed<R>,
@@ -1462,6 +1597,7 @@ impl RdpServer {
                     request_id: offer.request_id,
                     cookie: offer.cookie,
                     protocol: offer.protocol,
+                    soft_sync_sent: false,
                 });
                 debug!(
                     request_id = offer.request_id,
@@ -1736,6 +1872,18 @@ impl RdpServer {
                     let response = server_encode_svc_messages(response_pdus, data.channel_id, user_channel_id)?;
                     writer.write_all(&response).await?;
                 } else {
+                    // (vendored, feature=multitransport) The client's Initiate
+                    // Multitransport Response rides the MCS message channel (granted
+                    // by the acceptor when an offer is active, M3c), so it lands here
+                    // rather than on the IO channel or a static channel. On S_OK it's
+                    // the gate to begin Soft-Sync (move EGFX onto the UDP tunnel).
+                    #[cfg(feature = "multitransport")]
+                    if self
+                        .maybe_handle_multitransport_response(writer, data.user_data.as_ref(), user_channel_id)
+                        .await?
+                    {
+                        return Ok(false);
+                    }
                     warn!(channel_id = data.channel_id, "Unexpected channel received: ID",);
                 }
             }


### PR DESCRIPTION
## What

Sends a `DYNVC_SOFT_SYNC_REQUEST` to the client once the UDP multitransport tunnel is up — the cue that will (next step) migrate EGFX onto the tunnel. This is a **safe spike**: the request carries an **empty channel list** (flush TCP, migrate nothing), so video keeps flowing over TCP. It only proves the send path + the client's Soft-Sync Response decode (M5b-2) end-to-end, with zero risk to the live session.

## Key finding

From the first live mstsc run: **mstsc signals multitransport success by *creating the UDP tunnel*, NOT by an Initiate Multitransport Response over TCP** — that TCP response only comes on *failure* (E_ABORT). So the success gate has to come from the listener, not a message-channel PDU.

## How

- `CookieRegistry` now maps each issued cookie → a shared **tunnel-bound flag** (`Arc<AtomicBool>`). The offer path keeps the flag (`RdpServer::udp_tunnel_bound`); the listener flips it `true` inside `take()` when it binds the matching tunnel (cookie match).
- In the **EGFX dispatch arm**, `maybe_soft_sync_on_egfx` fires the Soft-Sync request once the flag is set **and** EGFX is shipping (DVC channel open, client fully in DVC mode) — guarded by `MigrationState::soft_sync_sent` so it sends exactly once. That couples the trigger to the right moment, which is also where the real migration will hook.
- A secondary TCP gate (`maybe_handle_multitransport_response`, in `handle_x224`'s message-channel else branch) still handles a client that *does* send an Initiate Response (E_ABORT → stay on TCP; S_OK → send), but mstsc never exercises it.
- `send_soft_sync_request` ships the PDU as a top-level `SvcMessage` on the drdynvc static channel (not sub-channel DATA).
- `switch_to_udpfecr(vec![])` now encodes a clean flush-only probe (no list, `NumberOfTunnels=0`); byte-exact test added.

## Verification (real mstsc, Win11 over WiFi LAN)

```
UDP tunnel bound + EGFX active — Soft-Sync gate open
Sent DYNVC_SOFT_SYNC_REQUEST (M5c safe spike: empty channel list)
Got DVC Soft-Sync Response PDU: SoftSyncResponsePdu { ... tunnels: [] }
```

mstsc replied with a `DYNVC_SOFT_SYNC_RESPONSE` (`tunnels: []`), decoded cleanly by the vendored ironrdp-dvc (the M5b-2 fix proven on the wire — without it this PDU would tear the session down). **EGFX + audio kept flowing**; the session ended only on the user's graceful disconnect.

`cargo test` (70 pass) · clippy clean · release build + sign OK.

## Next

The real migration: list the EGFX channel id in the Soft-Sync request + the server→listener data handoff + route EGFX over the tunnel as `RDP_TUNNEL_DATA`.