### PR TITLE
chore(multitransport): set up the P2.2 lossy-delivery soak harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.lock.bak
 
 # SwiftPM build output for the menu-bar controller (gui/)
 /gui/.build/
+
+# Soak run logs (scripts/soak-lossy.sh)
+/soak-lossy-*.log

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -136,6 +136,9 @@ another machine) and the Mac's built-in `pf`/`dnctl` traffic shaper.
 **Tooling:** `scripts/netshape.sh` shapes both directions of TCP+UDP on the macrdp
 port (default 3390) via dummynet — `sudo scripts/netshape.sh on --loss 5 --delay 100`
 to apply, `sudo scripts/netshape.sh off` to restore, `status` to inspect.
+`scripts/soak-lossy.sh` is a turnkey server runner for the **lossy-delivery** soak (sets
+the lossy env gates, captures the full log, live-prints the handshake markers) — see the
+"P2.2 lossy-delivery soak (runbook)" subsection below.
 
 **Observability:** the reliable transport's RTO retransmits are surfaced (the state
 machine is sans-I/O, so `StepOutput.retransmits` / `.syn_retransmit` are counted in
@@ -227,6 +230,62 @@ reliable-only multitransport.
    video becomes a goal. Note this also means the **default TCP** EGFX path has the
    same loss sensitivity (matching client resolution to avoid scaling + a capable
    client are the practical mitigations there).
+
+### P2.2 lossy-delivery soak (runbook)
+
+The first soak (above) shaped the **reliable** EGFX-over-UDP path. This one targets the
+**lossy delivery policy** (P2.2 steps 1–2): a `SYN_LOSSY` flow driving
+`DeliveryMode::Lossy` (deliver-on-arrival, **send-once / no retransmit**). It's verified
+green on a *clean* link (DTLS handshake + MS-RDPEMT tunnel reach established); the soak
+exists to find where send-once breaks under real loss.
+
+**What it probes (the known caveats):** because the lossy SM never retransmits, a dropped
+handshake datagram isn't recovered by the transport. Specifically:
+1. the server's one-shot **`CREATERESPONSE(S_OK)`** — if it's lost, the listener's
+   `tunnel_created` guard answers a repeated `CREATEREQUEST` only once, so the tunnel may
+   never establish;
+2. the **DTLS server flight** (ServerHello/Certificate/Done) — sent once by the SM; DTLS
+   has its *own* flight retransmission (client-driven on timeout), so this *may* self-heal,
+   but that's exactly the thing to confirm.
+
+**Run it (two terminals, real mstsc on another machine):**
+```
+# 1) shape both directions of TCP+UDP on the port:
+sudo scripts/netshape.sh on --loss 5 --delay 100
+
+# 2) run the server under the lossy-delivery soak config (sets the env, captures the
+#    full log to a file, live-prints only the soak markers):
+scripts/soak-lossy.sh --enable-udp-multitransport --enable-h264 \
+    --username "$USER" --password 'PASS' --bind 0.0.0.0:3390
+
+# …connect mstsc, exercise it, then restore:
+sudo scripts/netshape.sh off
+```
+
+**Read the markers** (`soak-lossy.sh` highlights them; the full log is in the file):
+- `RDPEUDP peer using LOSSY delivery` — the lossy SM is engaged for that flow.
+- `P2.1 GREEN` (DTLS complete) → `P2.4 GREEN` (tunnel established) — **both appearing =
+  the lossy handshake survived the loss to established.** *Neither/only-one appearing,
+  with the client repeatedly sending `CREATEREQUEST`, is the stall the caveats predict.*
+- `RTO retransmit` lines should be **zero for the lossy flow** (it never retransmits); any
+  you see are the *reliable* (`UdpFecR`) flow doing its job — don't confuse them.
+
+**A/B (isolates "needs retransmission" from "loss simply too high"):** at the *same*
+shaping, run once as above (`MACRDP_UDP_LOSSY_DELIVERY=1`, the default in the script) and
+once with `MACRDP_UDP_LOSSY_DELIVERY=0 scripts/soak-lossy.sh …` (the lossy flow then rides
+the **reliable** SM, which retransmits). If the reliable control reaches `P2.4 GREEN`
+where lossy stalls, the stall is the missing handshake retransmission — not the link.
+Sweep loss `0 → 2 → 5 → 10 %` and latency `+60 / +150 ms`; record at which cell lossy
+first fails to establish and whether the reliable control still does.
+
+**If lossy stalls under loss (expected at some loss level), the fix** is handshake-phase
+robustness without giving up steady-state losslessness: make the `CREATERESPONSE`
+**idempotent** (re-answer every `CREATEREQUEST` in lossy mode instead of gating on
+`tunnel_created`), and/or drive DTLS's `handle_timeout` from the listener's existing
+retransmit tick for a lossy peer so the server re-sends its own handshake flight. Both are
+handshake-only — once the tunnel is up, data stays send-once. (Deferred until the soak
+shows it's needed, per the project's "don't build it until the soak proves it" rule that
+landed the reliable-path timer tick.)
 
 ## Audio belongs on the lossy transport, not the reliable one
 

