### PR TITLE
feat(multitransport): lossy-link soak prep — retransmit observability + netshape tooling

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -114,6 +114,55 @@ server-only glue (UDP listener, cookie→session binding, channel migration via
 spec walks you through — and FreeRDP never finished the *client* UDP path either,
 so there was no OSS implementation of any of it to crib from.
 
+## Soak testing the UDP path under loss
+
+EGFX-over-UDP has only been verified on a clean WiFi/LAN so far — which proves it
+*works* but not that it delivers the actual win (no head-of-line blocking on a
+lossy/high-latency link). This section is the protocol for soaking it under emulated
+loss. Loopback can't reproduce real loss, so this needs a **real client** (mstsc on
+another machine) and the Mac's built-in `pf`/`dnctl` traffic shaper.
+
+**Tooling:** `scripts/netshape.sh` shapes both directions of TCP+UDP on the macrdp
+port (default 3390) via dummynet — `sudo scripts/netshape.sh on --loss 5 --delay 100`
+to apply, `sudo scripts/netshape.sh off` to restore, `status` to inspect.
+
+**Observability:** the reliable transport's RTO retransmits are surfaced (the state
+machine is sans-I/O, so `StepOutput.retransmits` / `.syn_retransmit` are counted in
+`ironrdp-rdpeudp` and *logged by the listener*). Run the server with:
+
+```
+RUST_LOG=info,ironrdp_server::multitransport::listener=debug
+```
+
+and watch for:
+- `RDPEUDP RTO retransmit` / `RDPEUDP RTO retransmit (outbound)` — recovery firing
+  (inbound-driven vs server-data path). **Zero on a clean link**; a steady trickle
+  under loss is the system working as intended, not a fault.
+- `RDPEUDP reliable data delivered` — in-order bytes reassembled.
+- `RDPEUDP DATA datagram delivered nothing (receive-sequence mismatch)` — an
+  inbound gap (loss/reorder) the receiver is holding for.
+
+**A/B protocol — the comparison that shows the win:**
+1. Apply the same shaping for both runs, e.g. `--loss 5 --delay 100`.
+2. **Run A (EGFX on UDP):** start macrdp `--enable-udp-multitransport --enable-h264`
+   with `MACRDP_UDP_MIGRATE_EGFX=1`. Connect mstsc, drive video (scroll a page,
+   play a non-DRM clip), and type continuously.
+3. **Run B (EGFX on TCP):** same flags but **without** `MACRDP_UDP_MIGRATE_EGFX`
+   (EGFX stays on TCP — the safe spike). Same client activity.
+4. Compare: in Run B a lost segment on the shared TCP stream stalls video *and*
+   input together; Run A should keep video moving and input responsive because the
+   video channel is independent of the control TCP. Repeat across loss steps
+   (0% → 2% → 5% → 10%) and a couple of latencies (+60ms, +150ms).
+
+**What to record per cell:** subjective video smoothness + typing latency, the
+retransmit-log rate, and whether the session ever stalls/disconnects. Known thing to
+probe specifically: on a **static screen** under loss (no SCK frames flowing — see
+the flush-burst quirk) the state machine is only pumped by inbound datagrams, so if a
+trailing video segment *and* the client's follow-up ACKs are both lost, recovery can
+be delayed until the next screen change. If that shows up, the fix is a periodic
+timer tick driving `step(now, None)` in the listener — deferred until the soak proves
+it's needed.
+
 ## TL;DR
 
 *Original feasibility framing (2026-06-25), kept for the record. The "don't / not

