### PR TITLE
feat(rdpeudp): P2.2 step 1 — lossy delivery mode in the SM (logic only)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -391,6 +391,18 @@ Each milestone is its own gated PR, real-client-verified, feature-flagged
   is a second delivery policy in `state.rs`, not a new crate. Sans-I/O, unit-tested under
   injected loss/reorder/dup like the reliable machine.
 
+  **Step 1 done (2026-06-27): the lossy delivery policy, SM-only.** `Config.mode`
+  (`DeliveryMode { Reliable, Lossy }`, default `Reliable` → existing callers
+  byte-identical). Lossy delivers source payloads on arrival (no reorder buffer, no
+  HOL) and sends our data once (no RTO retransmit; the `unacked` push is skipped).
+  Inbound is not de-duplicated in lossy mode (DTLS/audio self-dedup). Unit-tested
+  (deliver-on-arrival/no-HOL with a reliable control + send-once/no-retransmit). **Not
+  wired:** the listener still builds every peer `Reliable`, so the `UdpFecL` flow keeps
+  riding the reliable SM on a clean link. **Step 2** = switch the lossy flow to
+  `DeliveryMode::Lossy` per-flow and confirm the DTLS handshake still completes when the
+  transport stops retransmitting (DTLS retransmits its own flights) — needs a live mstsc
+  run, ideally with the netshape soak.
+
 - **P2.3 — FEC encoder (optional, deferrable).** Researched: MS-RDPEUDP FEC is
   **GF(256) Reed–Solomon**, not XOR parity; each FEC packet recovers exactly **one** lost
   source packet within its range; the wire header is `RDPUDP_FEC_PAYLOAD_HEADER`

--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,31 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **P2.2 step 1 — lossy delivery mode (done, 2026-06-27; SM logic only, NOT yet
+  wired):** `Config` gained `mode: DeliveryMode { Reliable, Lossy }` (default
+  `Reliable`, so every existing caller/test is byte-identical). In
+  `DeliveryMode::Lossy` the SM (a) **delivers each source payload on arrival** —
+  no reorder buffer, no in-order head-of-line block (the whole point; a packet
+  after a gap is handed up immediately) — advancing `recv_next` monotonically to
+  the highest seen seq + 1 so the cumulative ACK still reports progress (it
+  over-reports under loss, but a lossy sender never retransmits on it, so harmless);
+  and (b) **sends our own data once, never retransmits** — the send loop skips the
+  `unacked` push in lossy mode, so the RTO retransmit loop is a no-op and the window
+  check never blocks. We do NOT dedup inbound in lossy mode — the upper layer (DTLS
+  records / audio) is self-deduplicating. Unit-tested: `lossy_delivers_out_of_order_
+  on_arrival_no_hol` (fed in reverse, every packet but the first is a gap, each
+  delivered immediately; reassembly matches), a reliable control
+  (`reliable_buffers_out_of_order_head`: the same future packet is buffered →
+  nothing delivered), and `lossy_sender_sends_once_never_retransmits` (no resend on
+  RTO ever). 46 crate tests. **NOT integrated:** the listener
+  (`ironrdp-server/src/multitransport/listener.rs`) still builds every peer with
+  `DeliveryMode::Reliable` — the lossy (`UdpFecL`) flow keeps riding the reliable SM
+  (fine on a clean link; the DTLS handshake currently relies on it). Switching the
+  lossy flow to `DeliveryMode::Lossy` per-flow — and confirming the DTLS handshake
+  still completes when the transport stops retransmitting (DTLS has its own flight
+  retransmission) — is P2.2 step 2. See `docs/rdp-udp-multitransport-feasibility.md`
+  "P2.2".
+
 - **Soak observability (done, 2026-06-26):** `StepOutput` gained two diagnostic
   fields — `retransmits: usize` (in-flight data segments resent on RTO this step)
   and `syn_retransmit: bool` (client SYN resent). Set in `pump()`; the crate stays

--- a/vendor/ironrdp-rdpeudp/src/state.rs
+++ b/vendor/ironrdp-rdpeudp/src/state.rs
@@ -40,6 +40,27 @@ pub enum Role {
     Server,
 }
 
