### PR TITLE
Fix stale 'session still runs over TCP' multitransport startup log

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2140,10 +2140,13 @@ async fn async_main() -> Result<()> {
         .await
         {
             Ok(listener) => {
+                let migrate_egfx = std::env::var_os("MACRDP_UDP_MIGRATE_EGFX").is_some();
                 info!(
                     addr = %args.bind,
-                    "UDP multitransport listener bound (M3: RDPEUDP handshake; \
-                     session still runs over TCP)"
+                    migrate_egfx,
+                    "UDP multitransport listener bound — EGFX migrates to the reliable UDP tunnel \
+                     when MACRDP_UDP_MIGRATE_EGFX is set (otherwise EGFX stays on TCP); \
+                     input/audio/clipboard always ride TCP"
                 );
                 server
                     .set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));


### PR DESCRIPTION
The UDP-listener-bound `INFO` line still carried its M3-era wording ("M3: RDPEUDP handshake; session still runs over TCP") from before the UDP data path existed. Since M5c step 3b, EGFX migrates onto the reliable UDP tunnel at runtime when `MACRDP_UDP_MIGRATE_EGFX` is set — so the old text is misleading (it's what prompted the "why does it say still runs over TCP?" question).

Reworded to state EGFX migrates when the flag is set (else stays on TCP), that input/audio/clipboard always ride TCP, and to log the flag state. Cosmetic only — no behavior change. build/fmt clean.