### PR TITLE
feat(multitransport): P2.0 go/no-go spike — lossy UdpFecL offer + DTLS observe (GREEN on mstsc)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -316,15 +316,46 @@ Offer `UdpFecL` and watch a real mstsc (Win11/WiFi, the Phase-1 rig). Concretely
 This one spike converts "should we build a multi-week lossy stack?" into an empirical
 yes/no for the cost of a flag and a capture. **Do not skip it.**
 
+#### Result (2026-06-26): **GREEN** — verified live on real mstsc (Win11/WiFi)
+
+Ran with `MACRDP_UDP_OFFER_FECL=1` (the spike toggle in `src/multitransport.rs`).
+The log answered every sub-question, and decisively in favor of building Phase 2:
+
+- **mstsc advertises lossy and *prefers* UDP.** Its CS multitransport block was
+  `TRANSPORT_TYPE_UDP_FECR | TRANSPORT_TYPE_UDP_FECL | TRANSPORT_TYPE_UDP_PREFERRED |
+  SOFT_SYNC_TCP_TO_UDP` — so the "RDPEUDP2 dropped lossy, mstsc won't use it" worry was
+  unfounded for *this* mstsc build: it not only supports `UDP_FECL`, it sets
+  `UDP_PREFERRED`.
+- **It opened a lossy flow.** Once we emitted the `UdpFecL` Initiate Request, mstsc sent
+  a SYN with the **`SYN_LOSSY`** flag set (`FecFlags(SYN | SYN_LOSSY | CORRELATION_ID |
+  SYNEX)`), RDPEUDP version **V2** — the same version family as the reliable path, just
+  in lossy mode. So the lossy flow is *not* a different/older RDPEUDP; it's V2 with the
+  lossy bit.
+- **It started a DTLS handshake — DTLS 1.2, not 1.0.** The listener observed a
+  **DTLS 1.2** ClientHello (`0x16 0xFE 0xFD`), correcting the up-front research's
+  "DTLS 1.0" assumption. **This simplifies P2.1:** `boring`'s safe DTLS API covers 1.2
+  natively, so the one reason to prefer `openssl` (explicit DTLS-1.0 version pinning) is
+  moot — **`boring` is the clear choice.** (Implement 1.2; allow 1.0 fallback only if a
+  later client demands it.)
+- **Graceful throughout.** We implement no DTLS, so the handshake never completed; mstsc
+  simply retried its ClientHello periodically while the **session ran normally over TCP**
+  the entire time. Confirms the lossy offer is safe to ship behind a flag — a
+  non-responsive lossy flow costs nothing.
+
+**Verdict: proceed to P2.1 when ready.** The lossy payoff is reachable by the primary
+client. The spike code stays in-tree, env-gated and default-off (zero effect on the
+proven Phase-1 reliable path), as the harness for the P2.1+ DTLS work.
+
 ### If GREEN — the staged build (mirrors Phase 1's M1→M5 discipline)
 
 Each milestone is its own gated PR, real-client-verified, feature-flagged
 (`multitransport` cargo feature already exists; reuse it), zero-cost when off.
 
-- **P2.1 — DTLS layer (the hard new dependency).** Add `boring` (or `openssl` if we
-  want to pin DTLS 1.0 explicitly — it edges ahead there; `boring` does DTLS 1.0/1.2
-  over a memory BIO via `SslMethod::dtls()` + `Ssl::setup_accept()`, no DTLS 1.3 via the
-  safe API, which is fine — mstsc speaks DTLS 1.0). Quarantine **all** of it behind one
+- **P2.1 — DTLS layer (the hard new dependency).** Add `boring` — the P2.0 capture
+  showed mstsc offers **DTLS 1.2**, which `boring`'s safe API does natively
+  (`SslMethod::dtls()` + `Ssl::setup_accept()` over a memory BIO; no DTLS 1.3 via the
+  safe API, which is fine). The one reason to have considered `openssl` (explicit
+  DTLS-1.0 version pinning) is moot now that the client is 1.2. Quarantine **all** of it behind one
   maintenance-boundary file `vendor/ironrdp-server/src/multitransport/dtls.rs`, the same
   way Phase 1's rustls layer is isolated. **Wire layering (researched):** the DTLS record
   sits *inside* the cleartext RDPUDP framing, not around it —
@@ -390,13 +421,15 @@ new audio DVC (P2.4) — on top of, not instead of, Phase 1.
 
 ### Bottom line
 