--- a/scripts/netshape.sh
+++ b/scripts/netshape.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+# netshape.sh — apply / clear an emulated lossy, high-latency network condition on
+# the macrdp listening port, for soak-testing RDP UDP multitransport (EGFX over
+# the reliable RDPEUDP tunnel) against a real client.
+#
+# It shapes BOTH directions of BOTH protocols (TCP + UDP) on the chosen port using
+# macOS's built-in pf + dnctl/dummynet — no extra software. Shaping the Mac side
+# is enough: every packet between the RDP client and macrdp crosses this host.
+#
+# WHY this is the test that matters: in a pure-TCP session every channel (video,
+# input, audio, clipboard) multiplexes onto ONE TCP stream, so a single dropped
+# segment head-of-line-blocks *everything* until it's retransmitted. With EGFX
+# migrated onto UDP (MACRDP_UDP_MIGRATE_EGFX=1), video rides its own reliable
+# channel: loss on the control TCP no longer freezes the picture, and a lost video
+# packet only delays that packet. This script lets you see that difference.
+#
+# Requires sudo (pf + dnctl are privileged). Review before running.
+#
+#   sudo scripts/netshape.sh on  [--loss PCT] [--delay MS] [--bw RATE] [--port N]
+#   sudo scripts/netshape.sh off
+#   scripts/netshape.sh status
+#
+# Examples:
+#   sudo scripts/netshape.sh on --loss 5 --delay 100     # 5% loss, +100ms each way
+#   sudo scripts/netshape.sh on --loss 2 --delay 60 --bw 20Mbit/s
+#   sudo scripts/netshape.sh off                         # restore the network
+#
+# NOTE: --delay is per-pipe and applied to EACH direction, so round-trip latency
+# rises by ~2x the value. --loss is per-packet drop probability per direction.
+#
+# A note on scope: this enables pf for the duration of the test. On a stock Mac pf
+# is idle/disabled by default; `off` flushes our anchor + pipes and restores the
+# default ruleset. If you run a custom firewall, review the `off` path first.
+
+set -eu
+
+ANCHOR="macrdp-netshape"
+PIPE_IN=1
+PIPE_OUT=2
+
+PORT=3390
+LOSS=0      # percent
+DELAY=0     # ms, each direction
+BW=0        # 0 = unlimited; else e.g. 20Mbit/s, 1500Kbit/s
+
+usage() {
+    sed -n '2,40p' "$0"
+    exit "${1:-1}"
+}
+
+require_root() {
+    if [ "$(id -u)" != "0" ]; then
+        echo "error: must run as root (use sudo)" >&2
+        exit 1
+    fi
+}
+
+cmd="${1:-}"
+[ -n "$cmd" ] || usage 1
+shift || true
+
+# Parse flags (only meaningful for `on`).
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --loss)  LOSS="$2"; shift 2 ;;
+        --delay) DELAY="$2"; shift 2 ;;
+        --bw)    BW="$2"; shift 2 ;;
+        --port)  PORT="$2"; shift 2 ;;
+        -h|--help) usage 0 ;;
+        *) echo "unknown arg: $1" >&2; usage 1 ;;
+    esac
+done
+
+# dummynet wants a 0..1 probability for packet-loss-rate.
+plr() { awk "BEGIN { printf \"%.4f\", $LOSS / 100 }"; }
+
+bw_arg() {
+    if [ "$BW" = "0" ]; then echo ""; else echo "bw $BW"; fi
+}
+
+case "$cmd" in
+    on)
+        require_root
+        echo "shaping port $PORT: loss=${LOSS}% delay=${DELAY}ms/dir bw=${BW}"
+
+        # Two pipes (in / out) so each direction is shaped independently.
+        # shellcheck disable=SC2046
+        dnctl pipe "$PIPE_IN"  config $(bw_arg) delay "$DELAY" plr "$(plr)"
+        # shellcheck disable=SC2046
+        dnctl pipe "$PIPE_OUT" config $(bw_arg) delay "$DELAY" plr "$(plr)"
+
+        # Load the default ruleset plus our dummynet anchor declarations, then
+        # populate the anchor with the per-port classification rules.
+        {
+            cat /etc/pf.conf 2>/dev/null || true
+            echo "dummynet-anchor \"$ANCHOR\""
+            echo "anchor \"$ANCHOR\""
+        } | pfctl -q -f -
+
+        echo "dummynet in  quick proto { tcp udp } from any to any port $PORT pipe $PIPE_IN
+dummynet out quick proto { tcp udp } from any to any port $PORT pipe $PIPE_OUT" \
+            | pfctl -q -a "$ANCHOR" -f -
+
+        pfctl -q -E 2>/dev/null || pfctl -q -e 2>/dev/null || true
+        echo "done. clear with: sudo $0 off"
+        ;;
+
+    off)
+        require_root
+        echo "clearing shaping on anchor $ANCHOR"
+        pfctl -q -a "$ANCHOR" -F all 2>/dev/null || true
+        dnctl -q pipe "$PIPE_IN"  delete 2>/dev/null || true
+        dnctl -q pipe "$PIPE_OUT" delete 2>/dev/null || true
+        # Restore the stock ruleset (drops our anchor declarations).
+        pfctl -q -f /etc/pf.conf 2>/dev/null || true
+        # Leave pf as we found it on a stock Mac (idle). If you rely on pf, re-enable.
+        pfctl -q -d 2>/dev/null || true
+        echo "done."
+        ;;
+
+    status)
+        echo "=== dnctl pipes ==="
+        dnctl -q list 2>/dev/null || dnctl list 2>/dev/null || echo "(none / need sudo)"
+        echo "=== pf anchor $ANCHOR ==="
+        pfctl -q -a "$ANCHOR" -s rules 2>/dev/null || echo "(none / need sudo)"
+        ;;
+
+    *)
+        usage 1
+        ;;
+esac

