### PR TITLE
M5c step 3b — EGFX renders over the UDP multitransport tunnel (verified on mstsc)

### DIFF
--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -49,27 +49,36 @@ mod tests {
         let cookie = [0xABu8; 16];
         let other = [0x11u8; 16];
 
-        // Unknown cookie is rejected.
-        assert!(!reg.take(&other), "unregistered cookie must not bind");
+        // Unknown cookie is rejected (no inbound sink returned).
+        assert!(
+            reg.take(&other).is_none(),
+            "unregistered cookie must not bind"
+        );
 
         // Registered cookie binds exactly once, then is consumed — and the bind
-        // flips the tunnel-bound flag the offer path keeps (M5c).
-        let flag = reg.register(cookie);
+        // flips the tunnel-bound flag the offer path keeps (M5c) and returns the
+        // connection's inbound sink (M5c step 3b).
+        let (in_tx, _in_rx) = tokio::sync::mpsc::unbounded_channel();
+        let flag = reg.register(cookie, in_tx);
         assert!(!flag.load(Ordering::Relaxed), "flag starts unset");
-        assert!(reg.take(&cookie), "registered cookie must bind once");
+        assert!(
+            reg.take(&cookie).is_some(),
+            "registered cookie must bind once (returns its inbound sink)"
+        );
         assert!(
             flag.load(Ordering::Relaxed),
             "binding the cookie sets its tunnel-bound flag"
         );
         assert!(
-            !reg.take(&cookie),
+            reg.take(&cookie).is_none(),
             "a consumed cookie must not bind again (replay protection)"
         );
 
         // Explicit removal (teardown / eviction) also clears it.
-        reg.register(other);
+        let (in_tx2, _in_rx2) = tokio::sync::mpsc::unbounded_channel();
+        reg.register(other, in_tx2);
         reg.remove(&other);
-        assert!(!reg.take(&other), "removed cookie must not bind");
+        assert!(reg.take(&other).is_none(), "removed cookie must not bind");
     }
 
     // The Initiate Multitransport Request the server sends in M1 is the one bit

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -475,3 +475,39 @@ AND released — #1276 landing is NOT sufficient.
     step 3b. Watch the gate/send lines plus
     `MACRDP_UDP_MIGRATE_EGFX: Soft-Sync will migrate the EGFX DVC` and (listener)
     `MS-RDPEMT tunnel PDU not handled yet … action=2`.