-Phase 2 is **gated on a one-day go/no-go spike (P2.0)** because the lossy path is a
-legacy codepath and it is unproven that modern mstsc will use it at all. If it's GREEN,
-the highest-value payload is **audio** (a new `AUDIO_PLAYBACK_LOSSY_DVC`, reusing our AAC
-encoder), not video; FEC is encoder-only and even then optional; and DTLS 1.0 is the one
-hard new dependency, quarantined behind a single file. If P2.0 is RED, Phase 2 is parked
-with a clear conscience — Phase 1 (reliable EGFX over UDP, the path mstsc actually
-negotiates) stands on its own as the clean-link feature it is.
+Phase 2 was **gated on a one-day go/no-go spike (P2.0)** because the lossy path is a
+legacy codepath and it was unproven that modern mstsc would use it at all. **P2.0 ran
+GREEN (2026-06-26):** real mstsc advertises `UDP_FECL` + `UDP_PREFERRED`, opens a
+`SYN_LOSSY` flow, and starts a **DTLS 1.2** handshake — so the lossy payoff is reachable.
+Building it: the highest-value payload is **audio** (a new `AUDIO_PLAYBACK_LOSSY_DVC`,
+reusing our AAC encoder), not video; FEC is encoder-only and even then optional; and
+DTLS 1.2 via `boring` is the one hard new dependency, quarantined behind a single file.
+Phase 1 (reliable EGFX over UDP) remains the proven clean-link feature; Phase 2 lossy
+audio is the loss-resilience win, now greenlit to build when prioritized.
 
 ## TL;DR
 

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -20,11 +20,26 @@ use ironrdp_server::MultitransportProvider;
 /// M1 provider: offer reliable UDP multitransport. Reliable (`UdpFecR`) rides
 /// the connection's existing rustls TLS, so no DTLS / new crypto dependency is
 /// needed. Lossy (`UdpFecL`, which needs DTLS) is a later milestone.
+///
+/// **P2.0 go/no-go spike:** set `MACRDP_UDP_OFFER_FECL=1` to offer **lossy**
+/// (`UdpFecL`) *instead of* reliable, then connect a real mstsc and watch the
+/// listener log. The spike answers the gating Phase-2 question — does modern
+/// mstsc open a lossy UDP flow (a DTLS ClientHello, not TLS) at all, given that
+/// RDPEUDP2 dropped lossy and mstsc prefers reliable RDPEUDP2? No DTLS is
+/// implemented; the listener only *observes* whether the client starts a DTLS
+/// handshake. Default (env unset) is unchanged Phase-1 reliable behavior. See
+/// `docs/rdp-udp-multitransport-feasibility.md` → "P2.0 — Go/No-Go spike".
 pub struct MacMultitransport;
 
 impl MultitransportProvider for MacMultitransport {
     fn requested_protocol(&self) -> RequestedProtocol {
-        RequestedProtocol::UdpFecR
+        // P2.0 spike toggle: offer lossy instead of reliable. Read per call (the
+        // provider is process-wide; this is cheap and avoids extra plumbing).
+        if std::env::var_os("MACRDP_UDP_OFFER_FECL").is_some_and(|v| v == "1") {
+            RequestedProtocol::UdpFecL
+        } else {
+            RequestedProtocol::UdpFecR
+        }
     }
 }
 

--- a/vendor/ironrdp-acceptor/CLAUDE.md
+++ b/vendor/ironrdp-acceptor/CLAUDE.md
@@ -118,3 +118,13 @@ vendor dir until divergence (1) is upstreamed AND released.
       negotiates RDPEUDP **V2**, where the 16-byte security cookie is NOT in the
       SYN (the SYN `cookieHash` is V3/RDPEUDP2 only) — it rides the MS-RDPEMT
       `RDP_TUNNEL_CREATEREQUEST`, so strict cookie binding is an M4 concern.
+
+    P2.0 spike (2026-06-26): the `SC_MULTITRANSPORT` advertise at
+    `BasicSettingsSendResponse` now emits the flag MATCHING the offer's protocol
+    (`UDP_FECL` when `self.multitransport_offer.protocol == UdpFecL`, else
+    `UDP_FECR`) instead of hardcoding `UDP_FECR` — the advertised type and the
+    Initiate Request must agree. Default offer is still reliable; lossy is the
+    env-gated spike (`MACRDP_UDP_OFFER_FECL=1`). Verified GREEN on real mstsc: it
+    advertises `UDP_FECR|UDP_FECL|UDP_PREFERRED|SOFT_SYNC`, accepts the `UdpFecL`
+    Initiate Request, opens a `SYN_LOSSY` flow, and starts a **DTLS 1.2**
+    handshake. See docs/rdp-udp-multitransport-feasibility.md → "P2.0 Result".

