### PR TITLE
docs(multitransport): P2.4b spike — audio output DVC handshake (gated, paused)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -425,6 +425,47 @@ Each milestone is its own gated PR, real-client-verified, feature-flagged
   tunnel. This is the **substantial, genuinely-new** piece of Phase 2 — a new audio
   channel, not a wiring change.
 
+  **P2.4b-1 spike result (2026-06-27): the DVC audio handshake works — but the EGFX
+  "negotiate-on-TCP-then-migrate" pattern does NOT carry over to a *lossy*-named channel.**
+  Verified on real mstsc. Built a `DvcProcessor` for the audio DVC
+  (`vendor/ironrdp-server/src/multitransport/audio_dvc.rs`, gated behind the experimental
+  `MACRDP_UDP_LOSSY_AUDIO` env, default off) that, on channel open, sends Server Audio
+  Formats (v8) and runs the MS-RDPEA handshake, reusing `ironrdp-rdpsnd`'s
+  `ServerAudioOutputPdu`/`ClientAudioOutputPdu` codecs verbatim (the **SNDPROLOG header is
+  kept** — byte-identical to the static path). Three concrete findings:
+  - **A channel literally named `AUDIO_PLAYBACK_LOSSY_DVC` is rejected if the server pushes
+    anything on it over TCP/DRDYNVC.** mstsc accepts the DVC Create (it can't refuse), then
+    on receiving our Server Audio Formats over TCP it goes **silent and stops reading the
+    whole TCP socket** (broken pipe ~3–4 s later — it kills EGFX/everything, not just
+    audio). So the lossy DVC must be **Soft-Synced onto the lossy tunnel *before* any data**,
+    with the handshake running over the tunnel — the opposite of EGFX, where the channel
+    negotiates over TCP and is migrated to the *reliable* tunnel afterward. (This contradicts
+    a naive reading of MS-RDPEDYC Soft-Sync — "all DVC data rides DRDYNVC until Soft-Sync
+    completes" — which is true *in general* but the `_LOSSY_`-named channel is the exception:
+    mstsc treats data on it over TCP as a violation.)
+  - **The reliable `AUDIO_PLAYBACK_DVC` name works perfectly over TCP** (diagnostic env
+    `MACRDP_AUDIO_DVC_RELIABLE=1`): Server Audio Formats → Client Audio Formats (AAC chosen)
+    → Client Quality Mode → Server Training → Client Training Confirm all round-trip, audio
+    plays, EGFX stays healthy. This is the discriminator that proved the channel *name* is
+    the blocker — not the PDU framing, and not coexistence with static rdpsnd.
+  - **Dual negotiation is fine.** Running the static `rdpsnd` SVC and the audio DVC
+    simultaneously does NOT confuse mstsc (it negotiated AAC/v8 on both with no conflict) —
+    so a server can keep static rdpsnd as the fallback while offering the DVC.
+  - **Sequence note (spec-confirmed live):** for v6+, the client sends a **Quality Mode PDU
+    immediately after Client Audio Formats**, and the server sends **Training only after
+    that** (MS-RDPEA "Initialization Sequence"). The handler waits for Quality Mode before
+    replying with Training.
+
+  **Implication for the build:** lossy audio needs the lossy DVC Soft-Synced onto the DTLS
+  tunnel up front + the handshake + AAC waves carried over the tunnel — i.e. it depends on a
+  solid lossy *data path* (P2.2/P2.3) underneath, which doesn't exist yet. And note the
+  reliable `AUDIO_PLAYBACK_DVC` path that *does* work is **not worth landing on its own**: a
+  reliable tunnel HOL-blocks under loss exactly like TCP (Phase 1 soak), so reliable
+  audio-over-UDP delivers no loss-resilience over TCP audio. **Status: paused after the
+  spike.** The hard unknowns are now banked (above); the verified groundwork (`audio_dvc.rs`
+  + the handshake) is kept in-tree, gated off by default. Resume by Soft-Syncing the lossy
+  DVC onto the tunnel before the handshake, after the lossy transport SM + FEC are mature.
+
 - **P2.5 — route audio to the lossy tunnel + reconcile the lag model.** Point the audio
   path at the lossy tunnel and reconcile with the existing audio-lag / drop-stale model
   (vendor server divergence (2)/(3)/(8)) — on a lossy transport, dropping a stale wave is

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -112,11 +112,7 @@ impl SoundServerFactory for MacRdpsnd {
         // AAC first so the negotiation in `start()` (first server format the
         // client also accepts) prefers it; PCM stays as the fallback for
         // clients without AAC decode.
-        let formats = if self.enable_aac {
-            vec![aac_format(self.aac_bitrate), pcm_format()]
-        } else {
-            vec![pcm_format()]
-        };
+        let formats = server_audio_formats(self.enable_aac, self.aac_bitrate);
         Box::new(MacRdpsndBackend {
             sender: self.sender.clone(),
             audio_sender: self.audio_sender.clone(),
@@ -132,6 +128,18 @@ impl SoundServerFactory for MacRdpsnd {
 
     fn set_audio_sender(&mut self, audio_sender: mpsc::Sender<AudioWave>) {
         *self.audio_sender.lock().unwrap() = Some(audio_sender);
+    }
+}
+
+/// The server audio format list, ordered by our preference (AAC ahead of PCM
+/// when `enable_aac`), exactly as `build_backend` advertises on the static
+/// RDPSND channel. Exposed so the UDP-multitransport lossy audio DVC
+/// (`AUDIO_PLAYBACK_LOSSY_DVC`) can advertise the *same* list it will encode in.
+pub fn server_audio_formats(enable_aac: bool, aac_bitrate: u32) -> Vec<AudioFormat> {
+    if enable_aac {
+        vec![aac_format(aac_bitrate), pcm_format()]
+    } else {
+        vec![pcm_format()]
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2202,6 +2202,23 @@ async fn async_main() -> Result<()> {
                     .set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));
                 server.set_multitransport_cookie_registry(Some(cookie_registry));
                 server.set_multitransport_tunnel_sender(Some(tunnel_sender));
+                // (P2.4b, EXPERIMENTAL) Register the lossy-UDP audio DVC
+                // (AUDIO_PLAYBACK_LOSSY_DVC). Behind its OWN dedicated env gate
+                // (`MACRDP_UDP_LOSSY_AUDIO=1`) — NOT the lossy-offer flag — so the
+                // proven lossy transport path runs unbroken by default; this
+                // sub-step is opt-in until the handshake is verified on mstsc.
+                // Requires AAC (the lossy DVC needs version >= 8 + AAC,
+                // MS-RDPEA Appendix A note <2>). Advertises the SAME format list
+                // the static RDPSND path encodes.
+                if std::env::var_os("MACRDP_UDP_LOSSY_AUDIO").is_some() && args.enable_aac {
+                    let formats = audio::server_audio_formats(args.enable_aac, args.aac_bitrate);
+                    info!(
+                        formats = formats.len(),
+                        "P2.4b (EXPERIMENTAL, MACRDP_UDP_LOSSY_AUDIO): offering AUDIO_PLAYBACK_LOSSY_DVC \
+                         (lossy-UDP audio) — AAC negotiation over TCP"
+                    );
+                    server.set_multitransport_lossy_audio_formats(Some(formats));
+                }
                 Some(listener)
             }
             Err(e) => {

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -595,3 +595,33 @@ AND released — #1276 landing is NOT sufficient.
     sent → tunnel established AND the client STOPPED retransmitting (the definitive
     accept signal). Next = P2.4b (migrate the AUDIO_PLAYBACK_LOSSY_DVC audio
     channel onto the tunnel). See feasibility doc "P2.4a".
+
+    P2.4b-1 — audio output DVC handshake (2026-06-27, `multitransport/audio_dvc.rs`;
+    PAUSED after the spike): a `DvcProcessor`/`DvcServerProcessor` (`AudioLossyDvc`)
+    that, on channel open, sends Server Audio Formats (v8) and runs the MS-RDPEA
+    format/quality-mode/training handshake, reusing `ironrdp-rdpsnd`'s
+    `ServerAudioOutputPdu`/`ClientAudioOutputPdu` codecs verbatim — the SNDPROLOG
+    header is KEPT (byte-identical to the static rdpsnd path), wrapped in an
+    `OwnedAudioPdu` that delegates `Encode` (so the DRDYNVC framing length matches).
+    Registered in `attach_channels` (after the egfx block) ONLY when the application
+    calls `RdpServer::set_multitransport_lossy_audio_formats(Some(formats))` — macrdp
+    gates that behind the experimental `MACRDP_UDP_LOSSY_AUDIO` env (+ `--enable-aac`),
+    so the default build is byte-unchanged. **KEY FINDING (verified on real mstsc): the
+    EGFX "negotiate-on-TCP-then-Soft-Sync" pattern does NOT carry to a *lossy*-named
+    channel.** With the literal name `AUDIO_PLAYBACK_LOSSY_DVC`, mstsc accepts the DVC
+    Create but, on receiving Server Audio Formats over TCP/DRDYNVC, goes silent and
+    **stops reading the whole TCP socket** (broken pipe ~3–4 s later — it tears down
+    EGFX/everything, not just audio). The reliable name `AUDIO_PLAYBACK_DVC`
+    (diagnostic env `MACRDP_AUDIO_DVC_RELIABLE=1`) handshakes perfectly over TCP
+    (formats → client formats(AAC) → quality mode → training → confirm), audio plays,
+    EGFX stays healthy — the discriminator proving the channel *name* is the blocker,
+    not the PDU/framing and not coexistence with static rdpsnd (dual negotiation is
+    fine). So the lossy DVC must be **Soft-Synced onto the lossy tunnel BEFORE any
+    data**, with the handshake over the tunnel (opposite of EGFX, which migrates to the
+    RELIABLE tunnel *after* a TCP handshake). Spec note (confirmed live): for v6+ the
+    client sends Quality Mode immediately after Client Audio Formats and the server
+    sends Training only after that (MS-RDPEA Initialization Sequence) — the handler
+    waits for Quality Mode. **Paused** here: the verified groundwork is kept in-tree,
+    default-off; resume once the lossy data path (P2.2/P2.3) is mature. The
+    reliable-DVC path that works is NOT worth landing on its own (a reliable tunnel
+    HOL-blocks under loss like TCP — no win). See feasibility doc "P2.4b".

--- a/vendor/ironrdp-server/src/multitransport/audio_dvc.rs
+++ b/vendor/ironrdp-server/src/multitransport/audio_dvc.rs
@@ -1,0 +1,196 @@
+//! (vendored, feature=multitransport, Phase 2 / P2.4b) The
+//! `AUDIO_PLAYBACK_LOSSY_DVC` dynamic virtual channel — MS-RDPEA audio output over
+//! a DVC, destined for the lossy UDP tunnel.
+//!
+//! MS-RDPEA §2.1: the audio output channel is named `AUDIO_PLAYBACK_DVC` over a
+//! reliable transport and **`AUDIO_PLAYBACK_LOSSY_DVC` over an unreliable UDP
+//! transport**. The server opens it (DRDYNVC Create Request), runs the normal
+//! RDPSND format/training handshake over it (on the main TCP connection), and then
+//! — via MS-RDPEDYC Soft-Sync — migrates it onto the lossy (`UDPFECL`) tunnel, over
+//! which the Wave2 audio PDUs flow.
+//!
+//! **Gating (MS-RDPEA Appendix A note <2>):** a client uses the lossy DVC only when
+//! all of (a) a lossy UDP transport is available, (b) both ends are protocol
+//! version ≥ 8, and (c) AAC is the codec. So we advertise `Version::V8` and the
+//! caller passes a format list that includes AAC (`WAVE_FORMAT_AAC_MS`).
+//!
+//! **STATUS: P2.4b-1 spike, PAUSED (verified on real mstsc 2026-06-27).** Registered
+//! only when the application calls
+//! [`RdpServer::set_multitransport_lossy_audio_formats`](crate::RdpServer::set_multitransport_lossy_audio_formats)
+//! (macrdp gates that behind the experimental `MACRDP_UDP_LOSSY_AUDIO` env), so the
+//! default build is byte-unchanged.
+//!
+//! **KEY FINDING — the EGFX "negotiate-on-TCP-then-Soft-Sync" pattern does NOT carry
+//! to a *lossy*-named channel.** With the literal name `AUDIO_PLAYBACK_LOSSY_DVC`,
+//! mstsc accepts the DVC Create but, on receiving Server Audio Formats over
+//! TCP/DRDYNVC, goes silent and tears down the whole TCP connection (broken pipe a
+//! few seconds later — it kills EGFX too, not just audio). The reliable name
+//! `AUDIO_PLAYBACK_DVC` (diagnostic env `MACRDP_AUDIO_DVC_RELIABLE=1`) handshakes
+//! perfectly over TCP (formats → client formats(AAC) → quality mode → training →
+//! confirm), audio plays, EGFX stays healthy — proving the channel *name* is the
+//! blocker, not the PDU/framing and not coexistence with static rdpsnd (dual
+//! negotiation is fine). So the **lossy** DVC must be Soft-Synced onto the lossy
+//! tunnel BEFORE any data, with the handshake over the tunnel — the opposite of EGFX
+//! (which migrates to the RELIABLE tunnel *after* a TCP handshake). That, plus routing
+//! the AAC waves over the tunnel, is deferred until the lossy data path (P2.2/P2.3) is
+//! mature; the reliable-DVC path that works isn't worth landing on its own (a reliable
+//! tunnel HOL-blocks under loss like TCP). See `docs/rdp-udp-multitransport-feasibility.md`
+//! ("P2.4b").
+//!
+//! **Sequence (MS-RDPEA Initialization Sequence, confirmed live):** for v6+ the client
+//! sends a Quality Mode PDU immediately after Client Audio Formats, and the server
+//! sends Training only after that — so this handler records the chosen format on Client
+//! Audio Formats and replies with Training on Quality Mode.
+//!
+//! **PDU framing:** the DVC carries *byte-identical* RDPSND PDUs — the `SNDPROLOG`
+//! header is **kept**, not stripped — so we reuse `ironrdp_rdpsnd`'s
+//! `ServerAudioOutputPdu` / `ClientAudioOutputPdu` codecs verbatim; only the channel
+//! envelope (DVC vs the static SVC) differs.
+
+use ironrdp_core::{Encode, EncodeResult, WriteCursor, decode, impl_as_any};
+use ironrdp_dvc::{DvcEncode, DvcMessage, DvcProcessor, DvcServerProcessor};
+use ironrdp_pdu::{PduResult, decode_err};
+use ironrdp_rdpsnd::pdu::{
+    AudioFormat, ClientAudioOutputPdu, ServerAudioFormatPdu, ServerAudioOutputPdu, TrainingPdu, Version, WaveFormat,
+};
+use tracing::{debug, warn};
+
+/// Channel name for the lossy (unreliable-UDP) audio output DVC (MS-RDPEA §2.1).
+pub const AUDIO_PLAYBACK_LOSSY_DVC: &str = "AUDIO_PLAYBACK_LOSSY_DVC";
+/// Channel name for the reliable audio output DVC (MS-RDPEA §2.1).
+pub const AUDIO_PLAYBACK_DVC: &str = "AUDIO_PLAYBACK_DVC";
+
+/// An owned RDPSND server PDU (Format/Training — no borrowed wave data) wrapped as
+/// a `DvcMessage`. `ironrdp_rdpsnd`'s PDUs implement `SvcEncode` (for the static
+/// channel) but not `DvcEncode`; rather than orphan-impl, we hold the PDU and
+/// delegate `Encode` (which already writes the full `SNDPROLOG` + body). The DVC
+/// layer adds only its own framing around this payload.
+struct OwnedAudioPdu(ServerAudioOutputPdu<'static>);
+
+impl Encode for OwnedAudioPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.0.encode(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        "RdpsndDvcPdu"
+    }
+
+    fn size(&self) -> usize {
+        self.0.size()
+    }
+}
+
+impl DvcEncode for OwnedAudioPdu {}
+
+fn dvc_msg(pdu: ServerAudioOutputPdu<'static>) -> DvcMessage {
+    Box::new(OwnedAudioPdu(pdu))
+}
+
+/// MS-RDPEA server handler for the audio output dynamic channel.
+pub struct AudioLossyDvc {
+    /// Channel name. Defaults to `AUDIO_PLAYBACK_LOSSY_DVC`; the diagnostic env
+    /// `MACRDP_AUDIO_DVC_RELIABLE=1` switches it to the reliable
+    /// `AUDIO_PLAYBACK_DVC` to test whether mstsc rejects the format handshake
+    /// specifically on a *lossy*-named channel over TCP (vs. any audio DVC).
+    channel_name: &'static str,
+    /// The server audio format list to advertise (PCM + AAC). Passed in by the
+    /// application so it matches exactly what the wave path will encode.
+    formats: Vec<AudioFormat>,
+    /// The client-list index of the format we'll send waves in, once negotiated.
+    chosen_format_no: Option<u16>,
+    /// Whether the client confirmed our Training PDU (handshake complete).
+    training_confirmed: bool,
+}
+
+impl AudioLossyDvc {
+    pub fn new(formats: Vec<AudioFormat>) -> Self {
+        let channel_name = if std::env::var_os("MACRDP_AUDIO_DVC_RELIABLE").is_some() {
+            AUDIO_PLAYBACK_DVC
+        } else {
+            AUDIO_PLAYBACK_LOSSY_DVC
+        };
+        Self {
+            channel_name,
+            formats,
+            chosen_format_no: None,
+            training_confirmed: false,
+        }
+    }
+}
+
+impl_as_any!(AudioLossyDvc);
+
+impl DvcProcessor for AudioLossyDvc {
+    fn channel_name(&self) -> &str {
+        self.channel_name
+    }
+
+    fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        debug!(
+            channel = self.channel_name,
+            formats = self.formats.len(),
+            "audio output DVC opened — sending Server Audio Formats (v8)"
+        );
+        let pdu = ServerAudioOutputPdu::AudioFormat(ServerAudioFormatPdu {
+            version: Version::V8,
+            formats: self.formats.clone(),
+        });
+        Ok(vec![dvc_msg(pdu)])
+    }
+
+    fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        match decode::<ClientAudioOutputPdu>(payload).map_err(|e| decode_err!(e))? {
+            ClientAudioOutputPdu::AudioFormat(cf) => {
+                // Per MS-RDPEA the client sends a Quality Mode PDU immediately
+                // after Client Audio Formats (v6+), and the server sends Training
+                // only after that — so here we just record the chosen format and
+                // WAIT for Quality Mode before replying with Training. Prefer AAC
+                // (the lossy DVC requires it); else fall back to the first format
+                // the client accepted. wFormatNo indexes the CLIENT list.
+                let chosen = cf
+                    .formats
+                    .iter()
+                    .position(|f| f.format == WaveFormat::AAC_MS)
+                    .or_else(|| (!cf.formats.is_empty()).then_some(0));
+                match chosen {
+                    Some(idx) => {
+                        let is_aac = cf.formats[idx].format == WaveFormat::AAC_MS;
+                        self.chosen_format_no = Some(u16::try_from(idx).unwrap_or(0));
+                        warn!(
+                            channel = self.channel_name,
+                            client_formats = cf.formats.len(),
+                            chosen_wformatno = idx,
+                            aac = is_aac,
+                            "P2.4b: audio DVC client formats received — awaiting Quality Mode"
+                        );
+                    }
+                    None => warn!(channel = self.channel_name, "audio DVC: client accepted none of the server formats"),
+                }
+                Ok(Vec::new())
+            }
+            ClientAudioOutputPdu::QualityMode(q) => {
+                debug!(channel = self.channel_name, quality = ?q.quality_mode, "audio DVC quality mode — sending Training");
+                // Training PDU: a fixed timestamp + a 1 KiB training block (the
+                // client echoes its size in the Training Confirm).
+                let training = ServerAudioOutputPdu::Training(TrainingPdu {
+                    timestamp: 0,
+                    data: vec![0u8; 1024],
+                });
+                Ok(vec![dvc_msg(training)])
+            }
+            ClientAudioOutputPdu::TrainingConfirm(_) => {
+                self.training_confirmed = true;
+                warn!(
+                    channel = self.channel_name,
+                    chosen_wformatno = ?self.chosen_format_no,
+                    "P2.4b GREEN: audio DVC negotiated + training confirmed over TCP — ready for Soft-Sync wave migration"
+                );
+                Ok(Vec::new())
+            }
+            ClientAudioOutputPdu::WaveConfirm(_) => Ok(Vec::new()),
+        }
+    }
+}
+
+impl DvcServerProcessor for AudioLossyDvc {}

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -21,6 +21,7 @@
 //! `migration` submodules (the UDP transport + channel migration); the trait
 //! will gain methods accordingly.
 
+pub mod audio_dvc;
 pub mod dtls;
 pub mod listener;
 

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -392,6 +392,12 @@ pub struct RdpServer {
     /// in flight (TCP-only).
     #[cfg(feature = "multitransport")]
     multitransport_tunnel_inbound_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
+    /// (P2.4b) Audio format list to advertise on the lossy-UDP `AUDIO_PLAYBACK_LOSSY_DVC`
+    /// dynamic channel. `Some` registers the channel (the application supplies a
+    /// PCM+AAC list matching what its wave path encodes); `None` (default) leaves
+    /// the channel unregistered. Set via `set_multitransport_lossy_audio_formats`.
+    #[cfg(feature = "multitransport")]
+    multitransport_lossy_audio_formats: Option<Vec<ironrdp_rdpsnd::pdu::AudioFormat>>,
 }
 
 #[derive(Debug)]
@@ -504,6 +510,8 @@ impl RdpServer {
             egfx_on_udp: false,
             #[cfg(feature = "multitransport")]
             multitransport_tunnel_inbound_rx: None,
+            #[cfg(feature = "multitransport")]
+            multitransport_lossy_audio_formats: None,
         }
     }
 
@@ -596,6 +604,18 @@ impl RdpServer {
         self.multitransport_tunnel_sender = sender;
     }
 
+    /// (P2.4b) Supply the audio format list for the lossy-UDP `AUDIO_PLAYBACK_LOSSY_DVC`
+    /// dynamic channel. `Some(formats)` registers the channel and advertises those
+    /// formats (the caller passes a PCM+AAC list matching what its wave path
+    /// encodes); `None` (default) leaves it unregistered.
+    #[cfg(feature = "multitransport")]
+    pub fn set_multitransport_lossy_audio_formats(
+        &mut self,
+        formats: Option<Vec<ironrdp_rdpsnd::pdu::AudioFormat>>,
+    ) {
+        self.multitransport_lossy_audio_formats = formats;
+    }
+
     /// Returns the shared ECHO server handle for runtime probe requests and RTT measurements.
     pub fn echo_handle(&self) -> &EchoServerHandle {
         &self.echo_handle
@@ -680,6 +700,21 @@ impl RdpServer {
                     let gfx_server = ironrdp_egfx::server::GraphicsPipelineServer::new(handler);
                     dvc = dvc.with_dynamic_channel(gfx_server);
                 }
+            }
+            dvc
+        };
+
+        // (vendored, feature=multitransport, P2.4b) The lossy-UDP audio output DVC
+        // (`AUDIO_PLAYBACK_LOSSY_DVC`). Registered only when the application
+        // supplied a format list (macrdp does so when `--enable-aac` + the lossy
+        // UDP offer are both on). The format handshake runs over the main TCP
+        // connection first; Soft-Sync migration of the wave data onto the DTLS
+        // tunnel is a later sub-step.
+        #[cfg(feature = "multitransport")]
+        let dvc = {
+            let mut dvc = dvc;
+            if let Some(formats) = self.multitransport_lossy_audio_formats.clone() {
+                dvc = dvc.with_dynamic_channel(crate::multitransport::audio_dvc::AudioLossyDvc::new(formats));
             }
             dvc
         };


### PR DESCRIPTION
## What

Spike of the MS-RDPEA **audio output DVC** handshake for Phase-2 lossy audio, behind the experimental `MACRDP_UDP_LOSSY_AUDIO` env (+ `--enable-aac`) so the **default build is byte-unchanged**. Paused after the spike; this PR banks the verified groundwork + the finding.

## Key finding (verified on real mstsc)

The EGFX "negotiate-on-TCP-then-Soft-Sync" pattern does **not** carry to a *lossy*-named channel:

- With the literal name **`AUDIO_PLAYBACK_LOSSY_DVC`**, mstsc accepts the DVC Create but, on receiving Server Audio Formats over TCP/DRDYNVC, goes silent and **tears down the whole TCP connection** (broken pipe a few seconds later — kills EGFX too, not just audio).
- With the reliable name **`AUDIO_PLAYBACK_DVC`** (diagnostic env `MACRDP_AUDIO_DVC_RELIABLE=1`), the handshake completes cleanly over TCP (formats → client formats (AAC) → quality mode → training → confirm), audio plays, EGFX stays healthy.

That discriminator proves the channel **name** is the blocker — not the PDU/framing, and not coexistence with static `rdpsnd` (dual negotiation is fine). **Conclusion:** the lossy DVC must be Soft-Synced onto the lossy tunnel **before** any data, with the handshake over the tunnel — the opposite of EGFX (which migrates to the *reliable* tunnel after a TCP handshake). That, plus routing AAC waves over the tunnel, is deferred until the lossy data path (P2.2/P2.3) is mature. The reliable-DVC path that works is **not worth landing on its own** (a reliable tunnel HOL-blocks under loss like TCP — no win over TCP audio).

Spec note (confirmed live): for v6+ the client sends **Quality Mode immediately after Client Audio Formats**, and the server sends **Training only after that** (MS-RDPEA Initialization Sequence) — the handler waits for Quality Mode.

## Changes

- **New** `vendor/ironrdp-server/src/multitransport/audio_dvc.rs` — `AudioLossyDvc` `DvcProcessor`/`DvcServerProcessor`; reuses `ironrdp-rdpsnd`'s `ServerAudioOutputPdu`/`ClientAudioOutputPdu` codecs verbatim (SNDPROLOG kept), `OwnedAudioPdu` delegates `Encode` so DRDYNVC framing length matches. Channel name selectable via `MACRDP_AUDIO_DVC_RELIABLE` (diagnostic).
- `vendor/ironrdp-server/src/server.rs` — `multitransport_lossy_audio_formats` field + `set_multitransport_lossy_audio_formats` setter; registers the DVC in `attach_channels` only when `Some`.
- `src/audio.rs` — `pub fn server_audio_formats(enable_aac, aac_bitrate)` (the same PCM+AAC list the static path encodes); `build_backend` now reuses it.
- `src/main.rs` — wires the setter, gated on `MACRDP_UDP_LOSSY_AUDIO` + `--enable-aac`.
- Docs: finding written into `docs/rdp-udp-multitransport-feasibility.md` (P2.4b) and the vendored `ironrdp-server` `CLAUDE.md` divergence (12).

## Gating / safety

Default build is byte-identical (registration requires `set_multitransport_lossy_audio_formats(Some(..))`, which macrdp only calls under the `MACRDP_UDP_LOSSY_AUDIO` env). No change to the proven lossy-transport / EGFX paths.

## Verification

- Real mstsc (Win11/WiFi LAN): `AUDIO_PLAYBACK_DVC` handshake green, audio plays, EGFX renders.
- `cargo fmt` / `cargo clippy --all-targets -D warnings` / `cargo test` (69 passed) all clean.