--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,14 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **Soak observability (done, 2026-06-26):** `StepOutput` gained two diagnostic
+  fields — `retransmits: usize` (in-flight data segments resent on RTO this step)
+  and `syn_retransmit: bool` (client SYN resent). Set in `pump()`; the crate stays
+  sans-I/O and silent — the **listener** logs them (`RDPEUDP RTO retransmit`) so a
+  lossy-link soak can confirm the recovery path actually fires. Unit-tested
+  (`retransmit_counter_reports_rto_resends`: 0 before RTO → 1 on RTO → 0 after ACK).
+  See `docs/rdp-udp-multitransport-feasibility.md` "Soak testing the UDP path under
+  loss" + `scripts/netshape.sh`.
 - **M5b-1 (done — data-path wire codecs, 2026-06-26; integration pending):** the
   pure, spec-verified codecs the EGFX-over-UDP data path needs, ahead of the
   (larger) server integration — same codecs-before-wiring pattern as M2. Two adds:

--- a/vendor/ironrdp-rdpeudp/src/state.rs
+++ b/vendor/ironrdp-rdpeudp/src/state.rs
@@ -71,6 +71,14 @@ pub struct StepOutput {
     pub delivered: Vec<Vec<u8>>,
     /// Encoded datagrams to transmit.
     pub to_send: Vec<Vec<u8>>,
+    /// Diagnostics: how many in-flight **data** segments were retransmitted this
+    /// step because their RTO elapsed. The state machine is sans-I/O and silent;
+    /// the caller (the UDP listener) logs this so a lossy-link soak can confirm
+    /// the recovery path is actually firing. Zero on a clean link.
+    pub retransmits: usize,
+    /// Diagnostics: the client SYN was retransmitted this step (RTO during the
+    /// handshake). Server instances never set this (they don't send a SYN).
+    pub syn_retransmit: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -290,6 +298,7 @@ impl RdpeudpState {
         {
             self.syn_last_sent_ms = now_ms;
             out.to_send.push(self.encode_syn());
+            out.syn_retransmit = true;
         }
 
         if !self.is_established() {
@@ -315,6 +324,7 @@ impl RdpeudpState {
                     ack_vector.clone(),
                 ));
                 sent_data = true;
+                out.retransmits += 1;
             }
         }
 
@@ -659,5 +669,47 @@ mod tests {
             }
             assert_eq!(delivered, msg, "seed {seed}: full in-order delivery");
         }