--- a/vendor/ironrdp-acceptor/src/connection.rs
+++ b/vendor/ironrdp-acceptor/src/connection.rs
@@ -655,14 +655,25 @@ impl Sequence for Acceptor {
                 let skip_channel_join = early_capability
                     .is_some_and(|client| client.contains(gcc::ClientEarlyCapabilityFlags::SUPPORT_SKIP_CHANNELJOIN));
 
-                // (vendored) Advertise reliable UDP multitransport + soft-sync
-                // in `SC_MULTITRANSPORT` when the server enabled the extended
-                // client data path (which it does only when a multitransport
-                // provider is installed). Lossy (`UDP_FECL`) is a later phase.
-                let multitransport = self.advertise_extended_client_data.then_some(
-                    gcc::MultiTransportFlags::TRANSPORT_TYPE_UDP_FECR
-                        | gcc::MultiTransportFlags::SOFT_SYNC_TCP_TO_UDP,
-                );
+                // (vendored) Advertise UDP multitransport + soft-sync in
+                // `SC_MULTITRANSPORT` when the server enabled the extended client
+                // data path (which it does only when a multitransport provider is
+                // installed). The advertised transport type MUST match the offer
+                // the server is about to emit (reliable `UDP_FECR` by default;
+                // lossy `UDP_FECL` for the P2.0 go/no-go spike), or the client
+                // sees an Initiate Request for a transport it wasn't told the
+                // server supports. The offer is set (in `client_accepted`) before
+                // this state, so `self.multitransport_offer` is available here.
+                let multitransport = self.advertise_extended_client_data.then(|| {
+                    let proto_flag = match self.multitransport_offer.map(|o| o.protocol) {
+                        Some(rdp::multitransport::RequestedProtocol::UdpFecL) => {
+                            gcc::MultiTransportFlags::TRANSPORT_TYPE_UDP_FECL
+                        }
+                        // Default / `UdpFecR` / no offer: reliable.
+                        _ => gcc::MultiTransportFlags::TRANSPORT_TYPE_UDP_FECR,
+                    };
+                    proto_flag | gcc::MultiTransportFlags::SOFT_SYNC_TCP_TO_UDP
+                });
 
                 // (vendored) Allocate a message channel (the next id after the
                 // virtual channels) when offering multitransport — the Initiate

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -547,3 +547,17 @@ AND released — #1276 landing is NOT sufficient.
     its own loss like TCP — so reliable-only multitransport does not beat TCP for
     video under loss; that needs Phase 2 (lossy `UdpFecL` + FEC). See the feasibility
     doc "First soak findings".
+
+    P2.0 go/no-go spike (2026-06-26, `multitransport/listener.rs`): observe-only
+    support for a LOSSY flow, to answer whether modern mstsc opens one at all
+    before committing to a DTLS+FEC build. `sniff_dtls_client_hello` scans each raw
+    datagram for a DTLS handshake record (`0x16 0xFE 0xFF`/`0xFD`); on a match the
+    peer is marked `dtls_observed`, logged at WARN ("P2.0 SPIKE GREEN …"), and the
+    rustls (TLS) feed is skipped for it (DTLS records aren't TLS — feeding them is
+    error spam; no DTLS is implemented). Paired with the env-gated `UdpFecL` offer
+    (`MACRDP_UDP_OFFER_FECL=1` in `src/multitransport.rs`) + the acceptor's
+    matching `SC_MULTITRANSPORT` advertise. **Result: GREEN on real mstsc** — it
+    opens a `SYN_LOSSY` V2 flow and sends a **DTLS 1.2** ClientHello; the TCP
+    session is unaffected (the lossy handshake just retries unanswered). Default
+    build/offer is unchanged reliable; this is harness for the Phase 2 lossy work.
+    See the feasibility doc "P2.0 — Go/No-Go spike".

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -104,6 +104,24 @@ struct Peer {
     /// connection's `client_loop`. `None` on the soft-bound (no-registry) test
     /// path — inbound channel data is then logged and dropped.
     inbound_sink: Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>,
+    /// (P2.0 spike) Set once this peer is observed sending a **DTLS** ClientHello
+    /// — i.e. it opened a *lossy* (`UdpFecL`) flow. When set, we do NOT feed this
+    /// peer's bytes into rustls (DTLS records aren't TLS records and would only
+    /// produce error spam): the spike is observe-only, no DTLS is implemented.
+    dtls_observed: bool,
+}
+
+/// (P2.0 spike) Scan a raw RDPEUDP datagram for a **DTLS handshake** record — the
+/// signal that a client opened a *lossy* flow (vs a TLS ClientHello on a reliable
+/// flow). A DTLS record header is ContentType `0x16` (handshake) followed by the
+/// DTLS ProtocolVersion `0xFEFF` (DTLS 1.0) or `0xFEFD` (DTLS 1.2). The record
+/// sits at a header-dependent offset inside the datagram, so rather than compute
+/// it we scan for the 3-byte signature — specific enough for a diagnostic. Returns
+/// the matched version bytes for the log, if any.
+fn sniff_dtls_client_hello(datagram: &[u8]) -> Option<[u8; 2]> {
+    datagram.windows(3).find_map(|w| {
+        (w[0] == 0x16 && w[1] == 0xFE && (w[2] == 0xFF || w[2] == 0xFD)).then_some([w[1], w[2]])
+    })
 }
 
 /// A running UDP multitransport listener. The receive loop runs on a spawned
@@ -496,8 +514,30 @@ async fn run_recv_loop(
                 emt_inbound: Vec::new(),
                 tunnel_created: false,
                 inbound_sink: None,
+                dtls_observed: false,
             }
         });
