### PR TITLE
feat(dvc): P2.4b-i — Soft-Sync switch_to_udpfecl (lossy tunnel) constructor

### DIFF
--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -158,6 +158,31 @@ mod tests {
         assert_eq!(bytes, expected);
     }
 
+    // P2.4b: the lossy-tunnel Soft-Sync (audio → AUDIO_PLAYBACK_LOSSY_DVC). Same
+    // shape as the reliable request, only TunnelType differs (FECL=0x03 vs FECR=0x01).
+    #[test]
+    fn soft_sync_request_udpfecl_encodes_to_exact_wire_bytes() {
+        use ironrdp_core::encode_vec;
+        use ironrdp_dvc::pdu::{DrdynvcServerPdu, SoftSyncRequestPdu};
+
+        let pdu =
+            DrdynvcServerPdu::SoftSyncRequest(SoftSyncRequestPdu::switch_to_udpfecl(vec![0x0009]));
+        let bytes = encode_vec(&pdu).unwrap();
+
+        #[rustfmt::skip]
+        let expected: [u8; 20] = [
+            0x80,                   // Header: Cmd=SoftSyncRequest(0x08)<<4, cbId=0, Sp=0
+            0x00,                   // Pad
+            0x12, 0x00, 0x00, 0x00, // Length = 18
+            0x03, 0x00,             // Flags = TCP_FLUSHED | CHANNEL_LIST_PRESENT
+            0x01, 0x00,             // NumberOfTunnels = 1 (u16 in the request)
+            0x03, 0x00, 0x00, 0x00, // TunnelType = TUNNELTYPE_UDPFECL
+            0x01, 0x00,             // NumberOfDVCs = 1
+            0x09, 0x00, 0x00, 0x00, // ListOfDVCIds[0] = 0x0009
+        ];
+        assert_eq!(bytes, expected);
+    }
+
     // The M5c "safe spike": an empty channel list (flush TCP, migrate nothing) —
     // no list is emitted, NumberOfTunnels = 0, CHANNEL_LIST_PRESENT unset.
     #[test]

--- a/vendor/ironrdp-dvc/CLAUDE.md
+++ b/vendor/ironrdp-dvc/CLAUDE.md
@@ -66,6 +66,11 @@ since the lib is `test = false`.
       NumberOfTunnels=0, CHANNEL_LIST_PRESENT unset), the M5c safe spike. Wired into
       `DrdynvcServerPdu::SoftSyncRequest` (Encode/name/size only — the server
       never *decodes* its own request, so no `DrdynvcServerPdu::decode` arm).
+      **P2.4b add (2026-06-27):** `switch_to_udpfecl(channel_ids)` (the lossy-audio
+      path, `TUNNELTYPE_UDPFECL`) + the shared `switch_to_tunnel(tunnel_type, …)` both
+      `switch_to_*` delegate to. Same wire shape as the reliable request, only
+      `TunnelType` differs (0x03 vs 0x01); round-trip tested in macrdp's
+      `src/multitransport.rs` (`soft_sync_request_udpfecl_encodes_to_exact_wire_bytes`).
     - `SoftSyncResponsePdu { header, tunnels: Vec<u32> }` — client→server
       DYNVC_SOFT_SYNC_RESPONSE (Header byte; Pad u8; NumberOfTunnels **u32** —
       asymmetric vs the request's u16; TunnelsToSwitch u32 each). Wired into

--- a/vendor/ironrdp-dvc/src/pdu.rs
+++ b/vendor/ironrdp-dvc/src/pdu.rs
@@ -731,13 +731,31 @@ impl SoftSyncRequestPdu {
     /// unset), which is the safe spike used to confirm the send path + the
     /// client's response decode without actually migrating any DVC.
     pub fn switch_to_udpfecr(channel_ids: Vec<DynamicChannelId>) -> Self {
+        Self::switch_to_tunnel(TUNNELTYPE_UDPFECR, channel_ids)
+    }
+
+    /// A request moving `channel_ids` onto the **lossy**-UDP tunnel
+    /// ([`TUNNELTYPE_UDPFECL`]) — the Phase-2 audio path (`AUDIO_PLAYBACK_LOSSY_DVC`).
+    /// Same shape as [`switch_to_udpfecr`](Self::switch_to_udpfecr); only the
+    /// `TunnelType` differs. An empty `channel_ids` is the "flush TCP, migrate
+    /// nothing" probe (no list emitted).
+    pub fn switch_to_udpfecl(channel_ids: Vec<DynamicChannelId>) -> Self {
+        Self::switch_to_tunnel(TUNNELTYPE_UDPFECL, channel_ids)
+    }
+
+    /// Build a single-tunnel Soft-Sync request. An **empty** `channel_ids` is a
+    /// valid "flush TCP, migrate nothing" probe: no channel list is emitted
+    /// (`NumberOfTunnels` = 0, `CHANNEL_LIST_PRESENT` unset) — the safe spike that
+    /// confirms the send path + the client's response decode without migrating any
+    /// DVC.
+    pub fn switch_to_tunnel(tunnel_type: u32, channel_ids: Vec<DynamicChannelId>) -> Self {
         let (flags, channel_lists) = if channel_ids.is_empty() {
             (SOFT_SYNC_TCP_FLUSHED, vec![])
         } else {
             (
                 SOFT_SYNC_TCP_FLUSHED | SOFT_SYNC_CHANNEL_LIST_PRESENT,
                 vec![SoftSyncChannelList {
-                    tunnel_type: TUNNELTYPE_UDPFECR,
+                    tunnel_type,
                     channel_ids,
                 }],
             )


### PR DESCRIPTION
First sub-step of **P2.4b** (lossy audio over the lossy tunnel).

The Soft-Sync codec could already express the lossy tunnel (`TUNNELTYPE_UDPFECL=0x03` via `SoftSyncChannelList.tunnel_type`) but had only a `switch_to_udpfecr` convenience. Add **`switch_to_udpfecl(channel_ids)`** for the `AUDIO_PLAYBACK_LOSSY_DVC` migration, plus the shared `switch_to_tunnel(tunnel_type, channel_ids)` both delegate to. Same wire shape as the reliable request — only `TunnelType` differs (0x03 vs 0x01).

Round-trip unit test in `src/multitransport.rs` (`soft_sync_request_udpfecl_encodes_to_exact_wire_bytes`), byte-exact against the expected FECL request.

**Pure codec; no behavior change** — no caller yet (the audio Soft-Sync trigger is sub-step 2b-ii). 70 tests pass, clippy/fmt clean.

## P2.4b plan (context)
- **2b-i (this PR):** `switch_to_udpfecl` codec helper.
- **2b-ii (next, needs mstsc):** create `AUDIO_PLAYBACK_LOSSY_DVC`, Soft-Sync it onto FECL without sending formats over TCP — does mstsc accept a lossy Soft-Sync? (the #54-finding linchpin)
- **2b-iii:** route the MS-RDPEA handshake over the lossy tunnel (lossy-peer server→listener handoff via `DtlsConn::send` + inbound tunnel→drdynvc).
- **2b-iv:** stream AAC Wave2 over the lossy tunnel + reconcile the drop-stale lag model.