### PR TITLE
M5c step 3a — EGFX migration request + outbound tunnel route (mstsc accepts the switch)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2126,11 +2126,16 @@ async fn async_main() -> Result<()> {
         // session. The server registers each issued cookie here; the listener
         // accepts a tunnel CREATEREQUEST only if its echoed cookie matches.
         let cookie_registry = ironrdp_server::CookieRegistry::new();
+        // M5c: the server→listener handoff. The server pushes EGFX frames (when
+        // migrated onto the tunnel) through the sender; the listener owns the rx
+        // and ships them as RDP_TUNNEL_DATA over the bound peer's UDP tunnel.
+        let (tunnel_sender, tunnel_rx) = ironrdp_server::tunnel_channel();
         match ironrdp_server::UdpMultitransportListener::bind(
             args.bind,
             cfg,
             Some(udp_tls_config.clone()),
             Some(cookie_registry.clone()),
+            Some(tunnel_rx),
         )
         .await
         {
@@ -2143,6 +2148,7 @@ async fn async_main() -> Result<()> {
                 server
                     .set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));
                 server.set_multitransport_cookie_registry(Some(cookie_registry));
+                server.set_multitransport_tunnel_sender(Some(tunnel_sender));
                 Some(listener)
             }
             Err(e) => {

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -208,10 +208,10 @@ mod tests {
         ];
 
         let cfg = ListenerConfig::default();
-        // No TLS config and no cookie registry: this test only exercises the
-        // SYN→SYN+ACK handshake (soft cookie binding).
+        // No TLS config, no cookie registry, no tunnel handoff: this test only
+        // exercises the SYN→SYN+ACK handshake (soft cookie binding).
         let listener =
-            UdpMultitransportListener::bind("127.0.0.1:0".parse().unwrap(), cfg, None, None)
+            UdpMultitransportListener::bind("127.0.0.1:0".parse().unwrap(), cfg, None, None, None)
                 .await
                 .expect("bind listener");
         let server_addr = listener.local_addr();

--- a/vendor/ironrdp-dvc/src/server.rs
+++ b/vendor/ironrdp-dvc/src/server.rs
@@ -85,6 +85,17 @@ impl DrdynvcServer {
         self.type_id_to_channel_id.get(&TypeId::of::<T>()).copied()
     }
 
+    /// (macrdp divergence) Find a dynamic channel's id by its announced name (e.g.
+    /// `"Microsoft::Windows::RDS::Graphics"` for EGFX). Used by the multitransport
+    /// path to name the DVC in a Soft-Sync request without needing its concrete
+    /// processor type. Returns the first match (channel names are unique).
+    pub fn get_channel_id_by_name(&self, name: &str) -> Option<u32> {
+        self.dynamic_channels
+            .iter()
+            .find(|(_, c)| c.processor.channel_name() == name)
+            .and_then(|(id, _)| u32::try_from(id).ok())
+    }
+
     /// Returns `true` if the DVC channel with the given ID has completed
     /// its creation handshake and is in the `Opened` state.
     pub fn is_channel_opened(&self, channel_id: u32) -> bool {

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -431,3 +431,47 @@ AND released — #1276 landing is NOT sufficient.
     the tunnel as RDP_TUNNEL_DATA) is the next step. Watch
     `RUST_LOG=...ironrdp_server::server=debug,ironrdp_dvc=debug` for the gate /
     send / "Got DVC Soft-Sync Response" lines.
+    **M5c step 3a (added 2026-06-26): real EGFX migration request + outbound
+    server→tunnel route — migration ACCEPTED by real mstsc.** Behind a second env
+    gate `MACRDP_UDP_MIGRATE_EGFX` (default OFF; when off, the M5c step-1+2 empty
+    safe spike is byte-for-byte unchanged — verified no-regression on mstsc). When
+    set:
+    1. **Name the EGFX DVC in the Soft-Sync.** `DrdynvcServer` gained
+       `get_channel_id_by_name` (vendored `ironrdp-dvc`); `maybe_soft_sync_on_egfx`
+       looks up `"Microsoft::Windows::RDS::Graphics"`, sets `RdpServer::egfx_on_udp`,
+       and sends `switch_to_udpfecr(vec![gfx_id])` (TCP_FLUSHED|CHANNEL_LIST_PRESENT).
+    2. **Outbound handoff (server→listener).** New `tunnel_channel()` →
+       (`TunnelSender`, `UnboundedReceiver<TunnelOutbound>`); `RdpServer` gained
+       `multitransport_tunnel_sender` (setter `set_multitransport_tunnel_sender`).
+       The `ServerEvent::Egfx` dispatch arm, when `egfx_on_udp`, calls
+       `route_egfx_over_udp` — `StaticVirtualChannel::chunkify(messages)` → each
+       chunk handed to the sender keyed by the connection's migration cookie
+       (instead of `server_encode_svc_messages` over TCP). The listener's recv loop
+       is now bidirectional (`tokio::select!` recv + an outbound arm); `ship_outbound`
+       wraps each chunk in `RDP_TUNNEL_DATA` (`emt::encode_tunnel_data`), encrypts
+       through the peer's MS-RDPEMT TLS, and ships it reliably over RDPEUDP (peer
+       looked up by cookie via `bound_addrs`, populated when `handle_emt_tunnel`
+       binds the tunnel). `main.rs` wires `tunnel_channel()` → sender to the server,
+       rx to `bind`. `TunnelOutbound` is `pub` (it leaks through the public `bind`
+       signature); when the feature/flag is off the outbound arm is just a
+       never-ready future, so the recv-only path is unchanged.
+    **VERIFIED on real mstsc 2026-06-26 — migration accepted, NOT yet rendering:**
+    `Sent DYNVC_SOFT_SYNC_REQUEST (migrating EGFX onto the UDP tunnel) gfx_channel_id=3`
+    → mstsc replied `DYNVC_SOFT_SYNC_RESPONSE { tunnels: [1] }` (**it agreed to
+    switch the EGFX channel onto the reliable UDP tunnel** — the migration request
+    is wire-correct). Then the session froze (~300 ms) and the user disconnected.
+    **Root cause (diagnosed, this is step 3b):** after migration EGFX is
+    bidirectional over the tunnel — mstsc's **frame acknowledgements** come back as
+    inbound `RDP_TUNNEL_DATA` (`action=2 len=10`, logged "not handled yet"), and we
+    drop them; macrdp's H.264 ship loop gates on frame acks (`max_in_flight=2`), so
+    after ~2 unacked frames it stalls → frozen video. The OUTBOUND route + the
+    migration handshake are proven; the missing piece is the **inbound tunnel →
+    drdynvc path**: un-tunnel the HigherLayerData (an SVC channel-data blob =
+    `CHANNEL_PDU_HEADER` + DRDYNVC PDU, identical to what `handle_x224` feeds
+    `svc.process(&data.user_data)` over TCP), route it back to the owning
+    connection's `client_loop` (a per-cookie reverse channel), and run it through
+    the drdynvc `StaticVirtualChannel::process` so the EGFX handler sees the acks
+    (shipping any reply PDUs back over the tunnel). That reverse handoff is M5c
+    step 3b. Watch the gate/send lines plus
+    `MACRDP_UDP_MIGRATE_EGFX: Soft-Sync will migrate the EGFX DVC` and (listener)
+    `MS-RDPEMT tunnel PDU not handled yet … action=2`.