+/// Delivery policy for the source-packet data path (MS-RDPEUDP §1.3.2).
+///
+/// The SYN/SYN+ACK handshake is identical in both modes; only how source
+/// payloads are received and sent differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DeliveryMode {
+    /// `UdpFecR` — reliable, in-order, de-duplicated: out-of-order datagrams are
+    /// buffered and delivered as contiguous runs; our own data is retransmitted
+    /// on RTO until cumulatively acked. The Phase-1 default.
+    #[default]
+    Reliable,
+    /// `UdpFecL` — lossy: source payloads are **delivered on arrival** (no
+    /// in-order head-of-line blocking — *the whole point*), and our own data is
+    /// sent **once, never retransmitted**. The upper layer tolerates loss (DTLS
+    /// records are independent and self-deduplicating; audio drops a stale frame
+    /// for free), and loss *recovery* — where wanted — comes from FEC (P2.3), not
+    /// retransmission. A reliable ordered stream head-of-line-blocks on its own
+    /// loss exactly like TCP, which is why video-under-loss needs this mode.
+    Lossy,
+}
+
 /// Per-connection configuration.
 #[derive(Debug, Clone, Copy)]
 pub struct Config {
@@ -51,6 +72,9 @@ pub struct Config {
     pub initial_seq: u32,
     /// Retransmit timeout, milliseconds.
     pub rto_ms: u64,
+    /// Reliable (`UdpFecR`) vs lossy (`UdpFecL`) delivery policy. Defaults to
+    /// [`DeliveryMode::Reliable`] so existing callers are unchanged.
+    pub mode: DeliveryMode,
 }
 
 impl Default for Config {
@@ -60,6 +84,7 @@ impl Default for Config {
             mtu: 1232,
             initial_seq: 0,
             rto_ms: 300,
+            mode: DeliveryMode::Reliable,
         }
     }
 }
@@ -272,6 +297,21 @@ impl RdpeudpState {
         }
         self.need_ack = true;
 
+        if self.cfg.mode == DeliveryMode::Lossy {
+            // Lossy: deliver on arrival, never buffer for ordering, never block on
+            // a gap (the whole point). We don't dedup here — the upper layer (DTLS)
+            // drops any duplicate/replayed record itself, and on a clean in-order
+            // link there are no duplicates. `recv_next` still advances
+            // monotonically to the highest seen seq + 1 so our cumulative ACK
+            // reports forward progress; under loss it over-reports, but a lossy
+            // sender never retransmits on that ACK, so it's harmless.
+            out.delivered.push(src.payload.clone());
+            if seq_leq(self.recv_next, seq) {
+                self.recv_next = seq.wrapping_add(1);
+            }
+            return;
+        }
+
         if seq == self.recv_next {
             out.delivered.push(src.payload.clone());
             self.recv_next = self.recv_next.wrapping_add(1);
@@ -345,11 +385,16 @@ impl RdpeudpState {
                 &payload,
                 ack_vector.clone(),
             ));
-            self.unacked.push_back(Unacked {
-                seq,
-                payload,
-                last_sent_ms: now_ms,
-            });
+            // Reliable: track for RTO retransmit until acked. Lossy: send once and
+            // forget (no retransmit) — `unacked` stays empty, so the window check
+            // above never blocks and the retransmit loop is a no-op.
+            if self.cfg.mode == DeliveryMode::Reliable {
+                self.unacked.push_back(Unacked {
+                    seq,
+                    payload,
+                    last_sent_ms: now_ms,
+                });
+            }
             sent_data = true;
         }
 
@@ -482,6 +527,7 @@ mod tests {
             mtu: 1132, // → small-ish payloads exercise fragmentation
             initial_seq,
             rto_ms: 100,
+            mode: DeliveryMode::Reliable,
         }
     }
 
@@ -570,6 +616,7 @@ mod tests {
                 mtu: 1232,
                 initial_seq: 0x61f7_b6e3,
                 rto_ms: 300,
+                mode: DeliveryMode::Reliable,
             },
         );
         let out = server.step(0, Some(&client_syn));
@@ -711,5 +758,113 @@ mod tests {
             out.retransmits, 0,
             "acked segment is no longer retransmitted"
         );