--- a/scripts/soak-lossy.sh
+++ b/scripts/soak-lossy.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# soak-lossy.sh — run macrdp configured for the P2.2 *lossy-delivery* UDP soak and
+# surface the handshake/tunnel markers that tell you whether the lossy
+# (`UdpFecL`) flow survives an emulated lossy link.
+#
+# Pairs with scripts/netshape.sh (the traffic shaper). Two terminals:
+#
+#   # terminal 1 — shape the link (both directions, TCP+UDP on the port):
+#   sudo scripts/netshape.sh on --loss 5 --delay 100
+#
+#   # terminal 2 — run the server under the lossy-delivery soak config:
+#   scripts/soak-lossy.sh --enable-udp-multitransport --enable-h264 \
+#       --username "$USER" --password 'PASS' --bind 0.0.0.0:3390
+#
+#   # …connect mstsc from another machine, exercise it, then:
+#   sudo scripts/netshape.sh off
+#
+# What it does: exports the two experimental env vars the lossy path needs
+# (MACRDP_UDP_OFFER_FECL=1 so the client opens a lossy flow; MACRDP_UDP_LOSSY_DELIVERY=1
+# so that flow drives DeliveryMode::Lossy), sets a soak-appropriate RUST_LOG if you
+# haven't, runs macrdp with the args you pass through, tees the FULL log to a
+# timestamped file, and live-prints only the soak-relevant lines so the signal isn't
+# buried. All other args (--password, --bind, feature flags, …) pass straight through.
+#
+# Override knobs (env):
+#   MACRDP   — path to the binary (default: target/release/macrdp)
+#   RUST_LOG — logging filter (default: the soak filter below)
+#   SOAK_LOG — full-log output path (default: ./soak-lossy-<timestamp>.log)
+#
+# A/B note: to compare against the *reliable* SM carrying the same lossy flow (the
+# control), re-run with MACRDP_UDP_LOSSY_DELIVERY=0 in front of this script — the
+# flow then rides the reliable SM (retransmits), which is the proven path.
+
+set -eu
+
+MACRDP="${MACRDP:-target/release/macrdp}"
+
+if [ ! -x "$MACRDP" ]; then
+    echo "error: macrdp binary not found / not executable at: $MACRDP" >&2
+    echo "  build it first: cargo build --release" >&2
+    echo "  (or set MACRDP=/path/to/macrdp)" >&2
+    exit 1
+fi
+
+# The lossy path is experimental + env-gated; the soak turns both gates on.
+export MACRDP_UDP_OFFER_FECL=1
+export MACRDP_UDP_LOSSY_DELIVERY="${MACRDP_UDP_LOSSY_DELIVERY:-1}"
+
+# Enough to see the handshake lifecycle + the reliability counters, without the
+# per-keystroke input spam.
+export RUST_LOG="${RUST_LOG:-info,ironrdp_server::multitransport=debug,ironrdp_acceptor=info,macrdp::h264=info,macrdp::audio=info}"
+
+ts="$(date +%Y%m%d-%H%M%S)"
+SOAK_LOG="${SOAK_LOG:-./soak-lossy-${ts}.log}"
+
+# The lines worth watching during a lossy soak: the lossy-flow classification, the
+# DTLS/tunnel handshake milestones (P2.1/P2.4 GREEN = it survived loss to established),
+# the reliability counters (RTO retransmits should be ZERO for a pure-lossy flow — any
+# reliable-flow retransmits still show), and the failure tells (broken pipe / reset /
+# cookie reject / handshake never completing).
+MARKERS='LOSSY delivery|MACRDP_UDP_LOSSY_DELIVERY|SPIKE GREEN|P2\.1 GREEN|P2\.4 GREEN|CREATEREQUEST|CREATERESPONSE|cookie not recognized|RTO retransmit|handshake established|Connection error|Broken pipe|Connection reset|reliable data delivered|receive-sequence mismatch'
+
+echo "soak-lossy: MACRDP_UDP_OFFER_FECL=$MACRDP_UDP_OFFER_FECL MACRDP_UDP_LOSSY_DELIVERY=$MACRDP_UDP_LOSSY_DELIVERY"
+echo "soak-lossy: binary=$MACRDP"
+echo "soak-lossy: full log -> $SOAK_LOG (paste this if reporting)"
+echo "soak-lossy: live view below is filtered to soak markers; the file has everything."
+echo "soak-lossy: shape the link in another terminal: sudo scripts/netshape.sh on --loss 5 --delay 100"
+echo "---"
+
+# Full output to the file; live console filtered to the markers. `grep -E` is line
+# buffered on a pipe under macOS, so lines appear as they happen.
+"$MACRDP" "$@" 2>&1 | tee "$SOAK_LOG" | grep -E --line-buffered "$MARKERS" || true