+
+        // (P2.0 spike) Before anything else, sniff the raw datagram for a DTLS
+        // ClientHello. This fires on a *lossy* flow regardless of whether the
+        // reliable SM delivers the payload, so it's the most robust go/no-go
+        // signal: if this logs, modern mstsc DID open a lossy UDP flow (GREEN).
+        if !peer.dtls_observed {
+            if let Some(ver) = sniff_dtls_client_hello(data) {
+                peer.dtls_observed = true;
+                let dtls = match ver {
+                    [0xFE, 0xFF] => "DTLS 1.0",
+                    [0xFE, 0xFD] => "DTLS 1.2",
+                    _ => "DTLS",
+                };
+                warn!(
+                    %peer_addr, %dtls,
+                    "P2.0 SPIKE GREEN: client opened a LOSSY (UdpFecL) UDP flow — \
+                     it sent a {dtls} ClientHello. Lossy multitransport is reachable; \
+                     observe-only (no DTLS implemented). See feasibility doc P2.0."
+                );
+            }
+        }
 
         let was_established = peer.sm.is_established();
         let had_data = Datagram::peek_fec_flags(data).is_some_and(|f| f.contains(FecFlags::DATA));
@@ -552,7 +592,10 @@ async fn run_recv_loop(
             // (M4c: answer CREATEREQUEST with CREATERESPONSE), and ship whatever
             // TLS output that produces back through the SM (reliable, fragmented
             // to the MTU). No-op when the listener has no TLS config (test path).
-            if let Some(tls_cfg) = tls_config.as_ref() {
+            // (P2.0 spike) Skipped for a peer on a lossy flow (DTLS observed):
+            // DTLS records aren't TLS records, so feeding them to rustls is pure
+            // error spam — the spike only observes that the lossy flow exists.
+            if let Some(tls_cfg) = tls_config.as_ref().filter(|_| !peer.dtls_observed) {
                 if peer.tls.is_none() {
                     match ServerConnection::new(Arc::clone(tls_cfg)) {
                         Ok(conn) => peer.tls = Some(conn),


### PR DESCRIPTION
Implements the **P2.0 go/no-go spike** from the Phase-2 scope (#50) and records its result.

## Why
Phase 2 (lossy `UdpFecL` + DTLS + FEC + lossy audio) was gated on one question: **does modern mstsc open a lossy UDP flow at all?** RDPEUDP2 dropped lossy transport, and mstsc prefers reliable RDPEUDP2 (the already-shipped Phase-1 path), so the multi-week lossy stack would be wasted if the client won't open a lossy flow. Phase 1 only ever offered `UdpFecR`, so we had zero evidence either way.

## What (all env-gated / observe-only — default reliable path byte-unchanged)
- **`src/multitransport.rs`**: `MACRDP_UDP_OFFER_FECL=1` makes the provider offer `UdpFecL` instead of `UdpFecR`.
- **`vendor/ironrdp-acceptor`**: the `SC_MULTITRANSPORT` advertise now emits the flag matching the offer's protocol (`UDP_FECL` vs `UDP_FECR`) so the advertise and the Initiate Request agree.
- **`vendor/ironrdp-server` listener**: `sniff_dtls_client_hello` scans each raw datagram for a DTLS handshake record (`0x16 0xFE 0xFF`/`0xFD`); on a match it marks the peer `dtls_observed`, logs GREEN at WARN, and skips the rustls feed for it (DTLS ≠ TLS; no DTLS is implemented).

## Result: 🟢 GREEN (verified live, real mstsc Win11/WiFi)
- mstsc advertises `UDP_FECR | UDP_FECL | UDP_PREFERRED | SOFT_SYNC` — it *prefers* UDP.
- It accepts the `UdpFecL` Initiate Request and opens a **`SYN_LOSSY`** RDPEUDP **V2** flow.
- It starts a **DTLS 1.2** handshake — correcting the scope's "DTLS 1.0" research assumption. `boring`'s safe API covers 1.2, so **`boring` is the clear pick for P2.1**.
- The TCP session is unaffected throughout (the unanswered lossy handshake just retries).

**Conclusion:** Phase 2 lossy is reachable by the primary client → proceed to P2.1 (DTLS via `boring`) when prioritized. The spike code stays in-tree as the harness for that work.

Docs: feasibility doc "P2.0 Result" + DTLS-1.2 correction; acceptor + server divergence logs updated. 69 tests pass; clippy + fmt clean.