--- a/vendor/ironrdp-server/src/lib.rs
+++ b/vendor/ironrdp-server/src/lib.rs
@@ -38,7 +38,7 @@ pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "multitransport")]
 pub use multitransport::listener::{ListenerConfig, UdpMultitransportListener};
 #[cfg(feature = "multitransport")]
-pub use multitransport::{CookieRegistry, MultitransportProvider, encode_initiate_request};
+pub use multitransport::{CookieRegistry, MultitransportProvider, TunnelSender, encode_initiate_request, tunnel_channel};
 pub use rdpdr::{
     AnnouncedDevice, DirEntry, RdpdrBackendFactory, RdpdrHandle, RdpdrServer, RdpdrServerFactory, RdpdrServerHandler,
     RdpdrServerMessage, RdpdrStatus, SCARD_EJECT_CARD, SCARD_LEAVE_CARD, SCARD_RESET_CARD, SCARD_SHARE_DIRECT,

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -37,8 +37,9 @@ use ironrdp_rdpeudp::datagram::Datagram;
 use ironrdp_rdpeudp::pdu::FecFlags;
 use ironrdp_rdpeudp::state::{Config, RdpeudpState, Role};
 
-use crate::multitransport::CookieRegistry;
+use crate::multitransport::{CookieRegistry, TunnelOutbound};
 use tokio::net::UdpSocket;
+use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::task::JoinHandle;
 use tokio_rustls::rustls::{ServerConfig, ServerConnection};
 use tracing::{debug, trace, warn};
@@ -125,6 +126,7 @@ impl UdpMultitransportListener {
         cfg: ListenerConfig,
         tls_config: Option<Arc<ServerConfig>>,
         cookie_registry: Option<CookieRegistry>,
+        tunnel_rx: Option<UnboundedReceiver<TunnelOutbound>>,
     ) -> io::Result<Self> {
         let socket = UdpSocket::bind(addr).await?;
         let local_addr = socket.local_addr()?;
@@ -133,6 +135,7 @@ impl UdpMultitransportListener {
             %local_addr, ?cfg,
             tls = tls_config.is_some(),
             cookie_binding = cookie_registry.is_some(),
+            tunnel_handoff = tunnel_rx.is_some(),
             "RDPEUDP multitransport listener bound"
         );
         let task = tokio::spawn(run_recv_loop(
@@ -140,6 +143,7 @@ impl UdpMultitransportListener {
             cfg,
             tls_config,
             cookie_registry,
+            tunnel_rx,
         ));
         Ok(Self { local_addr, task })
     }
@@ -176,6 +180,53 @@ async fn send_datagrams(socket: &UdpSocket, peer_addr: SocketAddr, to_send: Vec<
     }
 }
 
+/// (M5c) Ship one server-originated HigherLayerData chunk to a bound peer: wrap it
+/// in `RDP_TUNNEL_DATA` (action 0x2), encrypt through the peer's MS-RDPEMT TLS, and
+/// send the resulting ciphertext reliably over RDPEUDP. Best-effort — an unbound
+/// cookie / unknown peer / no-TLS peer / write error is logged and dropped (the
+/// tunnel is the optional UDP fast-path; the TCP path remains authoritative).
+async fn ship_outbound(
+    socket: &UdpSocket,
+    peers: &mut HashMap<SocketAddr, Peer>,
+    bound_addrs: &HashMap<[u8; 16], SocketAddr>,
+    cookie: [u8; 16],
+    higher_layer: &[u8],
+    now_ms: u64,
+    mtu: u16,
+) {
+    use ironrdp_rdpeudp::emt;
+
+    let Some(&peer_addr) = bound_addrs.get(&cookie) else {
+        trace!("tunnel data for an unbound cookie; dropping");
+        return;
+    };
+    let Some(peer) = peers.get_mut(&peer_addr) else {
+        trace!(%peer_addr, "tunnel data for an unknown peer; dropping");
+        return;
+    };
+    let Peer { sm, tls, .. } = peer;
+    let Some(tls) = tls.as_mut() else {
+        warn!(%peer_addr, "tunnel data to a peer with no TLS; dropping");
+        return;
+    };
+
+    let pdu = emt::encode_tunnel_data(higher_layer);
+    if tls.writer().write_all(&pdu).is_err() {
+        warn!(%peer_addr, "failed to write RDP_TUNNEL_DATA into TLS");
+        return;
+    }
+    let mut tls_out = Vec::new();
+    while tls.wants_write() {
+        if tls.write_tls(&mut tls_out).is_err() {
+            break;
+        }
+    }
+    if !tls_out.is_empty() {
+        let o = sm.enqueue(now_ms, &tls_out);
+        send_datagrams(socket, peer_addr, o.to_send, mtu).await;
+    }
+}
+
 /// Parse complete MS-RDPEMT tunnel PDUs from the TLS-decrypted plaintext and, on
 /// the client's `RDP_TUNNEL_CREATEREQUEST`, write a `CREATERESPONSE(S_OK)` into
 /// the TLS connection (its encrypted bytes are picked up by the caller's
@@ -196,8 +247,12 @@ fn handle_emt_tunnel(
     buf: &mut Vec<u8>,
     tunnel_created: &mut bool,
     cookie_registry: Option<&CookieRegistry>,
-) {
+) -> Option<[u8; 16]> {
     use ironrdp_rdpeudp::emt::{self, TunnelCreateRequest, TunnelCreateResponse};
+
+    // The cookie of a tunnel bound during this call, so the caller can map it to
+    // this peer address for the server→listener data handoff (M5c).
+    let mut bound_cookie: Option<[u8; 16]> = None;
 
     while let Some(total) = emt::peek_pdu_len(buf) {
         if buf.len() < total {
@@ -238,6 +293,7 @@ fn handle_emt_tunnel(
                         let resp = TunnelCreateResponse::ok().to_vec();
                         if tls.writer().write_all(&resp).is_ok() {
                             *tunnel_created = true;
+                            bound_cookie = Some(req.security_cookie);
                         } else {
                             warn!(%peer_addr, "failed to write MS-RDPEMT CREATERESPONSE into TLS");
                         }
@@ -258,6 +314,8 @@ fn handle_emt_tunnel(
             None => break,
         }
     }
+
+    bound_cookie
 }
 
 async fn run_recv_loop(
@@ -265,19 +323,48 @@ async fn run_recv_loop(
     cfg: ListenerConfig,
     tls_config: Option<Arc<ServerConfig>>,
     cookie_registry: Option<CookieRegistry>,
+    mut tunnel_rx: Option<UnboundedReceiver<TunnelOutbound>>,
 ) {
     let mut peers: HashMap<SocketAddr, Peer> = HashMap::new();
+    // (M5c) cookie -> peer address, populated when a tunnel binds, so
+    // server-originated `TunnelOutbound` (keyed by cookie) reaches the right peer.
+    let mut bound_addrs: HashMap<[u8; 16], SocketAddr> = HashMap::new();
     let mut session_counter: u32 = 0;
     let start = tokio::time::Instant::now();
     let mut buf = vec![0u8; 2048];
 
     loop {
-        let (len, peer_addr) = match socket.recv_from(&mut buf).await {
-            Ok(v) => v,
-            // UDP recv_from can surface a prior send_to's ICMP error (e.g. a
-            // ConnReset on Windows); it's per-datagram, so keep serving.
-            Err(e) => {
-                trace!(error = %e, "udp recv_from error; continuing");
+        // (M5c) The recv loop is now bidirectional: it reads inbound datagrams AND
+        // ships server-originated channel data (EGFX over the tunnel). When no
+        // handoff channel is wired, the outbound arm is a never-ready future, so
+        // behavior is identical to the recv-only path.
+        let outbound = async {
+            match tunnel_rx.as_mut() {
+                Some(rx) => rx.recv().await,
+                None => std::future::pending().await,
+            }
+        };
+
+        let (len, peer_addr) = tokio::select! {
+            recv = socket.recv_from(&mut buf) => match recv {
+                Ok(v) => v,
+                // UDP recv_from can surface a prior send_to's ICMP error (e.g. a
+                // ConnReset on Windows); it's per-datagram, so keep serving.
+                Err(e) => {
+                    trace!(error = %e, "udp recv_from error; continuing");
+                    continue;
+                }
+            },
+            out = outbound => {
+                let now_ms = start.elapsed().as_millis() as u64;
+                match out {
+                    Some(TunnelOutbound { cookie, data }) => {
+                        ship_outbound(&socket, &mut peers, &bound_addrs, cookie, &data, now_ms, cfg.mtu).await;
+                    }
+                    // Sender dropped: the owning connection went away. Nothing more
+                    // will be sent over the tunnel; keep serving inbound.
+                    None => tunnel_rx = None,
+                }
                 continue;
             }
         };
@@ -444,13 +531,17 @@ async fn run_recv_loop(
                     // response into the TLS connection here means the wants_write
                     // drain below picks up its encrypted bytes. M5a: bind the
                     // tunnel to a real TCP session via the cookie registry.
-                    handle_emt_tunnel(
+                    if let Some(cookie) = handle_emt_tunnel(
                         peer_addr,
                         tls,
                         emt_inbound,
                         tunnel_created,
                         cookie_registry.as_ref(),
-                    );
+                    ) {
+                        // (M5c) Record cookie -> this peer so server-originated
+                        // tunnel data (keyed by the same cookie) reaches it.
+                        bound_addrs.insert(cookie, peer_addr);
+                    }
 
                     while tls.wants_write() {
                         if tls.write_tls(&mut tls_out).is_err() {

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -166,6 +166,43 @@ pub(crate) fn new_offer(protocol: RequestedProtocol) -> MultitransportOffer {
     }
 }
 
+/// (M5c) One unit of server-originated data to ship over a bound UDP tunnel: the
+/// `cookie` selects which peer (the listener maps cookie → peer address on bind),
+/// and `data` is the **HigherLayerData** for an `RDP_TUNNEL_DATA` PDU (one SVC
+/// channel-data chunk — `CHANNEL_PDU_HEADER` + the DRDYNVC PDU — the same bytes
+/// that would otherwise ride the drdynvc static channel over TCP). The listener
+/// wraps it in `RDP_TUNNEL_DATA`, encrypts via the peer's MS-RDPEMT TLS, and sends
+/// it reliably over RDPEUDP.
+#[derive(Debug)]
+pub struct TunnelOutbound {
+    pub cookie: [u8; 16],
+    pub data: Vec<u8>,
+}
+
+/// (M5c) Clonable handle the per-connection [`RdpServer`](crate::RdpServer) uses to
+/// push channel data onto the process-global UDP listener's bound tunnel (the
+/// server→listener handoff). The listener owns the receiving end. Best-effort: a
+/// send failure (listener gone / channel full-less unbounded) is dropped — the
+/// channel is for the optional UDP fast-path, never the correctness-critical TCP
+/// path.
+#[derive(Clone)]
+pub struct TunnelSender(tokio::sync::mpsc::UnboundedSender<TunnelOutbound>);
+
+impl TunnelSender {
+    /// Queue one HigherLayerData chunk for the peer bound to `cookie`.
+    pub(crate) fn send(&self, cookie: [u8; 16], data: Vec<u8>) {
+        let _ = self.0.send(TunnelOutbound { cookie, data });
+    }
+}
+
+/// (M5c) Create the server→listener handoff channel. Hand the [`TunnelSender`] to
+/// the [`RdpServer`](crate::RdpServer) (via `set_multitransport_tunnel_sender`) and
+/// the receiver to [`UdpMultitransportListener::bind`](crate::multitransport::listener::UdpMultitransportListener::bind).
+pub fn tunnel_channel() -> (TunnelSender, tokio::sync::mpsc::UnboundedReceiver<TunnelOutbound>) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    (TunnelSender(tx), rx)
+}
+
 /// Per-connection negotiation state for an in-flight multitransport request:
 /// the `request_id` + 16-byte security cookie the server issued in the
 /// `MultitransportRequestPdu`, used to match the client's

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -281,6 +281,22 @@ impl DisplayControlHandler for DisplayControlBackend {
 /// Ok(())
 ///# }
 /// ```
+/// (M5c) The EGFX dynamic virtual channel's announced name (MS-RDPEGFX). Used to
+/// find its DVC id so it can be named in a Soft-Sync request.
+#[cfg(feature = "multitransport")]
+const EGFX_DVC_CHANNEL_NAME: &str = "Microsoft::Windows::RDS::Graphics";
+
+/// (M5c) EXPERIMENTAL: whether to actually migrate the EGFX channel onto the UDP
+/// tunnel (vs. the proven safe spike that sends an empty Soft-Sync and keeps EGFX
+/// on TCP). Gated on the `MACRDP_UDP_MIGRATE_EGFX` env var so the default build
+/// behaves exactly as the verified M5c step-1+2. Read once and cached.
+#[cfg(feature = "multitransport")]
+fn migrate_egfx_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("MACRDP_UDP_MIGRATE_EGFX").is_some())
+}
+
 pub struct RdpServer {
     opts: RdpServerOptions,
     // FIXME: replace with a channel and poll/process the handler?
@@ -358,6 +374,16 @@ pub struct RdpServer {
     /// this listener→server flag (not a message-channel PDU) is the real gate.
     #[cfg(feature = "multitransport")]
     udp_tunnel_bound: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// (M5c) Handoff to the process-global UDP listener for shipping channel data
+    /// (EGFX) over the bound tunnel. `None` = no UDP data path (EGFX stays on TCP).
+    #[cfg(feature = "multitransport")]
+    multitransport_tunnel_sender: Option<crate::multitransport::TunnelSender>,
+    /// (M5c) Set once a Soft-Sync request has migrated the EGFX DVC channel to the
+    /// UDP tunnel — from then on EGFX frames route over UDP, not TCP. Only ever set
+    /// when the experimental `MACRDP_UDP_MIGRATE_EGFX` env flag is on; the default
+    /// path leaves EGFX on TCP (the proven empty-Soft-Sync spike).
+    #[cfg(feature = "multitransport")]
+    egfx_on_udp: bool,
 }
 
 #[derive(Debug)]
@@ -464,6 +490,10 @@ impl RdpServer {
             multitransport_cookies: None,
             #[cfg(feature = "multitransport")]
             udp_tunnel_bound: None,
+            #[cfg(feature = "multitransport")]
+            multitransport_tunnel_sender: None,
+            #[cfg(feature = "multitransport")]
+            egfx_on_udp: false,
         }
     }
 
@@ -544,6 +574,16 @@ impl RdpServer {
         registry: Option<crate::multitransport::CookieRegistry>,
     ) {
         self.multitransport_cookies = registry;
+    }
+
+    /// (M5c) Install the handoff to the UDP listener so the server can ship channel
+    /// data (EGFX) over a bound multitransport tunnel. Pair it with the matching
+    /// receiver passed to
+    /// [`UdpMultitransportListener::bind`](crate::multitransport::listener::UdpMultitransportListener::bind)
+    /// (both from one [`tunnel_channel`](crate::multitransport::tunnel_channel)).
+    #[cfg(feature = "multitransport")]
+    pub fn set_multitransport_tunnel_sender(&mut self, sender: Option<crate::multitransport::TunnelSender>) {
+        self.multitransport_tunnel_sender = sender;
     }
 
     /// Returns the shared ECHO server handle for runtime probe requests and RTT measurements.
@@ -1134,6 +1174,15 @@ impl RdpServer {
                 #[cfg(feature = "egfx")]
                 ServerEvent::Egfx(msg) => match msg {
                     EgfxServerMessage::SendMessages { messages } => {
+                        // (M5c) Once EGFX has been migrated onto the UDP tunnel
+                        // (`egfx_on_udp`, only under MACRDP_UDP_MIGRATE_EGFX), route
+                        // its frames over the tunnel instead of the TCP drdynvc
+                        // channel. Default path is unchanged TCP.
+                        #[cfg(feature = "multitransport")]
+                        if self.egfx_on_udp {
+                            self.route_egfx_over_udp(messages)?;
+                            continue;
+                        }
                         let drdynvc_channel_id = self
                             .get_channel_id_by_type::<dvc::DrdynvcServer>()
                             .context("DRDYNVC channel not found")?;
@@ -1481,7 +1530,10 @@ impl RdpServer {
             request_id = resp.request_id,
             "Initiate Multitransport Response S_OK — Soft-Sync gate open"
         );
-        self.send_soft_sync_request(writer, user_channel_id).await?;
+        // Secondary TCP gate (a client that *does* send an Initiate Response S_OK
+        // — mstsc never does). Keep it an empty spike: EGFX migration is driven by
+        // the listener-bound gate (`maybe_soft_sync_on_egfx`), not this path.
+        self.send_soft_sync_request(writer, user_channel_id, Vec::new()).await?;
         Ok(true)
     }
 
@@ -1504,41 +1556,97 @@ impl RdpServer {
         if !bound {
             return Ok(());
         }
-        let Some(state) = self.multitransport_migration.as_mut() else {
-            return Ok(());
-        };
-        if state.soft_sync_sent {
-            return Ok(());
+        // One-time guard (drops the &mut borrow before the get_svc_processor below).
+        match self.multitransport_migration.as_mut() {
+            Some(state) if !state.soft_sync_sent => state.soft_sync_sent = true,
+            _ => return Ok(()),
         }
-        state.soft_sync_sent = true;
+
+        // EXPERIMENTAL (`MACRDP_UDP_MIGRATE_EGFX`): name the EGFX DVC in the request
+        // so the client actually moves it onto the UDP tunnel, and flip
+        // `egfx_on_udp` so subsequent frames route over UDP. Default (flag off) is
+        // the proven safe spike — an empty channel list, EGFX stays on TCP.
+        let channel_ids = if migrate_egfx_enabled() {
+            match self
+                .get_svc_processor::<dvc::DrdynvcServer>()
+                .and_then(|d| d.get_channel_id_by_name(EGFX_DVC_CHANNEL_NAME))
+            {
+                Some(id) => {
+                    self.egfx_on_udp = true;
+                    debug!(
+                        gfx_channel_id = id,
+                        "MACRDP_UDP_MIGRATE_EGFX: Soft-Sync will migrate the EGFX DVC onto the UDP tunnel"
+                    );
+                    vec![id]
+                }
+                None => {
+                    warn!("MACRDP_UDP_MIGRATE_EGFX set but EGFX DVC channel not found; sending empty Soft-Sync");
+                    Vec::new()
+                }
+            }
+        } else {
+            Vec::new()
+        };
         debug!("UDP tunnel bound + EGFX active — Soft-Sync gate open");
-        self.send_soft_sync_request(writer, user_channel_id).await
+        self.send_soft_sync_request(writer, user_channel_id, channel_ids).await
     }
 
     /// (M5c) Send a `DYNVC_SOFT_SYNC_REQUEST` over the DRDYNVC static channel on
-    /// TCP. **Safe spike:** an EMPTY channel list (TCP_FLUSHED only) — it
-    /// exercises the send path and the client's Soft-Sync Response decode without
-    /// actually migrating any DVC, so video keeps flowing over TCP. The real
-    /// migration (listing the EGFX channel id) layers on once this is proven.
+    /// TCP. `channel_ids` are the DVC channels to migrate onto the reliable UDP
+    /// tunnel — **empty** is the safe spike (TCP_FLUSHED only, migrate nothing, so
+    /// everything stays on TCP); a non-empty list (the EGFX id) commits those
+    /// channels' data to the tunnel.
     #[cfg(feature = "multitransport")]
     async fn send_soft_sync_request(
         &mut self,
         writer: &mut impl FramedWrite,
         user_channel_id: u16,
+        channel_ids: Vec<u32>,
     ) -> Result<()> {
         let Some(drdynvc_channel_id) = self.get_channel_id_by_type::<dvc::DrdynvcServer>() else {
             warn!("No DRDYNVC channel; cannot send Soft-Sync request");
             return Ok(());
         };
 
-        let req = dvc::pdu::SoftSyncRequestPdu::switch_to_udpfecr(Vec::new());
+        let migrating = !channel_ids.is_empty();
+        let req = dvc::pdu::SoftSyncRequestPdu::switch_to_udpfecr(channel_ids);
         let pdu = dvc::pdu::DrdynvcServerPdu::SoftSyncRequest(req);
         // Soft-Sync is a top-level DRDYNVC PDU (not sub-channel DATA), so it ships
         // as a plain SvcMessage on the drdynvc static channel.
         let msg = ironrdp_svc::SvcMessage::from(pdu).with_flags(ChannelFlags::SHOW_PROTOCOL);
         let data = server_encode_svc_messages(vec![msg], drdynvc_channel_id, user_channel_id)?;
         writer.write_all(&data).await?;
-        debug!("Sent DYNVC_SOFT_SYNC_REQUEST (M5c safe spike: empty channel list)");
+        if migrating {
+            debug!("Sent DYNVC_SOFT_SYNC_REQUEST (migrating EGFX onto the UDP tunnel)");
+        } else {
+            debug!("Sent DYNVC_SOFT_SYNC_REQUEST (empty channel list — EGFX stays on TCP)");
+        }
+        Ok(())
+    }
+
+    /// (M5c) Route one EGFX frame's DVC messages over the bound UDP tunnel instead
+    /// of TCP: chunk them to SVC channel-data (`CHANNEL_PDU_HEADER` + DRDYNVC PDU,
+    /// the HigherLayerData the tunnel carries) and hand each chunk to the listener
+    /// (keyed by this connection's cookie). Best-effort — if the handoff or cookie
+    /// is missing the frame is dropped (the experimental UDP path; only reached
+    /// when `egfx_on_udp` was set under `MACRDP_UDP_MIGRATE_EGFX`).
+    #[cfg(feature = "multitransport")]
+    fn route_egfx_over_udp(&self, messages: Vec<ironrdp_svc::SvcMessage>) -> Result<()> {
+        let Some(sender) = self.multitransport_tunnel_sender.as_ref() else {
+            warn!("egfx_on_udp set but no tunnel sender; dropping EGFX frame");
+            return Ok(());
+        };
+        let Some(cookie) = self.multitransport_migration.as_ref().map(|m| m.cookie) else {
+            warn!("egfx_on_udp set but no migration cookie; dropping EGFX frame");
+            return Ok(());
+        };
+        let chunks = ironrdp_svc::StaticVirtualChannel::chunkify(messages)
+            .map_err(|e| anyhow::anyhow!("chunkify EGFX for tunnel: {e}"))?;
+        let n = chunks.len();
+        for chunk in chunks {
+            sender.send(cookie, chunk.into_inner());
+        }
+        trace!(chunks = n, "routed EGFX frame over the UDP tunnel");
         Ok(())
     }
 


### PR DESCRIPTION
## What

M5c step 3a of the RDP UDP multitransport work: send the **real** EGFX migration Soft-Sync (naming the EGFX DVC) and route EGFX frames over the bound reliable UDP tunnel — behind a second env gate `MACRDP_UDP_MIGRATE_EGFX` (default **OFF**).

When the flag is off, the M5c step-1+2 empty safe spike is byte-for-byte unchanged (verified no-regression on real mstsc). When on:

- **vendored ironrdp-dvc**: `DrdynvcServer::get_channel_id_by_name` — find the EGFX channel id by its announced name (`Microsoft::Windows::RDS::Graphics`). Pure addition.
- **server**: `egfx_on_udp` + `multitransport_tunnel_sender` fields; `maybe_soft_sync_on_egfx` looks up the EGFX id, flips `egfx_on_udp`, and sends `switch_to_udpfecr(vec![gfx_id])`; the `ServerEvent::Egfx` dispatch arm routes frames via `route_egfx_over_udp` (chunkify → handoff by cookie) instead of TCP once migrated.
- **listener**: bidirectional recv loop (`select!` recv + outbound arm); `ship_outbound` wraps each chunk in `RDP_TUNNEL_DATA`, encrypts through the peer's MS-RDPEMT TLS, ships it reliably over RDPEUDP (peer looked up by cookie).
- new `tunnel_channel()` / `TunnelSender` / `TunnelOutbound`; `main.rs` wires the sender to the server and the rx to the listener `bind`.

## Verified on real mstsc (Win11 / WiFi LAN)

- **Flag OFF** (default): identical to step 1+2 — `Sent DYNVC_SOFT_SYNC_REQUEST (empty channel list — EGFX stays on TCP)`, mstsc replies `tunnels: []`, EGFX/audio flow over TCP, graceful disconnect. No regression.
- **Flag ON**: `Sent DYNVC_SOFT_SYNC_REQUEST (migrating EGFX onto the UDP tunnel) gfx_channel_id=3` → mstsc replied **`DYNVC_SOFT_SYNC_RESPONSE { tunnels: [1] }`** — it **accepted** migrating the EGFX channel onto the reliable UDP tunnel. The migration request is wire-correct.

## Known: not yet rendering (this is step 3b)

After migration EGFX is bidirectional over the tunnel. mstsc's frame acknowledgements come back as inbound `RDP_TUNNEL_DATA` (`action=2 len=10`) which we still drop, so the H.264 ship loop (`max_in_flight=2`) stalls and video freezes. The **inbound tunnel→drdynvc path** (un-tunnel the SVC channel-data, route it back to the owning connection's `client_loop`, run it through the drdynvc processor so the EGFX handler sees the acks) is M5c step 3b.

## Checks

`cargo build` / `clippy --all-targets` / `test` (69 pass) / `fmt` all clean. All new paths gated behind the `multitransport` feature + the `MACRDP_UDP_MIGRATE_EGFX` env var.