### PR TITLE
feat(multitransport): P2.2 step 2 — lossy flow uses lossy delivery (verified mstsc)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -396,12 +396,23 @@ Each milestone is its own gated PR, real-client-verified, feature-flagged
   byte-identical). Lossy delivers source payloads on arrival (no reorder buffer, no
   HOL) and sends our data once (no RTO retransmit; the `unacked` push is skipped).
   Inbound is not de-duplicated in lossy mode (DTLS/audio self-dedup). Unit-tested
-  (deliver-on-arrival/no-HOL with a reliable control + send-once/no-retransmit). **Not
-  wired:** the listener still builds every peer `Reliable`, so the `UdpFecL` flow keeps
-  riding the reliable SM on a clean link. **Step 2** = switch the lossy flow to
-  `DeliveryMode::Lossy` per-flow and confirm the DTLS handshake still completes when the
-  transport stops retransmitting (DTLS retransmits its own flights) — needs a live mstsc
-  run, ideally with the netshape soak.
+  (deliver-on-arrival/no-HOL with a reliable control + send-once/no-retransmit).
+
+  **Step 2 done (2026-06-27, verified on real mstsc): the lossy flow uses lossy
+  delivery.** Behind the experimental env `MACRDP_UDP_LOSSY_DELIVERY` (default off →
+  the lossy flow keeps riding the reliable SM, a clean one-var A/B), the listener
+  classifies each flow at its opening SYN (`SYN_LOSSY` ⇒ `UdpFecL`) and builds that
+  peer's SM with `DeliveryMode::Lossy`; the reliable (`UdpFecR`) flow is never touched.
+  **Verified live:** with the env set the lossy peer logs `RDPEUDP peer using LOSSY
+  delivery`, and the **DTLS 1.2 handshake + MS-RDPEMT tunnel both reach established over
+  send-once/no-retransmit delivery** (`P2.1 GREEN` → `P2.4 GREEN`), H.264 video + audio
+  stable. DTLS's own record-layer reordering plus a clean link (everything arrives once)
+  is what carries the handshake without transport retransmission. **Known under-loss
+  caveats (soak-phase, not hit on a clean link):** the one-shot `CREATERESPONSE(S_OK)`
+  and the DTLS server flight aren't resent by the SM, and the tunnel's `tunnel_created`
+  guard answers a repeated `CREATEREQUEST` only once — so under real loss the handshake
+  may need the response re-sent idempotently (or a handshake-phase retransmit). That's
+  the next thing the netshape soak should probe.
 
 - **P2.3 — FEC encoder (optional, deferrable).** Researched: MS-RDPEUDP FEC is
   **GF(256) Reed–Solomon**, not XOR parity; each FEC packet recovers exactly **one** lost

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -625,3 +625,24 @@ AND released — #1276 landing is NOT sufficient.
     default-off; resume once the lossy data path (P2.2/P2.3) is mature. The
     reliable-DVC path that works is NOT worth landing on its own (a reliable tunnel
     HOL-blocks under loss like TCP — no win). See feasibility doc "P2.4b".
+
+    P2.2 step 2 — lossy flow uses lossy delivery (2026-06-27, `listener.rs`; verified
+    on real mstsc). Behind the experimental env `MACRDP_UDP_LOSSY_DELIVERY` (read once
+    at the top of `run_recv_loop`; default off), the listener classifies each flow at
+    its opening SYN — `Datagram::peek_fec_flags(data)` containing `SYN_LOSSY` ⇒ the
+    `UdpFecL` flow (the first datagram from any peer is always its SYN, so peeking at
+    `peers.entry(..).or_insert_with` time is reliable) — and builds that peer's
+    `RdpeudpState` with `DeliveryMode::Lossy` (P2.2 step 1) instead of `Reliable`. The
+    reliable (`UdpFecR`) flow is unaffected; with the env unset every peer stays
+    `Reliable` (the proven P2.1a/P2.4a path), so it's a clean A/B + instant fallback.
+    **Verified live (mstsc, env set):** lossy peer logs `RDPEUDP peer using LOSSY
+    delivery`, then the DTLS 1.2 handshake (`P2.1 GREEN`) AND the MS-RDPEMT tunnel
+    (`P2.4 GREEN`) both reach established over send-once/no-retransmit delivery —
+    DTLS's own record reordering + a clean link (one-shot flights all arrive) carry it
+    without transport retransmission. **Under-loss caveats (soak-phase, NOT yet
+    addressed):** the SM no longer resends the one-shot `CREATERESPONSE(S_OK)` / DTLS
+    server flight, and `handle_emt_tunnel`'s `tunnel_created` guard answers a repeated
+    `CREATEREQUEST` only once — so a dropped handshake datagram under real loss may
+    stall the tunnel; making the response idempotent (re-answer on retransmit in lossy
+    mode) or adding a handshake-phase retransmit is the next soak fix. See feasibility
+    doc "P2.2".

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -423,6 +423,16 @@ async fn run_recv_loop(
     let start = tokio::time::Instant::now();
     let mut buf = vec![0u8; 2048];
 
+    // (P2.2 step 2, EXPERIMENTAL) When set, a lossy (`SYN_LOSSY`) flow drives the
+    // SM in `DeliveryMode::Lossy` (deliver-on-arrival, send-once-no-retransmit)
+    // instead of the reliable policy. Default OFF — the lossy flow keeps riding the
+    // reliable SM (the proven P2.1a/P2.4a path), so this is a one-env-var A/B and a
+    // clean fallback. The reliable (`UdpFecR`) flow is never affected.
+    let lossy_delivery = std::env::var_os("MACRDP_UDP_LOSSY_DELIVERY").is_some();
+    if lossy_delivery {
+        debug!("MACRDP_UDP_LOSSY_DELIVERY set — lossy (SYN_LOSSY) flows will use DeliveryMode::Lossy");
+    }
+
     // (Soak fix) Periodic clock for the reliability state machines. The SM only
     // retransmits / drains its send window when it's pumped (step/enqueue), and
     // those are otherwise driven solely by inbound datagrams or new outbound data.
@@ -514,9 +524,23 @@ async fn run_recv_loop(
             }
         }
 