+    }
+
+    // ---- P2.2: lossy delivery mode (UdpFecL) -------------------------------
+
+    fn cfg_lossy(initial_seq: u32) -> Config {
+        Config {
+            mode: DeliveryMode::Lossy,
+            ..cfg(initial_seq)
+        }
+    }
+
+    /// Drive a lossy client↔server pair to established. The handshake itself is
+    /// mode-independent, so this mirrors [`handshook`] with the lossy config.
+    fn handshook_lossy() -> (RdpeudpState, RdpeudpState, u64) {
+        let mut client = RdpeudpState::new(Role::Client, cfg_lossy(1000));
+        let mut server = RdpeudpState::new(Role::Server, cfg_lossy(9000));
+        let mut now = 0;
+        let o = client.start(now);
+        for dg in o.to_send {
+            let so = server.step(now, Some(&dg));
+            for back in so.to_send {
+                client.step(now, Some(&back));
+            }
+        }
+        now += 1;
+        assert!(client.is_established() && server.is_established());
+        (client, server, now)
+    }
+
+    /// Capture only the source-carrying (data) datagrams from a pump's output.
+    fn data_only(to_send: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
+        to_send
+            .into_iter()
+            .filter(|dg| {
+                Datagram::decode(dg)
+                    .map(|d| d.source.is_some())
+                    .unwrap_or(false)
+            })
+            .collect()
+    }
+
+    /// Lossy mode delivers a source payload on arrival even when it's ahead of the
+    /// expected sequence — no in-order head-of-line blocking. Fed in reverse, every
+    /// packet but the first is a gap, yet each is delivered immediately.
+    #[test]
+    fn lossy_delivers_out_of_order_on_arrival_no_hol() {
+        let (mut client, mut server, now) = handshook_lossy();
+        // ~2500 bytes over a 1132-MTU link → multiple source packets.
+        let msg: Vec<u8> = b"abcdefghij".iter().copied().cycle().take(2500).collect();
+        let data = data_only(client.enqueue(now, &msg).to_send);
+        assert!(data.len() >= 2, "message must span multiple source packets");
+
+        let mut delivered: Vec<Vec<u8>> = Vec::new();
+        for (i, dg) in data.iter().rev().enumerate() {
+            let so = server.step(now, Some(dg));
+            if i == 0 {
+                // The highest-seq packet arrives first (a gap from recv_next). Lossy
+                // hands it up immediately; reliable would buffer it (see the control
+                // test below).
+                assert_eq!(
+                    so.delivered.len(),
+                    1,
+                    "lossy delivers the out-of-order head on arrival (no HOL)"
+                );
+            }
+            delivered.extend(so.delivered);
+        }
+        // Every chunk arrived (in reverse); un-reversing reconstructs the message.
+        let reassembled: Vec<u8> = delivered.iter().rev().flatten().copied().collect();
+        assert_eq!(reassembled, msg, "all payloads delivered, none dropped");
+    }
+
+    /// Control: the reliable machine buffers a future (out-of-order) source packet
+    /// instead of delivering it — the HOL behavior lossy mode deliberately avoids.
+    #[test]
+    fn reliable_buffers_out_of_order_head() {
+        let (mut client, mut server, now) = handshook();
+        let msg: Vec<u8> = b"abcdefghij".iter().copied().cycle().take(2500).collect();
+        let data = data_only(client.enqueue(now, &msg).to_send);
+        assert!(data.len() >= 2);
+        // Feed the highest-seq packet first: reliable buffers it, delivers nothing.
+        let so = server.step(now, Some(data.last().unwrap()));
+        assert!(
+            so.delivered.is_empty(),
+            "reliable buffers the future packet (HOL) until the gap fills"
+        );
+    }
+
+    /// Lossy mode sends each source packet exactly once — no RTO retransmit, ever,
+    /// even when the peer never ACKs. (Reliable would resend; see
+    /// `retransmit_counter_reports_rto_resends`.)
+    #[test]
+    fn lossy_sender_sends_once_never_retransmits() {
+        let (_client, mut server, now) = handshook_lossy();
+        let rto = server.cfg.rto_ms;
+
+        let out = server.enqueue(now, b"a lossy audio access unit");
+        assert!(!out.to_send.is_empty(), "data goes on the wire once");
+        assert_eq!(out.retransmits, 0, "first send is not a retransmit");
+
+        // No ACK ever arrives. A reliable sender would resend on RTO; lossy must not.
+        let out = server.step(now + rto, None);
+        assert_eq!(out.retransmits, 0, "lossy never retransmits");
+        assert!(out.to_send.is_empty(), "no resend on RTO in lossy mode");
+
+        let out = server.step(now + rto * 10, None);
+        assert_eq!(out.retransmits, 0);
+        assert!(out.to_send.is_empty(), "still no resend much later");
     }
 }

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 
 use ironrdp_rdpeudp::datagram::Datagram;
 use ironrdp_rdpeudp::pdu::FecFlags;
