### PR TITLE
fix(multitransport): periodic retransmit timer — fixes lossy-link deadlock

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -135,9 +135,9 @@ RUST_LOG=info,ironrdp_server::multitransport::listener=debug
 ```
 
 and watch for:
-- `RDPEUDP RTO retransmit` / `RDPEUDP RTO retransmit (outbound)` — recovery firing
-  (inbound-driven vs server-data path). **Zero on a clean link**; a steady trickle
-  under loss is the system working as intended, not a fault.
+- `RDPEUDP RTO retransmit` / `… (outbound)` / `… (timer)` — recovery firing
+  (inbound-driven / server-data / periodic-timer path). **Zero on a clean link**; a
+  steady trickle under loss is the system working as intended, not a fault.
 - `RDPEUDP reliable data delivered` — in-order bytes reassembled.
 - `RDPEUDP DATA datagram delivered nothing (receive-sequence mismatch)` — an
   inbound gap (loss/reorder) the receiver is holding for.
@@ -162,6 +162,48 @@ trailing video segment *and* the client's follow-up ACKs are both lost, recovery
 be delayed until the next screen change. If that shows up, the fix is a periodic
 timer tick driving `step(now, None)` in the listener — deferred until the soak proves
 it's needed.
+
+### First soak findings (2026-06-26, mstsc, 5% loss + 100 ms/dir)
+
+Two distinct problems surfaced — the first fixed, the second a real limit of
+reliable-only multitransport.
+
+1. **Idle-retransmit deadlock — FIXED (the timer tick above, now landed).** At 5%
+   loss the *first run froze with a blank screen*: the SM was only pumped by inbound
+   datagrams / new outbound data, so the initial EGFX burst's lost segments were
+   never retransmitted, the in-flight window filled, and everything wedged (13 s of
+   inbound silence, zero retransmit logs). The deferred periodic timer (¼ RTO,
+   pumping every established peer with `step(now, None)`) was implemented in
+   response; the full screen then rendered. **So the timer is not optional — any
+   lossy link needs it.**
+
+2. **Steady-state freeze under a high-volume stream — a reliable-transport limit,
+   not a bug.** After rendering, the session still froze in steady state. Root
+   cause is structural: the EGFX channel rides **one reliable, *ordered* RDPEUDP
+   stream**, which has the *same head-of-line blocking as TCP* — a single lost video
+   segment stalls every byte behind it until it's retransmitted. Compounding it in
+   this test: (a) the client requested **1920×1080 on a 1512×982 Mac**, which forces
+   **full frames every tick, no damage rects** (the `configured size != native …
+   full frames every tick` warning) — a huge data volume that hits 5% loss
+   constantly; and (b) the H.264 encoder is throttled to `max_in_flight=2`, and its
+   credit is released by the client's **frame-acknowledge** PDUs *riding the same
+   reliable tunnel inbound* — which HOL-block under the same loss, starving the
+   encoder to a stop (observed: a flood of bare client ACKs, slow 48-byte inbound
+   frame-ack deliveries, then no new frames).
+
+   **The takeaway reframes the value prop:** reliable-only UDP multitransport
+   *isolates video from other channels' loss*, but the video stream still
+   HOL-blocks on its **own** loss — so it does **not** beat TCP for video on a lossy
+   link. The genuine loss-resilience win needs **Phase 2: the lossy `UdpFecL`
+   transport + FEC**, where video tolerates loss without retransmit-blocking. That
+   is now the clear next milestone if lossy-link video is the goal.
+
+   **Isolation experiments to run next** (cheap, pin the contribution of each
+   factor before committing to Phase 2): re-test at a **client resolution matching
+   the Mac** (kills the full-frame-every-tick volume → damage-rect updates) and at
+   **lower loss (1–2%)**; and A/B against EGFX-on-TCP (flag off) under identical
+   shaping to confirm the isolation benefit on the *other* channels even while video
+   is HOL-limited.
 
 ## TL;DR
 

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -531,3 +531,19 @@ AND released — #1276 landing is NOT sufficient.
     `RUST_LOG=ironrdp_server::multitransport::listener=debug`; protocol + the
     `scripts/netshape.sh` shaper are in `docs/rdp-udp-multitransport-feasibility.md`
     ("Soak testing the UDP path under loss").
+
+    **Soak fix — periodic retransmit timer (added 2026-06-26):** `run_recv_loop`'s
+    `tokio::select!` now has a third arm, a `retransmit_tick` interval at ¼ RTO that
+    calls `pump_peers_on_timer` (`step(now, None)` on every established peer, sending
+    due retransmits / queued data / owed ACKs; logs `RDPEUDP RTO retransmit (timer)`).
+    WHY: the SM only retransmits when pumped, and pumps were driven *solely* by
+    inbound datagrams / new outbound data. The **first 5%-loss soak deadlocked** —
+    the initial EGFX burst lost segments, the screen went static (no new frames), the
+    client went quiet waiting, so nothing pumped → lost segments never resent → window
+    filled → frozen (blank). The timer pumps during silence; full screen then
+    rendered. Idle ticks emit nothing (pump only sends what's due), so a clean link is
+    unaffected. **NOTE the soak also exposed a *structural* limit this does NOT fix:**
+    the EGFX channel rides one reliable *ordered* RDPEUDP stream, which HOL-blocks on
+    its own loss like TCP — so reliable-only multitransport does not beat TCP for
+    video under loss; that needs Phase 2 (lossy `UdpFecL` + FEC). See the feasibility
+    doc "First soak findings".

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -187,6 +187,32 @@ async fn send_datagrams(socket: &UdpSocket, peer_addr: SocketAddr, to_send: Vec<
     }
 }
 
+/// (Soak fix) Pump every established peer's reliability state machine on a timer
+/// tick (`step(now, None)`), shipping any due retransmits / queued data / owed ACK.
+/// This is what keeps the RTO retransmit clock running when neither inbound nor
+/// outbound traffic is flowing — without it a lossy link deadlocks (see the
+/// `retransmit_tick` rationale in `run_recv_loop`). Idle ticks emit nothing.
+async fn pump_peers_on_timer(
+    socket: &UdpSocket,
+    peers: &mut HashMap<SocketAddr, Peer>,
+    now_ms: u64,
+    mtu: u16,
+) {
+    for (addr, peer) in peers.iter_mut() {
+        if !peer.sm.is_established() {
+            continue;
+        }
+        let out = peer.sm.step(now_ms, None);
+        let (retransmits, syn_retransmit) = (out.retransmits, out.syn_retransmit);
+        if !out.to_send.is_empty() {
+            send_datagrams(socket, *addr, out.to_send, mtu).await;
+        }
+        if retransmits > 0 || syn_retransmit {
+            debug!(peer_addr = %addr, retransmits, syn_retransmit, "RDPEUDP RTO retransmit (timer)");
+        }
+    }
+}
+
 /// (M5c) Ship one server-originated HigherLayerData chunk to a bound peer: wrap it
 /// in `RDP_TUNNEL_DATA` (action 0x2), encrypt through the peer's MS-RDPEMT TLS, and
 /// send the resulting ciphertext reliably over RDPEUDP. Best-effort — an unbound
@@ -359,6 +385,21 @@ async fn run_recv_loop(
     let start = tokio::time::Instant::now();
     let mut buf = vec![0u8; 2048];
 
+    // (Soak fix) Periodic clock for the reliability state machines. The SM only
+    // retransmits / drains its send window when it's pumped (step/enqueue), and
+    // those are otherwise driven solely by inbound datagrams or new outbound data.
+    // On a lossy link that deadlocks: the initial EGFX burst loses segments, no new
+    // frames flow (static screen) and the client goes quiet waiting for the missing
+    // data, so nothing pumps → the lost segments are never resent → the in-flight
+    // window fills → frozen session (observed live at 5% loss). A timer well under
+    // the RTO pumps every peer on a `None` tick so retransmits fire on schedule even
+    // when both traffic directions are idle. Idle ticks send nothing (pump only
+    // emits due retransmits / queued data / an owed ACK), so the cost is negligible.
+    let tick_ms = (cfg.rto_ms / 4).clamp(20, 100);
+    let mut retransmit_tick = tokio::time::interval(std::time::Duration::from_millis(tick_ms));
+    retransmit_tick
+        .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
     loop {
         // (M5c) The recv loop is now bidirectional: it reads inbound datagrams AND
         // ships server-originated channel data (EGFX over the tunnel). When no
@@ -381,6 +422,11 @@ async fn run_recv_loop(
                     continue;
                 }
             },
+            _ = retransmit_tick.tick() => {
+                let now_ms = start.elapsed().as_millis() as u64;
+                pump_peers_on_timer(&socket, &mut peers, now_ms, cfg.mtu).await;
+                continue;
+            }
             out = outbound => {
                 let now_ms = start.elapsed().as_millis() as u64;
                 match out {


### PR DESCRIPTION
The first soak under emulated loss (mstsc, 5% loss + 100ms/dir) **deadlocked with a blank screen** — and that's exactly what this fixes.

### Root cause
The reliable RDPEUDP state machine only retransmits when it's *pumped* (`step`/`enqueue`), and `run_recv_loop` pumped it **solely** on inbound datagrams or new outbound data. So when the initial EGFX burst lost segments and the screen went static (no new frames) while the client went quiet waiting for the missing data, **nothing pumped** → lost segments never resent → in-flight window filled → frozen. The log signature: a 13-second inbound gap and **zero** retransmit lines.

### Fix
A third `tokio::select!` arm — a `retransmit_tick` interval at ¼ the RTO that calls `pump_peers_on_timer` (`step(now, None)` on every established peer), so RTO retransmits fire on schedule even when both traffic directions are idle. Idle ticks emit nothing (pump only sends due retransmits / queued data / an owed ACK), so a **clean link is unaffected**. New log line `RDPEUDP RTO retransmit (timer)`.

This is the periodic tick the soak-prep PR (#45) explicitly left deferred *"until the soak proves it's needed."* The soak proved it.

### Verified live
With this build, the **full screen now renders** under 5% loss where it was previously blank.

### Honest scope — what this does NOT fix
The same soak exposed a *structural* limit: the EGFX channel rides **one reliable, ordered RDPEUDP stream**, which head-of-line-blocks on its own loss exactly like TCP. So reliable-only multitransport **isolates video from other channels' loss but does not beat TCP for video under loss** — under a high-volume stream (worsened here by a 1080p-on-1512×982 full-frame-every-tick capture + a tight `max_in_flight=2` encoder credit released by HOL-blocked inbound frame-acks) it still freezes in steady state. The genuine loss-resilience win needs **Phase 2 (lossy `UdpFecL` + FEC)**. Documented in the feasibility doc's new "First soak findings" + the vendored server divergence (12).

Docs + divergence notes included.