+        // (P2.2 step 2) Classify the flow at creation from its opening SYN: a
+        // `SYN_LOSSY` SYN is the `UdpFecL` flow. The first datagram from any peer is
+        // always its SYN (RDPEUDP opens with one), so peeking here is reliable. Only
+        // promotes to lossy delivery when the experimental env is set; otherwise (and
+        // for the reliable flow) it stays `Reliable`.
+        let use_lossy = lossy_delivery
+            && Datagram::peek_fec_flags(data).is_some_and(|f| f.contains(FecFlags::SYN_LOSSY));
+
         let peer = peers.entry(peer_addr).or_insert_with(|| {
             session_counter = session_counter.wrapping_add(1);
             let initial_seq = cfg.server_isn_seed.wrapping_add(session_counter);
+            let mode = if use_lossy {
+                debug!(%peer_addr, "RDPEUDP peer using LOSSY delivery (SYN_LOSSY flow, MACRDP_UDP_LOSSY_DELIVERY)");
+                DeliveryMode::Lossy
+            } else {
+                DeliveryMode::Reliable
+            };
             Peer {
                 sm: RdpeudpState::new(
                     Role::Server,
@@ -525,12 +549,7 @@ async fn run_recv_loop(
                         mtu: cfg.mtu,
                         initial_seq,
                         rto_ms: cfg.rto_ms,
-                        // P2.2 step 1: the lossy delivery policy exists in the SM
-                        // (unit-tested) but is NOT wired here yet — the lossy
-                        // (UdpFecL) flow still rides the reliable SM (fine on a
-                        // clean link; the DTLS handshake relies on it). Switching
-                        // this to DeliveryMode::Lossy per-flow is step 2.
-                        mode: DeliveryMode::Reliable,
+                        mode,
                     },
                 ),
                 inbound: Vec::new(),


### PR DESCRIPTION
## What

P2.2 **step 2**: wire the lossy delivery policy (added in #55) into the listener so a lossy (`SYN_LOSSY` / `UdpFecL`) flow actually uses `DeliveryMode::Lossy`. Behind the experimental env **`MACRDP_UDP_LOSSY_DELIVERY`** (default off → lossy flow keeps riding the reliable SM, a clean one-var A/B and instant fallback). The reliable (`UdpFecR`) flow is never touched.

## How

The listener classifies each flow at its opening SYN — `Datagram::peek_fec_flags(data)` containing `SYN_LOSSY` ⇒ the `UdpFecL` flow. The first datagram from any peer is always its SYN, so peeking at `peers.entry(..).or_insert_with` time is reliable. That peer's `RdpeudpState` is then built `DeliveryMode::Lossy` instead of `Reliable`.

## Verified live on real mstsc (env set)

- `RDPEUDP peer using LOSSY delivery (SYN_LOSSY flow, MACRDP_UDP_LOSSY_DELIVERY)`
- `P2.1 GREEN: DTLS 1.2 handshake COMPLETE on the LOSSY flow` — **handshake completes over send-once/no-retransmit delivery** (the key question)
- `P2.4 GREEN: MS-RDPEMT tunnel ESTABLISHED over DTLS`
- H.264 video (keyframes 0→600) + audio stable until disconnect

DTLS's own record-layer reordering plus a clean link (one-shot flights all arrive) is what carries the handshake without transport-level retransmission.

## Known under-loss caveats (soak-phase, not yet addressed)

The SM no longer resends the one-shot `CREATERESPONSE(S_OK)` / DTLS server flight, and `handle_emt_tunnel`'s `tunnel_created` guard answers a repeated `CREATEREQUEST` only once — so a dropped handshake datagram under *real* loss may stall the tunnel. Making the response idempotent (re-answer on retransmit in lossy mode), or a handshake-phase retransmit, is the next soak fix. Doesn't affect a clean link.

## Safety

Default build/behavior byte-unchanged (env-gated). Reliable flow unaffected. `cargo fmt` / `clippy --all-targets -D warnings` / `cargo test` (69) all clean.