+    **M5c step 3b (added 2026-06-26): EGFX RENDERS over the UDP tunnel — VERIFIED
+    end-to-end on real mstsc.** Two fixes, together making H.264 video flow over
+    UDP (still behind `MACRDP_UDP_MIGRATE_EGFX`; default OFF unchanged + verified
+    no-regression):
+    1. **Outbound framing fix (the unlock).** The MS-RDPEMT tunnel carries the
+       **bare DRDYNVC PDU**, NOT a static-channel-framed one — HigherLayerData has
+       no `CHANNEL_PDU_HEADER` (confirmed empirically: inbound `action=2 len=10`
+       ⇒ 6-byte HigherLayerData, smaller than the 8-byte header; and ironrdp-svc
+       exposes `SvcMessage::encode_unframed_pdu` documented "for RDPEMT tunnel
+       data"). Step 3a wrongly used `StaticVirtualChannel::chunkify`, which prepends
+       `CHANNEL_PDU_HEADER`, so mstsc misparsed the EGFX stream → froze.
+       `route_egfx_over_udp` now encodes each message via `encode_unframed_pdu` (one
+       tunnel PDU per message; `encode_dvc_messages` already DVC-chunked them to
+       fit). This alone makes video render — macrdp's H.264 throttle is
+       `submitted − shipped` (ack-INDEPENDENT, `max_frames_in_flight = u32::MAX`),
+       so dropping inbound frame acks never stalled it; the freeze was purely the
+       garbled outbound framing.
+    2. **Inbound tunnel→drdynvc path (protocol correctness).** `CookieRegistry`
+       now stores a per-cookie inbound sink (`register(cookie, sender)`; `take`
+       returns the sink on bind). The listener's `Peer` gained `inbound_sink`, set
+       on a cookie-bound CREATEREQUEST; on inbound `RDP_TUNNEL_DATA` (action 0x2) it
+       extracts the HigherLayerData (`emt::tunnel_data_payload`) and forwards the
+       bare DRDYNVC PDU to the owning connection (instead of the old log-and-drop).
+       `RdpServer` gained `multitransport_tunnel_inbound_rx` (created at the offer
+       site alongside the cookie registration); `client_loop` adds a
+       `dispatch_tunnel_inbound` select arm that drains it into
+       `process_tunnel_inbound` → `DrdynvcServer::process` (no CHANNEL_PDU_HEADER to
+       strip — the tunnel replaced that layer), shipping any reply PDUs back over
+       the tunnel. Idle-forever (`std::future::pending`) when there's no inbound
+       tunnel, so feature-off / no-migration / soft-bound paths are unchanged.
+    **VERIFIED on real mstsc 2026-06-26:** `tunnels: [1]` accepted → EGFX H.264
+    **renders and stays live** (mouse/keyboard/window changes all update over UDP),
+    inbound `RDP_TUNNEL_DATA` now delivered+processed (the "not handled yet" lines
+    are gone), audio still on TCP (RDPSND channel 1005) throughout. This is the
+    first open-source RDP **server** serving real EGFX video over a UDP
+    multitransport tunnel. Flag-OFF (empty safe spike) re-verified no-regression.

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -39,7 +39,7 @@ use ironrdp_rdpeudp::state::{Config, RdpeudpState, Role};
 
 use crate::multitransport::{CookieRegistry, TunnelOutbound};
 use tokio::net::UdpSocket;
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_rustls::rustls::{ServerConfig, ServerConnection};
 use tracing::{debug, trace, warn};
@@ -97,6 +97,13 @@ struct Peer {
     /// (M4c). The client retransmits the request until it sees the response, so
     /// we reply once and then ignore the retransmits.
     tunnel_created: bool,
+    /// (M5c step 3b) The owning connection's inbound-tunnel-data sink, set on a
+    /// successful cookie-bound CREATEREQUEST (`CookieRegistry::take`). Each
+    /// inbound `RDP_TUNNEL_DATA` HigherLayerData (a bare DRDYNVC PDU from the
+    /// migrated channel — e.g. an EGFX frame ack) is forwarded here to the
+    /// connection's `client_loop`. `None` on the soft-bound (no-registry) test
+    /// path — inbound channel data is then logged and dropped.
+    inbound_sink: Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>,
 }
 
 /// A running UDP multitransport listener. The receive loop runs on a spawned
@@ -247,6 +254,7 @@ fn handle_emt_tunnel(
     buf: &mut Vec<u8>,
     tunnel_created: &mut bool,
     cookie_registry: Option<&CookieRegistry>,
+    inbound: &mut Option<UnboundedSender<Vec<u8>>>,
 ) -> Option<[u8; 16]> {
     use ironrdp_rdpeudp::emt::{self, TunnelCreateRequest, TunnelCreateResponse};
 
@@ -270,20 +278,24 @@ fn handle_emt_tunnel(
                             .map(|b| format!("{b:02x}"))
                             .collect::<String>();
                         // M5a: bind to a real TCP session. `take` is atomic
-                        // check-and-consume, so a cookie is one-time use.
-                        let bound = match cookie_registry {
-                            Some(reg) => reg.take(&req.security_cookie),
-                            None => true, // soft binding (test path)
+                        // check-and-consume (one-time use), and returns the
+                        // connection's inbound sink so we can forward this
+                        // tunnel's client→server channel data (M5c step 3b).
+                        let inbound_sink = match cookie_registry {
+                            Some(reg) => match reg.take(&req.security_cookie) {
+                                Some(sink) => Some(sink),
+                                None => {
+                                    warn!(
+                                        %peer_addr,
+                                        request_id = req.request_id,
+                                        %cookie,
+                                        "MS-RDPEMT tunnel CREATEREQUEST cookie not recognized — rejecting tunnel (client stays on TCP)"
+                                    );
+                                    continue;
+                                }
+                            },
+                            None => None, // soft binding (test path): accept, no forwarding
                         };
-                        if !bound {
-                            warn!(
-                                %peer_addr,
-                                request_id = req.request_id,
-                                %cookie,
-                                "MS-RDPEMT tunnel CREATEREQUEST cookie not recognized — rejecting tunnel (client stays on TCP)"
-                            );
-                            continue;
-                        }
                         debug!(
                             %peer_addr,
                             request_id = req.request_id,
@@ -293,6 +305,7 @@ fn handle_emt_tunnel(
                         let resp = TunnelCreateResponse::ok().to_vec();
                         if tls.writer().write_all(&resp).is_ok() {
                             *tunnel_created = true;
+                            *inbound = inbound_sink;
                             bound_cookie = Some(req.security_cookie);
                         } else {
                             warn!(%peer_addr, "failed to write MS-RDPEMT CREATERESPONSE into TLS");
@@ -301,15 +314,28 @@ fn handle_emt_tunnel(
                 }
                 Err(e) => warn!(%peer_addr, error = %e, "malformed MS-RDPEMT CREATEREQUEST"),
             },
+            Some(emt::action::DATA) => {
+                // (M5c step 3b) Migrated-channel client→server data (e.g. an EGFX
+                // frame ack). Forward the bare DRDYNVC PDU (HigherLayerData) to
+                // the owning connection's drdynvc processor.
+                match emt::tunnel_data_payload(&pdu) {
+                    Ok(higher) => match inbound.as_ref() {
+                        Some(sink) => {
+                            if sink.send(higher.to_vec()).is_err() {
+                                trace!(%peer_addr, "inbound tunnel sink closed; dropping channel data");
+                            }
+                        }
+                        None => debug!(
+                            %peer_addr,
+                            len = higher.len(),
+                            "inbound RDP_TUNNEL_DATA with no inbound sink (soft-bound); dropping"
+                        ),
+                    },
+                    Err(e) => warn!(%peer_addr, error = %e, "malformed inbound RDP_TUNNEL_DATA"),
+                }
+            }
             Some(other) => {
-                // RDP_TUNNEL_DATA (action 0x2) and friends carry migrated channel
-                // data — M5. Skip until then.
-                debug!(
-                    %peer_addr,
-                    action = other,
-                    len = total,
-                    "MS-RDPEMT tunnel PDU not handled yet (channel migration is M5)"
-                );
+                debug!(%peer_addr, action = other, len = total, "MS-RDPEMT tunnel PDU: unexpected action, ignoring");
             }
             None => break,
         }
@@ -423,6 +449,7 @@ async fn run_recv_loop(
                 tls_done_logged: false,
                 emt_inbound: Vec::new(),
                 tunnel_created: false,
+                inbound_sink: None,
             }
         });
 
@@ -488,6 +515,7 @@ async fn run_recv_loop(
                     tls_done_logged,
                     emt_inbound,
                     tunnel_created,
+                    inbound_sink,
                     ..
                 } = peer;
 
@@ -537,6 +565,7 @@ async fn run_recv_loop(
                         emt_inbound,
                         tunnel_created,
                         cookie_registry.as_ref(),
+                        inbound_sink,
                     ) {
                         // (M5c) Record cookie -> this peer so server-originated
                         // tunnel data (keyed by the same cookie) reaches it.

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -89,8 +89,22 @@ pub fn encode_initiate_request(
 /// or replayed cookie can't open a tunnel. Cookies are one-time: the listener
 /// removes a cookie when it accepts the tunnel, and the offer path evicts the
 /// previous connection's (unconsumed) cookie before registering a new one.
+/// Per-cookie registry entry: the tunnel-bound flag plus the owning connection's
+/// inbound-tunnel-data sink.
+struct CookieEntry {
+    /// Flipped `true` when the listener binds the matching tunnel; the
+    /// offer-issuing [`RdpServer`](crate::RdpServer) reads it to fire Soft-Sync.
+    bound: Arc<AtomicBool>,
+    /// (M5c step 3b) The owning connection's inbound-tunnel-data sink. The
+    /// listener, on a successful bind, takes this sender and forwards each
+    /// inbound `RDP_TUNNEL_DATA` HigherLayerData (a bare DRDYNVC PDU — e.g. an
+    /// EGFX frame acknowledgement) to it, so the connection's drdynvc processor
+    /// sees the migrated channel's client→server traffic.
+    inbound: tokio::sync::mpsc::UnboundedSender<Vec<u8>>,
+}
+
 #[derive(Clone, Default)]
-pub struct CookieRegistry(Arc<Mutex<HashMap<[u8; 16], Arc<AtomicBool>>>>);
+pub struct CookieRegistry(Arc<Mutex<HashMap<[u8; 16], CookieEntry>>>);
 
 impl CookieRegistry {
     /// A fresh, empty registry. Create one in `main` and share it (clone) with
@@ -99,16 +113,24 @@ impl CookieRegistry {
         Self::default()
     }
 
-    /// Register an issued cookie as valid and return its **tunnel-bound flag**:
-    /// the listener sets it `true` when it binds the matching tunnel (M5c), and
-    /// the offer-issuing [`RdpServer`](crate::RdpServer) reads it to know the UDP
-    /// multitransport connection is up (the cue to send the Soft-Sync request).
-    pub fn register(&self, cookie: [u8; 16]) -> Arc<AtomicBool> {
-        let flag = Arc::new(AtomicBool::new(false));
+    /// Register an issued cookie as valid, alongside the connection's inbound
+    /// sink (M5c step 3b — where the listener forwards migrated-channel client
+    /// data). Returns the **tunnel-bound flag**: the listener sets it `true`
+    /// when it binds the matching tunnel, and the offer-issuing
+    /// [`RdpServer`](crate::RdpServer) reads it to know the UDP multitransport
+    /// connection is up (the cue to send the Soft-Sync request).
+    pub fn register(&self, cookie: [u8; 16], inbound: tokio::sync::mpsc::UnboundedSender<Vec<u8>>) -> Arc<AtomicBool> {
+        let bound = Arc::new(AtomicBool::new(false));
         if let Ok(mut map) = self.0.lock() {
-            map.insert(cookie, Arc::clone(&flag));
+            map.insert(
+                cookie,
+                CookieEntry {
+                    bound: Arc::clone(&bound),
+                    inbound,
+                },
+            );
         }
-        flag
+        bound
     }
 
     /// Drop a cookie (evicted on teardown / TCP fallback).
@@ -118,22 +140,19 @@ impl CookieRegistry {
         }
     }
 
-    /// Atomically check-and-consume a cookie: returns `true` (and removes it,
-    /// **setting its tunnel-bound flag**) if it was registered. One-time use — a
-    /// retransmitted/replayed CREATEREQUEST with the same cookie won't bind a
-    /// second tunnel.
-    pub fn take(&self, cookie: &[u8; 16]) -> bool {
+    /// Atomically check-and-consume a cookie: on a match, removes it, **sets its
+    /// tunnel-bound flag**, and returns the connection's inbound sink (so the
+    /// listener can forward this tunnel's client→server channel data). Returns
+    /// `None` for an unknown cookie. One-time use — a retransmitted/replayed
+    /// CREATEREQUEST with the same cookie won't bind a second tunnel.
+    pub fn take(&self, cookie: &[u8; 16]) -> Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>> {
         let removed = match self.0.lock() {
             Ok(mut map) => map.remove(cookie),
             Err(_) => None,
         };
-        match removed {
-            Some(flag) => {
-                flag.store(true, Ordering::Relaxed);
-                true
-            }
-            None => false,
-        }
+        let entry = removed?;
+        entry.bound.store(true, Ordering::Relaxed);
+        Some(entry.inbound)
     }
 }
 

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -384,6 +384,14 @@ pub struct RdpServer {
     /// path leaves EGFX on TCP (the proven empty-Soft-Sync spike).
     #[cfg(feature = "multitransport")]
     egfx_on_udp: bool,
+    /// (M5c step 3b) Receiver for inbound migrated-channel data the UDP listener
+    /// forwards (each item is a bare DRDYNVC PDU — HigherLayerData of an inbound
+    /// `RDP_TUNNEL_DATA`, e.g. an EGFX frame ack). Created + registered (with the
+    /// matching sender in the cookie registry) per connection at the offer site;
+    /// `client_loop` drains it into the drdynvc processor. `None` when no offer is
+    /// in flight (TCP-only).
+    #[cfg(feature = "multitransport")]
+    multitransport_tunnel_inbound_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
 }
 
 #[derive(Debug)]
@@ -494,6 +502,8 @@ impl RdpServer {
             multitransport_tunnel_sender: None,
             #[cfg(feature = "multitransport")]
             egfx_on_udp: false,
+            #[cfg(feature = "multitransport")]
+            multitransport_tunnel_inbound_rx: None,
         }
     }
 
@@ -715,9 +725,14 @@ impl RdpServer {
                 if let Some(prev) = self.multitransport_migration.as_ref() {
                     registry.remove(&prev.cookie);
                 }
+                // (M5c step 3b) Per-connection inbound channel: the listener
+                // forwards this tunnel's client→server channel data (bare DRDYNVC
+                // PDUs) here, keyed by cookie. `client_loop` drains the receiver.
+                let (in_tx, in_rx) = tokio::sync::mpsc::unbounded_channel();
+                self.multitransport_tunnel_inbound_rx = Some(in_rx);
                 // Keep the tunnel-bound flag: the listener flips it on a cookie
                 // match, and the EGFX dispatch path reads it to fire Soft-Sync.
-                self.udp_tunnel_bound = Some(registry.register(offer.cookie));
+                self.udp_tunnel_bound = Some(registry.register(offer.cookie, in_tx));
             }
             acceptor.set_advertise_extended_client_data(true);
             acceptor.set_multitransport_offer(Some(offer));
@@ -1233,6 +1248,10 @@ impl RdpServer {
         let mut audio_writer = writer.clone();
         let ev_receiver = Arc::clone(&self.ev_receiver);
         let audio_receiver = Arc::clone(&self.audio_receiver);
+        // (M5c step 3b) Take this connection's inbound-tunnel receiver before `self`
+        // is moved into the shared Rc; `dispatch_tunnel_inbound` drains it.
+        #[cfg(feature = "multitransport")]
+        let tunnel_inbound = self.multitransport_tunnel_inbound_rx.take();
         let s = Rc::new(Mutex::new(self));
 
         let this = Rc::clone(&s);
@@ -1422,11 +1441,29 @@ impl RdpServer {
             }
         };
 
+        // (M5c step 3b) Drain inbound migrated-channel data (EGFX over the UDP
+        // tunnel) into the drdynvc processor. Idle forever (never resolves) when
+        // there's no inbound tunnel — feature off, no migration, or the channel
+        // closed — so the other arms drive the session.
+        let this_tunnel = Rc::clone(&s);
+        let dispatch_tunnel_inbound = async move {
+            let _ = &this_tunnel;
+            #[cfg(feature = "multitransport")]
+            if let Some(mut rx) = tunnel_inbound {
+                while let Some(pdu) = rx.recv().await {
+                    let mut this = this_tunnel.lock().await;
+                    this.process_tunnel_inbound(pdu);
+                }
+            }
+            std::future::pending::<Result<RunState>>().await
+        };
+
         let state = tokio::select!(
             state = dispatch_pdu => state,
             state = dispatch_display => state,
             state = dispatch_events => state,
             state = dispatch_audio => state,
+            state = dispatch_tunnel_inbound => state,
         );
 
         debug!("End of client loop: {state:?}");
@@ -1640,14 +1677,49 @@ impl RdpServer {
             warn!("egfx_on_udp set but no migration cookie; dropping EGFX frame");
             return Ok(());
         };
-        let chunks = ironrdp_svc::StaticVirtualChannel::chunkify(messages)
-            .map_err(|e| anyhow::anyhow!("chunkify EGFX for tunnel: {e}"))?;
-        let n = chunks.len();
-        for chunk in chunks {
-            sender.send(cookie, chunk.into_inner());
+        // The MS-RDPEMT tunnel carries the BARE DRDYNVC PDU (no static-channel
+        // CHANNEL_PDU_HEADER) — RDP_TUNNEL_DATA provides the framing, so encode
+        // each message unframed (NOT `chunkify`, which prepends CHANNEL_PDU_HEADER
+        // and would make the client misparse the EGFX stream). `encode_dvc_messages`
+        // already DVC-chunked these to fit, so one tunnel PDU per message is fine.
+        let mut n = 0usize;
+        for msg in messages {
+            let pdu = msg
+                .encode_unframed_pdu()
+                .map_err(|e| anyhow::anyhow!("encode EGFX PDU for tunnel: {e}"))?;
+            sender.send(cookie, pdu);
+            n += 1;
         }
-        trace!(chunks = n, "routed EGFX frame over the UDP tunnel");
+        trace!(pdus = n, "routed EGFX PDUs over the UDP tunnel");
         Ok(())
+    }
+
+    /// (M5c step 3b) Process one inbound migrated-channel PDU the UDP listener
+    /// forwarded: a bare DRDYNVC PDU (HigherLayerData of an inbound
+    /// `RDP_TUNNEL_DATA`, e.g. an EGFX frame acknowledgement). Feed it straight to
+    /// the drdynvc processor (the tunnel replaces the static-channel framing, so no
+    /// `CHANNEL_PDU_HEADER` to strip) and ship any reply PDUs back over the tunnel.
+    /// Errors are logged, not propagated — the optional UDP fast-path must never
+    /// tear down the TCP-authoritative session.
+    #[cfg(feature = "multitransport")]
+    fn process_tunnel_inbound(&mut self, pdu: Vec<u8>) {
+        use ironrdp_svc::SvcProcessor as _;
+        let Some(drdynvc) = self.get_svc_processor::<dvc::DrdynvcServer>() else {
+            warn!("inbound tunnel data but no DRDYNVC channel; dropping");
+            return;
+        };
+        let replies = match drdynvc.process(&pdu) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(error = %e, "failed to process inbound tunnel DRDYNVC PDU");
+                return;
+            }
+        };
+        if !replies.is_empty() {
+            if let Err(e) = self.route_egfx_over_udp(replies) {
+                warn!(error = %e, "failed to ship tunnel reply PDUs");
+            }
+        }
     }
 
     async fn client_accepted<R, W>(


### PR DESCRIPTION
## What

The payoff of the whole RDP UDP multitransport effort: **H.264 EGFX video now renders over the reliable UDP tunnel**, verified end-to-end on real mstsc. Two fixes (still behind `MACRDP_UDP_MIGRATE_EGFX`, default **OFF**):

1. **Outbound framing fix (the unlock).** The MS-RDPEMT tunnel carries the **bare DRDYNVC PDU** — HigherLayerData has no `CHANNEL_PDU_HEADER`. Step 3a wrongly used `StaticVirtualChannel::chunkify` (which prepends that header), so mstsc misparsed the EGFX stream and froze. `route_egfx_over_udp` now uses `SvcMessage::encode_unframed_pdu` (one tunnel PDU per message; `encode_dvc_messages` already DVC-chunked them to fit). macrdp's H.264 throttle is `submitted − shipped` (ack-independent, `max_frames_in_flight = u32::MAX`), so the garbled framing — not the dropped acks — was the freeze.

2. **Inbound tunnel→drdynvc path (protocol correctness).** `CookieRegistry` now stores a per-cookie inbound sink (`register(cookie, sender)` / `take` returns it on bind). The listener's `Peer` gains `inbound_sink`, set on a cookie-bound CREATEREQUEST; inbound `RDP_TUNNEL_DATA` (action 0x2) HigherLayerData (`emt::tunnel_data_payload`) is forwarded to the owning connection instead of dropped. `RdpServer` gains `multitransport_tunnel_inbound_rx` (created at the offer site); `client_loop` adds a `dispatch_tunnel_inbound` select arm draining it into `process_tunnel_inbound` → `DrdynvcServer::process`, shipping replies back over the tunnel. Idle-forever when there's no inbound tunnel, so feature-off / no-migration / soft-bound paths are unchanged.

## Verified on real mstsc (Win11 / WiFi LAN)

- **Flag ON**: `tunnels: [1]` accepted → **EGFX H.264 renders and stays live** (mouse / keyboard / window changes all update over UDP), inbound `RDP_TUNNEL_DATA` now delivered+processed (the "not handled yet" lines are gone), audio still on TCP (RDPSND channel 1005) throughout.
- **Flag OFF** (default): empty safe spike, re-verified no-regression — EGFX over TCP, session normal.

This is, as far as we know, the first open-source RDP **server** serving real EGFX video over a UDP multitransport tunnel.

## Checks

`cargo build` / `clippy --all-targets` / `test` (69 pass) / `fmt` all clean. All new paths gated behind the `multitransport` feature + the `MACRDP_UDP_MIGRATE_EGFX` env var.