+    }
+
+    /// The diagnostic `StepOutput.retransmits` counter increments when an
+    /// unacked data segment's RTO elapses (the signal a lossy-link soak watches),
+    /// and stays zero while the segment is still fresh / once it's acked.
+    #[test]
+    fn retransmit_counter_reports_rto_resends() {
+        let (_client, mut server, now) = handshook();
+        let rto = server.cfg.rto_ms;
+
+        // Server sends one data segment; it's now in-flight (unacked).
+        let out = server.enqueue(now, b"hello over udp");
+        assert!(!out.to_send.is_empty(), "data segment went on the wire");
+        assert_eq!(out.retransmits, 0, "first send is not a retransmit");
+
+        // Before the RTO elapses, a timer tick must NOT retransmit.
+        let out = server.step(now + rto - 1, None);
+        assert_eq!(out.retransmits, 0, "still within RTO — no resend");
+
+        // Once the RTO elapses with no ACK, the segment is retransmitted.
+        let out = server.step(now + rto, None);
+        assert_eq!(out.retransmits, 1, "RTO elapsed → exactly one resend");
+        assert!(
+            !out.to_send.is_empty(),
+            "the retransmitted datagram is emitted"
+        );
+
+        // After the peer cumulatively ACKs it, the window drains and further
+        // ticks neither resend nor count.
+        let ack = Datagram::ack(
+            server.send_next.wrapping_sub(1) as i32,
+            8,
+            server.ack_vector(),
+        )
+        .encode()
+        .expect("encode ack");
+        server.step(now + rto, Some(&ack));
+        let out = server.step(now + rto * 4, None);
+        assert_eq!(
+            out.retransmits, 0,
+            "acked segment is no longer retransmitted"
+        );
     }
 }

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -520,3 +520,14 @@ AND released — #1276 landing is NOT sufficient.
     / ogon / gnome-remote-desktop / Weston are TCP-only or ride FreeRDP's server
     lib. ("first" can't be proven exhaustively — phrase it "first known".)
     Flag-OFF (empty safe spike) re-verified no-regression.
+
+    **Soak observability (added 2026-06-26):** the listener now logs the reliable
+    transport's RTO retransmits — `RDPEUDP RTO retransmit` at the inbound-driven
+    `step()` site and `RDPEUDP RTO retransmit (outbound)` at the server-data
+    `enqueue()` site, gated `if retransmits > 0 || syn_retransmit` so a clean link
+    stays silent. The counts come from the new `StepOutput.{retransmits,
+    syn_retransmit}` diagnostic fields (`ironrdp-rdpeudp`; the SM stays sans-I/O —
+    it counts, the listener logs). For a lossy-link soak run with
+    `RUST_LOG=ironrdp_server::multitransport::listener=debug`; protocol + the
+    `scripts/netshape.sh` shaper are in `docs/rdp-udp-multitransport-feasibility.md`
+    ("Soak testing the UDP path under loss").

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -456,7 +456,13 @@ async fn run_recv_loop(
         let was_established = peer.sm.is_established();
         let had_data = Datagram::peek_fec_flags(data).is_some_and(|f| f.contains(FecFlags::DATA));
         let out = peer.sm.step(now_ms, Some(data));
+        let (retransmits, syn_retransmit) = (out.retransmits, out.syn_retransmit);
         send_datagrams(&socket, peer_addr, out.to_send, cfg.mtu).await;
+        if retransmits > 0 || syn_retransmit {
+            // The reliable transport recovered lost packets — the signal a
+            // lossy-link soak watches. Quiet (count is 0) on a clean link.
+            debug!(%peer_addr, retransmits, syn_retransmit, "RDPEUDP RTO retransmit");
+        }
 
         if !was_established && peer.sm.is_established() {
             debug!(
@@ -581,7 +587,11 @@ async fn run_recv_loop(
                 }
                 if !tls_out.is_empty() {
                     let o = sm.enqueue(now_ms, &tls_out);
+                    let (retransmits, syn_retransmit) = (o.retransmits, o.syn_retransmit);
                     send_datagrams(&socket, peer_addr, o.to_send, cfg.mtu).await;
+                    if retransmits > 0 || syn_retransmit {
+                        debug!(%peer_addr, retransmits, syn_retransmit, "RDPEUDP RTO retransmit (outbound)");
+                    }
                 }
                 if handshake_done && !*tls_done_logged {
                     *tls_done_logged = true;


### PR DESCRIPTION
Prep for the next multitransport step: **soak EGFX-over-UDP under real packet loss.** Phase 1 is verified on a clean WiFi/LAN, which proves it *works* but not that it delivers the actual win (no head-of-line blocking on a lossy link). This lands what's needed to run — and measure — that soak.

### Observability (the substantive bit)
The reliable transport's RTO retransmits were completely silent, so a soak couldn't *confirm* recovery was happening. `ironrdp-rdpeudp`'s state machine is deliberately sans-I/O, so:
- `StepOutput` gains diagnostic fields `retransmits: usize` + `syn_retransmit: bool`, set in `pump()`.
- The **listener** logs them — `RDPEUDP RTO retransmit` (inbound-driven) and `RDPEUDP RTO retransmit (outbound)` (server-data path) — gated `if retransmits > 0 || syn_retransmit`, so a clean link stays quiet.
- Unit test `retransmit_counter_reports_rto_resends`: 0 before RTO → 1 on RTO → 0 after the ACK drains the window. (43 crate tests pass.)

### Tooling
`scripts/netshape.sh` — shapes both directions of TCP+UDP on the macrdp port using macOS's built-in `pf`/`dnctl` dummynet (no extra software):
```
sudo scripts/netshape.sh on --loss 5 --delay 100
sudo scripts/netshape.sh off
scripts/netshape.sh status
```

### Protocol
A "Soak testing the UDP path under loss" section in the feasibility doc: the A/B method (EGFX-on-UDP vs EGFX-on-TCP under identical shaping — the comparison that exposes head-of-line blocking), the `RUST_LOG` to set, what each log line means, and a specific edge to probe — on a **static screen** under loss the SM is only pumped by inbound datagrams, so a trailing video segment + lost ACKs could delay recovery. If the soak shows that, the fix is a periodic timer tick driving `step(now, None)`; deferred until proven needed (no speculative change).

### Safety
Feature/flag-off behavior is unchanged — the new `StepOutput` fields default to zero and the log lines never fire without retransmits. Divergence notes updated in both vendored CLAUDE.md files.

Build green (release), `ironrdp-rdpeudp` tests green, `cargo fmt` clean. The actual loss-test itself needs a real client + sudo, so it'll be run live next; this PR is the harness.