### PR TITLE
feat(multitransport): P2.1a — DTLS 1.2 server handshake on the lossy flow (GREEN on mstsc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +352,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "boring"
+version = "4.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0e3bc837369e9e662d3845c374ac3771b054d4bc2dee5457591198d16d684c"
+dependencies = [
+ "bitflags 2.11.1",
+ "boring-sys",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+]
+
+[[package]]
+name = "boring-sys"
+version = "4.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15aad385759d3da2737772aefb391332227bef7cb71fb85c106cadd9d1e63a98"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +462,17 @@ dependencies = [
  "block-buffer 0.11.0",
  "crypto-common 0.2.0-rc.8",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1005,6 +1068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1227,12 @@ checksum = "333de57ed9494a40df4bbb866752b100819dde0d18f2264c48f5a08a85fe673d"
 dependencies = [
  "polyval",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -1709,6 +1788,7 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "boring",
  "bytes",
  "getrandom 0.2.17",
  "ironrdp-acceptor",
@@ -1779,6 +1859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7660d28d24a831d690228a275d544654a30f3b167a8e491cf31af5fe5058b546"
 dependencies = [
  "untrusted",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2214,6 +2303,17 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "p256"
@@ -2700,6 +2800,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2824,6 +2936,12 @@ dependencies = [
  "num-traits",
  "realfft",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -365,7 +365,24 @@ Each milestone is its own gated PR, real-client-verified, feature-flagged
   self-signed cert as TCP/the reliable flow. **Risk:** a second C-crypto stack in the
   signed/notarized macOS binary — verify the build + notarization still pass (we already
   link aws-lc-rs/ring, so the toolchain exists, but `boring` is a distinct BoringSSL
-  vendored build). Spike the mstsc DTLS-1.0 handshake interop against a capture.
+  vendored build). Spike the mstsc DTLS handshake interop against a capture.
+
+  **Result (P2.1a, 2026-06-26): GREEN — verified live on real mstsc.** The DTLS
+  1.2 server handshake **completes** over the lossy (`UdpFecL`) RDPEUDP flow,
+  sans-I/O via `boring`'s custom-BIO `SslStream` (`multitransport/dtls.rs`),
+  driven datagram-by-datagram from the listener. Timeline from the log: client
+  DTLS 1.2 ClientHello → server flight (ServerHello/Certificate/Done) → client
+  ClientKeyExchange+ChangeCipherSpec+Finished → **handshake complete in ~13 ms /
+  ~2 RTT**, no errors. Build facts confirmed: `boring`/BoringSSL builds with the
+  local Go+cmake+libclang toolchain and coexists with rustls's aws-lc-rs; **no
+  DTLS cookie exchange needed** (BoringSSL dropped `DTLSv1_listen`); `set_mtu(1100)`
+  + `SslOptions::NO_DTLSV1` pin 1.2 (boring has no DTLS `SslVersion` constants).
+  Two follow-ups observed: (1) post-handshake the client retransmits an encrypted
+  MS-RDPEMT `CREATEREQUEST` (~5/s) we don't answer yet — that's **P2.4**
+  (EMT-over-DTLS tunnel); (2) the lossy flow is still driven through the
+  *reliable* RDPEUDP SM (fine on a clean link; proper lossy delivery is P2.2).
+  Env-gated (`MACRDP_UDP_OFFER_FECL=1`) + default-off; the reliable path is
+  byte-unchanged.
 
 - **P2.2 — lossy RDPEUDP state machine.** Extend `vendor/ironrdp-rdpeudp` with a lossy
   mode alongside the existing reliable one: source packets sent **without retransmit**,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1074,7 +1074,22 @@ fn generate_and_persist(
     Ok((vec![cert_der], key_der))
 }
 
-fn make_tls_acceptor(cert_dir: &Path) -> Result<(TlsAcceptor, Vec<u8>, Arc<ServerConfig>)> {
+/// The TLS material derived from the persisted cert/key, shared across the TCP
+/// connection and the UDP multitransport flows.
+struct TlsMaterial {
+    /// rustls acceptor for the main TCP RDP connection.
+    acceptor: TlsAcceptor,
+    /// Raw `subjectPublicKey` BIT STRING for CredSSP channel binding.
+    spki_der: Vec<u8>,
+    /// rustls config reused to secure the reliable (`UdpFecR`) UDP flow.
+    config: Arc<ServerConfig>,
+    /// Cert DER, for building the lossy (`UdpFecL`) flow's DTLS context (Phase 2).
+    cert_der: Vec<u8>,
+    /// Private-key DER, same purpose as `cert_der`.
+    key_der: Vec<u8>,
+}
+
+fn make_tls_acceptor(cert_dir: &Path) -> Result<TlsMaterial> {
     let cert_path = cert_dir.join("cert.pem");
     let key_path = cert_dir.join("key.pem");
 
@@ -1104,6 +1119,11 @@ fn make_tls_acceptor(cert_dir: &Path) -> Result<(TlsAcceptor, Vec<u8>, Arc<Serve
         .raw_bytes()
         .to_vec();
 
+    // Capture the cert + key DER before they're moved into the rustls config —
+    // the lossy UDP flow's DTLS server (Phase 2) is built from the same bytes.
+    let cert_der = cert_der_bytes.to_vec();
+    let key_der = key.secret_der().to_vec();
+
     let config = Arc::new(
         ServerConfig::builder()
             .with_no_client_auth()
@@ -1111,9 +1131,16 @@ fn make_tls_acceptor(cert_dir: &Path) -> Result<(TlsAcceptor, Vec<u8>, Arc<Serve
             .context("build rustls ServerConfig")?,
     );
     // The same cert/config also secures the auxiliary UDP multitransport (MS-RDPEMT
-    // over TLS) — the client trusts it via the main connection's TOFU. Returned so
-    // the UDP listener can reuse it without re-loading the cert.
-    Ok((TlsAcceptor::from(Arc::clone(&config)), spki_der, config))
+    // over TLS for the reliable flow; DTLS for the lossy flow) — the client trusts
+    // it via the main connection's TOFU. Returned so the UDP listener can reuse it
+    // without re-loading the cert.
+    Ok(TlsMaterial {
+        acceptor: TlsAcceptor::from(Arc::clone(&config)),
+        spki_der,
+        config,
+        cert_der,
+        key_der,
+    })
 }
 
 /// Spawn the session-transition watcher used by `--detach-primary`
@@ -1775,7 +1802,13 @@ async fn async_main() -> Result<()> {
         Some(p) => p,
         None => default_cert_dir()?,
     };
-    let (tls, spki_der, udp_tls_config) = make_tls_acceptor(&cert_dir)?;
+    let TlsMaterial {
+        acceptor: tls,
+        spki_der,
+        config: udp_tls_config,
+        cert_der: udp_cert_der,
+        key_der: udp_key_der,
+    } = make_tls_acceptor(&cert_dir)?;
 
     // Resolve desktop dimensions + geometry. Three paths:
     //   - virtual display: width/height are already enforced as required
@@ -2132,12 +2165,27 @@ async fn async_main() -> Result<()> {
         // migrated onto the tunnel) through the sender; the listener owns the rx
         // and ships them as RDP_TUNNEL_DATA over the bound peer's UDP tunnel.
         let (tunnel_sender, tunnel_rx) = ironrdp_server::tunnel_channel();
+        // Phase 2 (P2.1a): a DTLS 1.2 server context for the LOSSY (UdpFecL) flow,
+        // built from the same cert as the TCP/reliable path. Non-fatal if it fails
+        // to build (the lossy flow then falls back to observe-only); the reliable
+        // flow is unaffected.
+        let udp_dtls_config = match ironrdp_server::DtlsServerContext::from_der(
+            &udp_cert_der,
+            &udp_key_der,
+        ) {
+            Ok(ctx) => Some(ctx),
+            Err(e) => {
+                warn!(error = %e, "could not build DTLS server context for the lossy UDP flow; lossy stays observe-only");
+                None
+            }
+        };
         match ironrdp_server::UdpMultitransportListener::bind(
             args.bind,
             cfg,
             Some(udp_tls_config.clone()),
             Some(cookie_registry.clone()),
             Some(tunnel_rx),
+            udp_dtls_config,
         )
         .await
         {

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -234,10 +234,16 @@ mod tests {
         let cfg = ListenerConfig::default();
         // No TLS config, no cookie registry, no tunnel handoff: this test only
         // exercises the SYN→SYN+ACK handshake (soft cookie binding).
-        let listener =
-            UdpMultitransportListener::bind("127.0.0.1:0".parse().unwrap(), cfg, None, None, None)
-                .await
-                .expect("bind listener");
+        let listener = UdpMultitransportListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            cfg,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("bind listener");
         let server_addr = listener.local_addr();
 
         let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -561,3 +561,23 @@ AND released — #1276 landing is NOT sufficient.
     session is unaffected (the lossy handshake just retries unanswered). Default
     build/offer is unchanged reliable; this is harness for the Phase 2 lossy work.
     See the feasibility doc "P2.0 — Go/No-Go spike".
+
+    P2.1a — DTLS 1.2 server handshake on the lossy flow (2026-06-26,
+    `multitransport/dtls.rs`, gated `dep:boring` under the `multitransport`
+    feature): a sans-I/O DTLS 1.2 server over boring's custom-BIO `SslStream`
+    (`DtlsServerContext::from_der` built from the same cert as the TCP/reliable
+    path; per-peer `DtlsConn::read_datagram` fed one delivered chunk = one
+    datagram at a time — the load-bearing boundary rule). The listener creates a
+    `DtlsConn` for a `dtls_observed` peer when a `DtlsServerContext` is passed to
+    `bind` (6th arg; `None` = observe-only), feeds delivered datagrams, and ships
+    the handshake flights back via the reliable SM's `enqueue`. **Verified GREEN
+    on real mstsc**: full DTLS 1.2 handshake completes in ~13 ms / ~2 RTT over the
+    lossy flow, no errors. boring config: `SslMethod::dtls()` + `set_mtu(1100)` +
+    `SslOptions::NO_DTLSV1` (boring has no DTLS `SslVersion` consts) + `set_verify(NONE)`;
+    no cookie exchange (BoringSSL dropped `DTLSv1_listen`). BoringSSL is vendored +
+    built from source (cmake+Go+libclang; coexists with rustls aws-lc-rs via symbol
+    prefixing). Scope is handshake-only — post-handshake the client retransmits an
+    encrypted EMT `CREATEREQUEST` we don't answer yet (P2.4). Default build pulls in
+    boring (multitransport feature always-on for macrdp); runtime DTLS path only
+    runs for a lossy peer, i.e. only when `MACRDP_UDP_OFFER_FECL=1`. See the
+    feasibility doc "P2.1 … Result (P2.1a)".

--- a/vendor/ironrdp-server/Cargo.toml
+++ b/vendor/ironrdp-server/Cargo.toml
@@ -30,7 +30,7 @@ egfx = ["dep:ironrdp-egfx"]
 # the standard build is byte-identical. M1 performs the negotiation handshake;
 # M3 adds the UDP listener + RDPEUDP SYN/SYN+ACK handshake (pulls in the
 # sans-I/O ironrdp-rdpeudp crate for the wire codecs + reliability SM).
-multitransport = ["dep:ironrdp-rdpeudp", "dep:getrandom"]
+multitransport = ["dep:ironrdp-rdpeudp", "dep:getrandom", "dep:boring"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at any time.
@@ -64,6 +64,12 @@ ironrdp-rdpdr = "0.5" # public (vendored — server-direction RDPDR)
 # via the root patch to the same git rev.
 ironrdp-rdpeudp = { path = "../ironrdp-rdpeudp", optional = true }
 getrandom = { version = "0.2", optional = true } # multitransport: CSPRNG cookie
+# (vendored, multitransport-only, Phase 2) DTLS 1.2 server for the LOSSY
+# (`UdpFecL`) flow — sans-I/O over boring's custom-BIO `SslStream`. BoringSSL is
+# vendored + built from source (needs cmake + Go + libclang at build time;
+# GitHub-hosted CI runners ship all three). Coexists with rustls's aws-lc-rs/ring
+# via symbol prefixing. Only pulled in with the multitransport feature.
+boring = { version = "4", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 x509-cert = { version = "0.2.5", optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }

--- a/vendor/ironrdp-server/src/lib.rs
+++ b/vendor/ironrdp-server/src/lib.rs
@@ -36,6 +36,8 @@ pub use echo::{EchoDvcBridge, EchoRoundTripMeasurement, EchoServerHandle, EchoSe
 pub use gfx::{EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle};
 pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "multitransport")]
+pub use multitransport::dtls::DtlsServerContext;
+#[cfg(feature = "multitransport")]
 pub use multitransport::listener::{ListenerConfig, UdpMultitransportListener};
 #[cfg(feature = "multitransport")]
 pub use multitransport::{CookieRegistry, MultitransportProvider, TunnelSender, encode_initiate_request, tunnel_channel};

--- a/vendor/ironrdp-server/src/multitransport/dtls.rs
+++ b/vendor/ironrdp-server/src/multitransport/dtls.rs
@@ -1,0 +1,219 @@
+//! (vendored, feature=multitransport, Phase 2) Sans-I/O **DTLS 1.2 server** for
+//! the LOSSY (`UdpFecL`) RDPEUDP flow.
+//!
+//! The reliable (`UdpFecR`) flow secures its MS-RDPEMT tunnel with **rustls**
+//! over the reliable byte-stream (see `listener.rs`). The lossy flow instead
+//! carries **DTLS** records inside its RDPEUDP payloads — mstsc was observed
+//! (P2.0 spike) opening a `SYN_LOSSY` flow and sending a **DTLS 1.2** ClientHello
+//! (`0x16 0xFE 0xFD`). This module drives BoringSSL's DTLS server handshake
+//! sans-I/O: macrdp owns the UDP socket + RDPEUDP demux, so we feed inbound
+//! datagram bytes in and pull outbound datagram bytes out, rather than handing
+//! BoringSSL a socket.
+//!
+//! ## The load-bearing rule (datagram boundaries)
+//!
+//! boring's [`SslStream<S>`] installs a *custom BIO* whose read callback calls
+//! `S::read` exactly once per `BIO_read` and returns that call's bytes verbatim.
+//! BoringSSL's DTLS record layer expects **one whole datagram per `BIO_read`**.
+//! So [`MemTransport::read`] MUST return exactly one inbound datagram per call —
+//! never coalesce two received datagrams, never split one. We enforce this by
+//! staging a single datagram into `inbound` before each `do_handshake` pump and
+//! draining it in one `read`. (We do NOT use a BoringSSL memory BIO
+//! `BIO_s_mem` — that's stream-oriented and corrupts DTLS record boundaries; the
+//! custom-BIO-over-`Read`/`Write` bridge is the correct sans-I/O mechanism.)
+//!
+//! ## No cookie exchange
+//!
+//! BoringSSL removed `DTLSv1_listen` and performs no HelloVerifyRequest by
+//! default (we never set `SSL_OP_COOKIE_EXCHANGE`). macrdp already demuxes peers
+//! by RDPEUDP flow, so the first ClientHello drives a full handshake straight
+//! away — exactly what we want.
+//!
+//! **Scope (P2.1a): handshake only.** Reaching "established" proves
+//! MS-RDPEMT-over-DTLS is reachable. The post-handshake app-record path (the EMT
+//! tunnel + lossy audio DVC) is P2.4+.
+
+use std::collections::VecDeque;
+use std::io::{self, Read, Write};
+use std::sync::Arc;
+
+use boring::pkey::PKey;
+use boring::ssl::{
+    HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslContextBuilder, SslMethod, SslOptions, SslStream,
+    SslVerifyMode,
+};
+use boring::x509::X509;
+
+/// Datagram MTU handed to BoringSSL so it fragments the Certificate handshake
+/// message to fit inside one RDPEUDP source payload. Kept comfortably under the
+/// RDPEUDP MTU (1232) minus RDPUDP/FEC/source-header overhead, so a DTLS
+/// datagram is never split across two RDPEUDP datagrams.
+const DTLS_MTU: u32 = 1100;
+
+fn stack(e: boring::error::ErrorStack) -> io::Error {
+    io::Error::other(e.to_string())
+}
+
+/// Built once from the server's cert+key (the same self-signed cert as the TCP
+/// TLS path), cheaply cloned per peer.
+#[derive(Clone)]
+pub struct DtlsServerContext {
+    ctx: Arc<SslContext>,
+}
+
+impl DtlsServerContext {
+    /// Build the DTLS 1.2 server context from DER-encoded cert + private key (the
+    /// bytes macrdp already holds for the rustls config).
+    pub fn from_der(cert_der: &[u8], key_der: &[u8]) -> io::Result<Self> {
+        let cert = X509::from_der(cert_der).map_err(stack)?;
+        let key = PKey::private_key_from_der(key_der).map_err(stack)?;
+
+        let mut b = SslContextBuilder::new(SslMethod::dtls()).map_err(stack)?;
+        // Pin DTLS 1.2 (mstsc's ClientHello is 0xFEFD). boring has no DTLS
+        // `SslVersion` constants — DTLS version is selected via SslOptions, so
+        // disable DTLS 1.0, leaving 1.2 as the only enabled version.
+        b.set_options(SslOptions::NO_DTLSV1);
+        b.set_certificate(&cert).map_err(stack)?;
+        b.set_private_key(&key).map_err(stack)?;
+        b.check_private_key().map_err(stack)?;
+        // Server-authenticated only; the client presents no cert (TOFU on the
+        // same self-signed cert as the TCP path). Deliberately NOT setting
+        // SSL_OP_COOKIE_EXCHANGE — we demux peers ourselves.
+        b.set_verify(SslVerifyMode::NONE);
+
+        Ok(Self { ctx: Arc::new(b.build()) })
+    }
+
+    /// One DTLS endpoint per RDPEUDP lossy peer/flow.
+    pub fn new_conn(&self) -> io::Result<DtlsConn> {
+        let mut ssl = Ssl::new(&self.ctx).map_err(stack)?;
+        ssl.set_mtu(DTLS_MTU).map_err(stack)?; // wired to BIO_CTRL_DGRAM_QUERY_MTU
+        // `setup_accept` puts the SSL in server-accept state and wraps the
+        // transport, performing no I/O (it returns a mid-handshake stream we
+        // drive datagram-by-datagram).
+        let mid = ssl.setup_accept(MemTransport::default());
+        Ok(DtlsConn {
+            state: State::Handshaking(Some(mid)),
+        })
+    }
+}
+
+/// Handshake state. `Option<>` lets us move the mid-handshake stream out of
+/// `&mut self` across `handshake()` (which consumes it).
+enum State {
+    Handshaking(Option<MidHandshakeSslStream<MemTransport>>),
+    Established(SslStream<MemTransport>),
+    Failed,
+}
+
+/// In-memory datagram transport backing boring's custom BIO. `inbound` holds the
+/// ONE datagram we want BoringSSL to read next (staged right before each pump);
+/// `outbound` queues the datagrams BoringSSL produced (one per `write` call).
+#[derive(Default)]
+struct MemTransport {
+    inbound: Vec<u8>,
+    outbound: VecDeque<Vec<u8>>,
+}
+
+impl Read for MemTransport {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.inbound.is_empty() {
+            // No staged datagram → tell BoringSSL WANT_READ; `do_handshake`
+            // then reports `would_block()`.
+            return Err(io::Error::from(io::ErrorKind::WouldBlock));
+        }
+        // Hand back exactly ONE datagram (truncate rather than split if it
+        // somehow exceeds buf — a malformed record the DTLS layer drops, never a
+        // silent mis-frame).
+        let n = self.inbound.len().min(buf.len());
+        buf[..n].copy_from_slice(&self.inbound[..n]);
+        self.inbound.clear();
+        Ok(n)
+    }
+}
+
+impl Write for MemTransport {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // One BIO_write == one outbound datagram; queue it whole.
+        self.outbound.push_back(buf.to_vec());
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// One peer's DTLS handshake state.
+pub struct DtlsConn {
+    state: State,
+}
+
+fn drain_outbound(t: &mut MemTransport) -> Vec<Vec<u8>> {
+    t.outbound.drain(..).collect()
+}
+
+impl DtlsConn {
+    /// Feed ONE inbound DTLS datagram (the bytes pulled from an RDPEUDP lossy
+    /// payload) and return the outbound datagrams to send back (wrap each in an
+    /// RDPEUDP payload). Returns several when a flight spans multiple records
+    /// (ServerHello + Certificate fragments + ServerHelloDone, or the final
+    /// Finished flight).
+    pub fn read_datagram(&mut self, input: &[u8]) -> io::Result<Vec<Vec<u8>>> {
+        if !input.is_empty() {
+            // Stage exactly this one datagram (drained in one `read`).
+            if let Some(t) = self.transport_mut() {
+                t.inbound = input.to_vec();
+            }
+        }
+        match core::mem::replace(&mut self.state, State::Failed) {
+            State::Handshaking(Some(mid)) => match mid.handshake() {
+                Ok(mut stream) => {
+                    let out = drain_outbound(stream.get_mut());
+                    self.state = State::Established(stream);
+                    Ok(out)
+                }
+                // Consumed the staged datagram, produced part of a flight; wait
+                // for the next inbound datagram.
+                Err(HandshakeError::WouldBlock(mut mid)) => {
+                    let out = drain_outbound(mid.get_mut());
+                    self.state = State::Handshaking(Some(mid));
+                    Ok(out)
+                }
+                Err(HandshakeError::Failure(mid)) => {
+                    self.state = State::Failed;
+                    Err(io::Error::other(format!("DTLS handshake failed: {}", mid.error())))
+                }
+                Err(HandshakeError::SetupFailure(e)) => {
+                    self.state = State::Failed;
+                    Err(io::Error::other(e.to_string()))
+                }
+            },
+            State::Handshaking(None) => {
+                self.state = State::Failed;
+                Err(io::Error::other("DTLS conn in invalid state"))
+            }
+            // Already established: post-handshake app records are P2.4+.
+            State::Established(s) => {
+                self.state = State::Established(s);
+                Ok(Vec::new())
+            }
+            State::Failed => {
+                self.state = State::Failed;
+                Err(io::Error::other("DTLS conn already failed"))
+            }
+        }
+    }
+
+    /// Whether the DTLS handshake has completed (the peer is established).
+    pub fn is_handshake_done(&self) -> bool {
+        matches!(self.state, State::Established(_))
+    }
+
+    fn transport_mut(&mut self) -> Option<&mut MemTransport> {
+        match &mut self.state {
+            State::Handshaking(Some(mid)) => Some(mid.get_mut()),
+            State::Established(s) => Some(s.get_mut()),
+            _ => None,
+        }
+    }
+}

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -37,6 +37,7 @@ use ironrdp_rdpeudp::datagram::Datagram;
 use ironrdp_rdpeudp::pdu::FecFlags;
 use ironrdp_rdpeudp::state::{Config, RdpeudpState, Role};
 
+use crate::multitransport::dtls::{DtlsConn, DtlsServerContext};
 use crate::multitransport::{CookieRegistry, TunnelOutbound};
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -106,9 +107,15 @@ struct Peer {
     inbound_sink: Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>,
     /// (P2.0 spike) Set once this peer is observed sending a **DTLS** ClientHello
     /// — i.e. it opened a *lossy* (`UdpFecL`) flow. When set, we do NOT feed this
-    /// peer's bytes into rustls (DTLS records aren't TLS records and would only
-    /// produce error spam): the spike is observe-only, no DTLS is implemented.
+    /// peer's bytes into rustls (DTLS records aren't TLS records). Instead, when a
+    /// DTLS server context is configured, P2.1 drives a DTLS handshake (below).
     dtls_observed: bool,
+    /// (P2.1a) The DTLS 1.2 server handshake for a lossy peer, created lazily on
+    /// the first delivered data once `dtls_observed` and a DTLS context is set.
+    /// `None` on the reliable path or the observe-only (no-DTLS-context) path.
+    dtls: Option<DtlsConn>,
+    /// Whether we've logged DTLS-handshake completion (avoid log spam).
+    dtls_done_logged: bool,
 }
 
 /// (P2.0 spike) Scan a raw RDPEUDP datagram for a **DTLS handshake** record — the
@@ -146,12 +153,19 @@ impl UdpMultitransportListener {
     /// When set, an inbound tunnel `CREATEREQUEST` is accepted only if its echoed
     /// cookie is registered (binding the UDP flow to a real TCP session, one-time
     /// use). `None` leaves binding soft (accept any cookie — handshake-test path).
+    ///
+    /// `dtls_config` (Phase 2 / P2.1a) is the DTLS 1.2 server context used to
+    /// secure the LOSSY (`UdpFecL`) flow (built from the SAME cert as the TCP /
+    /// reliable path). When set, a peer observed sending a DTLS ClientHello (a
+    /// lossy flow) is driven through a DTLS handshake instead of rustls. `None`
+    /// leaves the lossy flow observe-only (the P2.0 spike behavior).
     pub async fn bind(
         addr: SocketAddr,
         cfg: ListenerConfig,
         tls_config: Option<Arc<ServerConfig>>,
         cookie_registry: Option<CookieRegistry>,
         tunnel_rx: Option<UnboundedReceiver<TunnelOutbound>>,
+        dtls_config: Option<DtlsServerContext>,
     ) -> io::Result<Self> {
         let socket = UdpSocket::bind(addr).await?;
         let local_addr = socket.local_addr()?;
@@ -159,6 +173,7 @@ impl UdpMultitransportListener {
         debug!(
             %local_addr, ?cfg,
             tls = tls_config.is_some(),
+            dtls = dtls_config.is_some(),
             cookie_binding = cookie_registry.is_some(),
             tunnel_handoff = tunnel_rx.is_some(),
             "RDPEUDP multitransport listener bound"
@@ -169,6 +184,7 @@ impl UdpMultitransportListener {
             tls_config,
             cookie_registry,
             tunnel_rx,
+            dtls_config,
         ));
         Ok(Self { local_addr, task })
     }
@@ -394,6 +410,7 @@ async fn run_recv_loop(
     tls_config: Option<Arc<ServerConfig>>,
     cookie_registry: Option<CookieRegistry>,
     mut tunnel_rx: Option<UnboundedReceiver<TunnelOutbound>>,
+    dtls_config: Option<DtlsServerContext>,
 ) {
     let mut peers: HashMap<SocketAddr, Peer> = HashMap::new();
     // (M5c) cookie -> peer address, populated when a tunnel binds, so
@@ -515,6 +532,8 @@ async fn run_recv_loop(
                 tunnel_created: false,
                 inbound_sink: None,
                 dtls_observed: false,
+                dtls: None,
+                dtls_done_logged: false,
             }
         });
 
@@ -584,6 +603,57 @@ async fn run_recv_loop(
                     %peer_addr,
                     "RDPEUDP reliable stream carries a TLS ClientHello (MS-RDPEMT handshake starting)"
                 );
+            }
+
+            // (P2.1a) LOSSY flow: drive the DTLS 1.2 server handshake. The DTLS
+            // records ride this flow's RDPEUDP payloads, so we feed each delivered
+            // chunk (one datagram — the boundary rule in `dtls.rs`) into boring
+            // and ship the resulting datagram(s) back over RDPEUDP. Reaching
+            // "established" proves MS-RDPEMT-over-DTLS is reachable (P2.1a scope;
+            // the EMT tunnel + lossy audio DVC over it are P2.4+). Mutually
+            // exclusive with the rustls block below (that one is gated on
+            // `!dtls_observed`).
+            if peer.dtls_observed {
+                if let Some(dtls_ctx) = dtls_config.as_ref() {
+                    if peer.dtls.is_none() {
+                        match dtls_ctx.new_conn() {
+                            Ok(c) => peer.dtls = Some(c),
+                            Err(e) => warn!(%peer_addr, error = %e, "failed to create DTLS server conn"),
+                        }
+                    }
+                    let Peer {
+                        sm,
+                        dtls: dtls_opt,
+                        dtls_done_logged,
+                        ..
+                    } = peer;
+                    if let Some(conn) = dtls_opt.as_mut() {
+                        for chunk in &out.delivered {
+                            match conn.read_datagram(chunk) {
+                                Ok(outs) => {
+                                    // Send each DTLS datagram as its own RDPEUDP
+                                    // source payload (DTLS MTU < RDPEUDP MTU, so a
+                                    // datagram is never split across two).
+                                    for dg in outs {
+                                        let o = sm.enqueue(now_ms, &dg);
+                                        send_datagrams(&socket, peer_addr, o.to_send, cfg.mtu).await;
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!(%peer_addr, error = %e, "DTLS handshake error on lossy flow");
+                                    break;
+                                }
+                            }
+                        }
+                        if conn.is_handshake_done() && !*dtls_done_logged {
+                            *dtls_done_logged = true;
+                            warn!(
+                                %peer_addr,
+                                "P2.1 GREEN: DTLS 1.2 handshake COMPLETE on the LOSSY (UdpFecL) flow — MS-RDPEMT-over-DTLS reachable"
+                            );
+                        }
+                    }
+                }
             }
 
             // M4b/M4c: drive the MS-RDPEMT server-side TLS handshake over the

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -21,6 +21,7 @@
 //! `migration` submodules (the UDP transport + channel migration); the trait
 //! will gain methods accordingly.
 
+pub mod dtls;
 pub mod listener;
 
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};


### PR DESCRIPTION
First **Phase-2 build step**: a sans-I/O **DTLS 1.2 server handshake** over the lossy (`UdpFecL`) RDPEUDP flow, via `boring` (BoringSSL). Reaching "established" proves MS-RDPEMT-over-DTLS is reachable — the foundation for lossy audio (P2.4).

Builds directly on the P2.0 GREEN finding (#51): mstsc opens a `SYN_LOSSY` flow and starts a DTLS 1.2 handshake. Now we answer it.

## What
- **`multitransport/dtls.rs`** (new, the quarantined boundary file): `DtlsServerContext::from_der` (built from the same self-signed cert as the TCP path) + per-peer `DtlsConn` driven datagram-by-datagram over `boring`'s custom-BIO `SslStream`. The **load-bearing rule**: `MemTransport::read` returns exactly **one datagram per call**, so DTLS record boundaries are preserved. No cookie exchange (BoringSSL dropped `DTLSv1_listen`); `set_mtu(1100)` + `SslOptions::NO_DTLSV1` pin DTLS 1.2; `set_verify(NONE)` (server-auth-only TOFU).
- **listener**: a `dtls_observed` (lossy) peer is driven through the DTLS handshake when a `DtlsServerContext` is passed to `bind` (new 6th arg; `None` = observe-only), shipping flights back via the reliable SM's `enqueue`.
- **main.rs**: build the DTLS context from the cert/key DER (`make_tls_acceptor` now returns a `TlsMaterial` struct) and pass it in.
- **Cargo**: `boring` = optional dep, gated behind the `multitransport` feature.

## Result: 🟢 GREEN (verified live, real mstsc Win11/WiFi)
Full DTLS 1.2 handshake completes over the lossy flow in **~13 ms / ~2 RTT**, no errors:
`ClientHello → ServerHello/Certificate/Done → ClientKeyExchange/CCS/Finished → COMPLETE`. `boring`/BoringSSL builds with cmake+Go+libclang and coexists with rustls's aws-lc-rs.

## Scope / follow-ups
- **Handshake-only.** Post-handshake the client retransmits an encrypted EMT `CREATEREQUEST` we don't answer yet → **P2.4** (EMT-over-DTLS tunnel + lossy audio DVC).
- The lossy flow is still driven through the *reliable* RDPEUDP SM (fine on a clean link; proper lossy delivery is **P2.2**).
- Env-gated (`MACRDP_UDP_OFFER_FECL=1`) + default-off; the reliable Phase-1 path is **byte-unchanged**.

## CI note
`boring-sys` vendors + builds BoringSSL from source (needs cmake + Go + libclang). GitHub-hosted `ubuntu-latest`/`macos-latest` runners ship all three; first build is slower (cached after).

69 tests pass; clippy + fmt clean.