### PR DESCRIPTION
## What

Set up the soak harness for the **P2.2 lossy-delivery** path. Purely additive: a runner script + a documented runbook + a gitignore entry. **No macrdp behavior change.**

## Why

The reliable EGFX-over-UDP soak already had a harness (`netshape.sh`). The lossy delivery policy (P2.2 steps 1–2) is verified on a *clean* link but has known **send-once / no-retransmit** caveats that only show under real loss — this gives a turnkey way to find them.

## Added

- **`scripts/soak-lossy.sh`** — runs macrdp with the two lossy gates exported (`MACRDP_UDP_OFFER_FECL=1`, `MACRDP_UDP_LOSSY_DELIVERY=1`), a soak-appropriate `RUST_LOG`, pass-through args (`--password`, `--bind`, feature flags), tees the full log to a timestamped file, and **live-prints only the soak markers** (lossy-flow classification, `P2.1`/`P2.4 GREEN` handshake milestones, RTO-retransmit counters, broken-pipe/reset/cookie-reject tells). Smoke-tested against the real binary.
- **Feasibility doc — "P2.2 lossy-delivery soak (runbook)"**: what it probes (the one-shot `CREATERESPONSE(S_OK)` and DTLS server flight aren't resent; the `tunnel_created` guard answers a repeated `CREATEREQUEST` once), the two-terminal procedure, the marker-based pass/fail read, the `MACRDP_UDP_LOSSY_DELIVERY=1`-vs-`0` A/B that isolates "needs handshake retransmission" from "loss simply too high", the loss/latency sweep, and the handshake-only fix to apply **if** the soak shows a stall — kept deferred per the project's "don't build it until the soak proves it" rule.
- `.gitignore`: `/soak-lossy-*.log`.

## How to run (two terminals, real mstsc on another machine)

```
sudo scripts/netshape.sh on --loss 5 --delay 100
scripts/soak-lossy.sh --enable-udp-multitransport --enable-h264 --username "$USER" --password 'PASS' --bind 0.0.0.0:3390
# …connect mstsc, exercise it, then:
sudo scripts/netshape.sh off
```

## Verification

`sh -n` syntax check + smoke test against the real binary (env set, markers filtered, full log to file, clean exit). `cargo fmt`/`clippy`/`test` unaffected (no Rust change).