-use ironrdp_rdpeudp::state::{Config, RdpeudpState, Role};
+use ironrdp_rdpeudp::state::{Config, DeliveryMode, RdpeudpState, Role};
 
 use crate::multitransport::dtls::{DtlsConn, DtlsServerContext};
 use crate::multitransport::{CookieRegistry, TunnelOutbound};
@@ -525,6 +525,12 @@ async fn run_recv_loop(
                         mtu: cfg.mtu,
                         initial_seq,
                         rto_ms: cfg.rto_ms,
+                        // P2.2 step 1: the lossy delivery policy exists in the SM
+                        // (unit-tested) but is NOT wired here yet — the lossy
+                        // (UdpFecL) flow still rides the reliable SM (fine on a
+                        // clean link; the DTLS handshake relies on it). Switching
+                        // this to DeliveryMode::Lossy per-flow is step 2.
+                        mode: DeliveryMode::Reliable,
                     },
                 ),
                 inbound: Vec::new(),


### PR DESCRIPTION
## What

P2.2 **step 1**: add the lossy delivery policy to the `ironrdp-rdpeudp` state machine — the second delivery mode Phase-2 lossy UDP (`UdpFecL`) needs. **SM logic only, unit-tested; not yet wired** into the listener, so there is **no wire/behavior change** (every peer is still built `Reliable`).

## Why

The Phase-1 soak proved a reliable *ordered* RDPEUDP stream head-of-line-blocks on its own loss exactly like TCP — so reliable-only multitransport is a clean-link nicety, not a loss-resilience win. The genuine win needs a **lossy** delivery policy: deliver on arrival (no HOL), send once (no retransmit), and let the upper layer tolerate/recover loss (DTLS records are independent; audio drops a stale frame for free; FEC — P2.3 — recovers where wanted).

## Changes

- `Config.mode: DeliveryMode { Reliable, Lossy }` — **default `Reliable`**, so all existing callers/tests are byte-identical.
- `DeliveryMode::Lossy` in `recv_source`: deliver each source payload on arrival, no reorder buffer, no in-order gating; advance `recv_next` monotonically (cumulative ACK still reports progress; over-reports under loss but harmless since a lossy sender never retransmits on it). No inbound dedup (DTLS/audio self-dedup).
- `DeliveryMode::Lossy` in the `pump` send loop: skip the `unacked` push → send once, RTO retransmit loop is a no-op, window check never blocks.
- Listener (`ironrdp-server`) builds every peer `DeliveryMode::Reliable` explicitly — **lossy flow unchanged for now** (step 2 switches it per-flow).

## Tests (46 crate tests, all green)

- `lossy_delivers_out_of_order_on_arrival_no_hol` — fed in reverse, every packet but the first is a gap, each delivered immediately; reassembly matches.
- `reliable_buffers_out_of_order_head` — control: the same future packet is buffered (HOL), nothing delivered.
- `lossy_sender_sends_once_never_retransmits` — no resend on RTO, ever.

## Next (step 2)

Switch the lossy (`UdpFecL`) flow to `DeliveryMode::Lossy` per-flow in the listener and confirm the **DTLS handshake still completes** when the transport stops retransmitting (DTLS retransmits its own flights) — needs a live mstsc run, ideally with the netshape soak harness.

## Verification

`cargo fmt` / `cargo clippy --all-targets -D warnings` / full `cargo test` (69) + standalone `ironrdp-rdpeudp` tests (46) all clean. No client needed (sans-I/O SM logic, deterministic unit tests — same pattern as the M2 codecs).
