### PR TITLE
docs(multitransport): refresh stale --enable-udp-multitransport help text

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -449,13 +449,15 @@ struct Args {
     #[arg(long)]
     enable_smartcard_redirection: bool,
 
-    /// EXPERIMENTAL (M3, opt-in, default OFF). Offer RDP UDP multitransport
-    /// (MS-RDPEMT) to clients that advertise it, and bind a UDP listener on the
-    /// same address/port as TCP. **The session still runs over TCP:** the listener
-    /// answers the RDPEUDP SYN→SYN+ACK handshake (negotiating RDPEUDP2), but there
-    /// is no TLS/EMT tunnel or channel migration yet, so nothing actually moves to
-    /// UDP. Cookie validation is soft. No reason for end users to enable it. Not
-    /// supported under --fork-workers (falls back to TCP). macOS-only build; see
+    /// EXPERIMENTAL, opt-in (default OFF). Offer RDP UDP multitransport
+    /// (MS-RDPEMT over reliable RDPEUDP) to clients that advertise it, and bind a
+    /// UDP listener on the same address/port as TCP. With the env var
+    /// MACRDP_UDP_MIGRATE_EGFX=1 the EGFX (H.264) channel is migrated onto the
+    /// reliable UDP tunnel via MS-RDPEDYC Soft-Sync (verified rendering on mstsc);
+    /// without it, EGFX stays on TCP (the proven safe spike). Input, audio (RDPSND),
+    /// and clipboard always ride TCP. The win is on lossy/high-latency links (no
+    /// head-of-line blocking), marginal on a clean LAN. Not supported under
+    /// --fork-workers (falls back to TCP). macOS-only build; see
     /// docs/rdp-udp-multitransport-feasibility.md.
     #[arg(long)]
     enable_udp_multitransport: bool,


### PR DESCRIPTION
The `--enable-udp-multitransport` CLI flag's help (a clap doc-comment, which compiles into the binary) still described the **M3** milestone state:

> EXPERIMENTAL (M3, opt-in, default OFF). … **The session still runs over TCP:** the listener answers the RDPEUDP SYN→SYN+ACK handshake … but there is no TLS/EMT tunnel or channel migration yet, so nothing actually moves to UDP.

Phase 1 has since shipped — EGFX H.264 renders over the reliable RDPEUDP + rustls TLS + MS-RDPEMT tunnel (verified on mstsc), gated by `MACRDP_UDP_MIGRATE_EGFX`. This updates the help text to match the shipped behavior and the rest of the docs.

Found because the stale phrase showed up in `strings` on a freshly built binary even after #38 fixed the runtime startup log — they were two separate strings; #38 fixed the log line, this fixes the `--help` text.

Code-behavior unchanged (doc-comment only).