### PR TITLE
feat(multitransport): P2.4b-2 — lossy Soft-Sync of the audio DVC (accepted by mstsc)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -566,15 +566,31 @@ Each milestone is its own gated PR, real-client-verified, feature-flagged
     that** (MS-RDPEA "Initialization Sequence"). The handler waits for Quality Mode before
     replying with Training.
 
-  **Implication for the build:** lossy audio needs the lossy DVC Soft-Synced onto the DTLS
-  tunnel up front + the handshake + AAC waves carried over the tunnel — i.e. it depends on a
-  solid lossy *data path* (P2.2/P2.3) underneath, which doesn't exist yet. And note the
-  reliable `AUDIO_PLAYBACK_DVC` path that *does* work is **not worth landing on its own**: a
+  **P2.4b-2 spike result (2026-06-27, the linchpin de-risk): mstsc ACCEPTS a *lossy*
+  Soft-Sync of the audio DVC without tearing down.** This was the open question P2.4b-1 left
+  ("does a lossy Soft-Sync itself trip mstsc, or only format-data-over-TCP?"). Built it:
+  `audio_dvc.rs::start()` now returns **no formats** for the lossy name (defer over TCP —
+  finding above), and the server Soft-Syncs the channel onto the lossy
+  (`TUNNELTYPE_UDPFECL=0x03`) tunnel via the Phase-1 Soft-Sync codec
+  (`send_soft_sync_request(.., TUNNELTYPE_UDPFECL, vec![audio_id])`, triggered off the same
+  `maybe_soft_sync_on_egfx` machinery that migrates EGFX). Verified live on mstsc:
+  `lossy audio DVC opened — deferring Server Audio Formats` → `Sent DYNVC_SOFT_SYNC_REQUEST` →
+  **`SoftSyncResponsePdu { tunnels: [3] }`** (UDPFECL accepted) → session stayed alive to a
+  graceful disconnect ~13 s later, EGFX (on TCP) acking frames the whole time. **So the #54
+  blocker was specifically format data over TCP, NOT the lossy Soft-Sync** — the migration
+  primitive is clear. (Note: this run requires `--enable-h264` because the Soft-Sync trigger
+  is driven from the EGFX dispatch arm; EGFX stayed on TCP — `MACRDP_UDP_MIGRATE_EGFX` off.)
+
+  **Implication for the build:** the migration topology is now proven end-to-end (defer +
+  lossy Soft-Sync accepted). What remains is the *data over the tunnel*: run the MS-RDPEA
+  handshake (formats → quality → training) over the lossy/DTLS tunnel for the migrated peer
+  (2b-iii), then stream AAC Wave2 over it + reconcile the drop-stale lag model (2b-iv). That
+  depends on a solid lossy *data path* (P2.2/P2.3) underneath. And note the reliable
+  `AUDIO_PLAYBACK_DVC` path that works over TCP is **not worth landing on its own**: a
   reliable tunnel HOL-blocks under loss exactly like TCP (Phase 1 soak), so reliable
-  audio-over-UDP delivers no loss-resilience over TCP audio. **Status: paused after the
-  spike.** The hard unknowns are now banked (above); the verified groundwork (`audio_dvc.rs`
-  + the handshake) is kept in-tree, gated off by default. Resume by Soft-Syncing the lossy
-  DVC onto the tunnel before the handshake, after the lossy transport SM + FEC are mature.
+  audio-over-UDP delivers no loss-resilience over TCP audio. **Status: linchpin de-risked;
+  data path next.** The verified groundwork (`audio_dvc.rs` + defer + lossy Soft-Sync) is
+  kept in-tree, gated off by default (`MACRDP_UDP_OFFER_FECL` + `MACRDP_UDP_LOSSY_AUDIO`).
 
 - **P2.5 — route audio to the lossy tunnel + reconcile the lag model.** Point the audio
   path at the lossy tunnel and reconcile with the existing audio-lag / drop-stale model

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -593,8 +593,8 @@ AND released — #1276 landing is NOT sufficient.
     bytes at the same point, before its `wants_write` drain). **Verified GREEN on
     real mstsc**: CREATEREQUEST cookie matched the issued cookie → CREATERESPONSE
     sent → tunnel established AND the client STOPPED retransmitting (the definitive
-    accept signal). Next = P2.4b (migrate the AUDIO_PLAYBACK_LOSSY_DVC audio
-    channel onto the tunnel). See feasibility doc "P2.4a".
+    accept signal). P2.4b (migrate the AUDIO_PLAYBACK_LOSSY_DVC audio channel onto
+    the tunnel) is now de-risked — see P2.4b-2 below. See feasibility doc "P2.4a".
 
     P2.4b-1 — audio output DVC handshake (2026-06-27, `multitransport/audio_dvc.rs`;
     PAUSED after the spike): a `DvcProcessor`/`DvcServerProcessor` (`AudioLossyDvc`)
@@ -621,10 +621,33 @@ AND released — #1276 landing is NOT sufficient.
     RELIABLE tunnel *after* a TCP handshake). Spec note (confirmed live): for v6+ the
     client sends Quality Mode immediately after Client Audio Formats and the server
     sends Training only after that (MS-RDPEA Initialization Sequence) — the handler
-    waits for Quality Mode. **Paused** here: the verified groundwork is kept in-tree,
-    default-off; resume once the lossy data path (P2.2/P2.3) is mature. The
-    reliable-DVC path that works is NOT worth landing on its own (a reliable tunnel
-    HOL-blocks under loss like TCP — no win). See feasibility doc "P2.4b".
+    waits for Quality Mode. The reliable-DVC path that works over TCP is NOT worth
+    landing on its own (a reliable tunnel HOL-blocks under loss like TCP — no win).
+
+    P2.4b-2 — lossy Soft-Sync of the audio DVC ACCEPTED by mstsc (2026-06-27, the
+    linchpin de-risk; `audio_dvc.rs` + `server.rs`; verified on real mstsc): the open
+    question P2.4b-1 left was whether a *lossy* Soft-Sync itself trips mstsc or only
+    format-data-over-TCP. Answer: only the latter. `AudioLossyDvc::start()` now returns
+    NO formats for the lossy name (defers the handshake — P2.4b-1 finding), and the
+    server Soft-Syncs the channel onto the lossy tunnel:
+    `send_soft_sync_request(.., dvc::pdu::TUNNELTYPE_UDPFECL, vec![audio_id])`. The
+    trigger is a new branch in `maybe_soft_sync_on_egfx` (gated on
+    `multitransport_lossy_audio_formats.is_some()`, placed after the `udp_tunnel_bound`
+    check, before the EGFX one-time guard): it resolves the lossy DVC's channel id via
+    `DrdynvcServer::get_channel_id_by_name(AUDIO_PLAYBACK_LOSSY_DVC)` (retries next frame
+    if not open yet, guard intact), claims the one-time `MigrationState::soft_sync_sent`
+    guard, and Soft-Syncs FECL. `send_soft_sync_request` gained a `tunnel_type: u32`
+    param (uses `SoftSyncRequestPdu::switch_to_tunnel`); the two pre-existing callers
+    pass `TUNNELTYPE_UDPFECR`. Live mstsc result: `lossy audio DVC opened — deferring
+    Server Audio Formats` → `Sent DYNVC_SOFT_SYNC_REQUEST` → `SoftSyncResponsePdu {
+    tunnels: [3] }` (UDPFECL accepted) → session stayed alive to a graceful disconnect,
+    EGFX (on TCP) acking the whole time. So the #54 blocker is format-data-over-TCP, NOT
+    the lossy Soft-Sync. (This run needs `--enable-h264` — the trigger rides the EGFX
+    dispatch arm; EGFX itself stays on TCP, `MACRDP_UDP_MIGRATE_EGFX` off.) **Next
+    (2b-iii):** run the MS-RDPEA handshake (formats → quality → training) over the
+    lossy/DTLS tunnel for the migrated peer, then stream AAC waves (2b-iv) + reconcile
+    the drop-stale lag model. The verified groundwork is kept in-tree, default-off
+    (`MACRDP_UDP_OFFER_FECL` + `MACRDP_UDP_LOSSY_AUDIO`). See feasibility doc "P2.4b".
 
     P2.2 step 2 — lossy flow uses lossy delivery (2026-06-27, `listener.rs`; verified
     on real mstsc). Behind the experimental env `MACRDP_UDP_LOSSY_DELIVERY` (read once

--- a/vendor/ironrdp-server/src/multitransport/audio_dvc.rs
+++ b/vendor/ironrdp-server/src/multitransport/audio_dvc.rs
@@ -14,28 +14,36 @@
 //! version ≥ 8, and (c) AAC is the codec. So we advertise `Version::V8` and the
 //! caller passes a format list that includes AAC (`WAVE_FORMAT_AAC_MS`).
 //!
-//! **STATUS: P2.4b-1 spike, PAUSED (verified on real mstsc 2026-06-27).** Registered
-//! only when the application calls
+//! **STATUS: P2.4b-2 spike, VERIFIED on real mstsc 2026-06-27.** Registered only when
+//! the application calls
 //! [`RdpServer::set_multitransport_lossy_audio_formats`](crate::RdpServer::set_multitransport_lossy_audio_formats)
 //! (macrdp gates that behind the experimental `MACRDP_UDP_LOSSY_AUDIO` env), so the
 //! default build is byte-unchanged.
 //!
-//! **KEY FINDING — the EGFX "negotiate-on-TCP-then-Soft-Sync" pattern does NOT carry
-//! to a *lossy*-named channel.** With the literal name `AUDIO_PLAYBACK_LOSSY_DVC`,
-//! mstsc accepts the DVC Create but, on receiving Server Audio Formats over
-//! TCP/DRDYNVC, goes silent and tears down the whole TCP connection (broken pipe a
-//! few seconds later — it kills EGFX too, not just audio). The reliable name
-//! `AUDIO_PLAYBACK_DVC` (diagnostic env `MACRDP_AUDIO_DVC_RELIABLE=1`) handshakes
+//! **KEY FINDING #1 (P2.4b-1) — the EGFX "negotiate-on-TCP-then-Soft-Sync" pattern
+//! does NOT carry to a *lossy*-named channel.** With the literal name
+//! `AUDIO_PLAYBACK_LOSSY_DVC`, mstsc accepts the DVC Create but, on receiving Server
+//! Audio Formats over TCP/DRDYNVC, goes silent and tears down the whole TCP connection
+//! (broken pipe a few seconds later — it kills EGFX too, not just audio). The reliable
+//! name `AUDIO_PLAYBACK_DVC` (diagnostic env `MACRDP_AUDIO_DVC_RELIABLE=1`) handshakes
 //! perfectly over TCP (formats → client formats(AAC) → quality mode → training →
 //! confirm), audio plays, EGFX stays healthy — proving the channel *name* is the
 //! blocker, not the PDU/framing and not coexistence with static rdpsnd (dual
-//! negotiation is fine). So the **lossy** DVC must be Soft-Synced onto the lossy
-//! tunnel BEFORE any data, with the handshake over the tunnel — the opposite of EGFX
-//! (which migrates to the RELIABLE tunnel *after* a TCP handshake). That, plus routing
-//! the AAC waves over the tunnel, is deferred until the lossy data path (P2.2/P2.3) is
-//! mature; the reliable-DVC path that works isn't worth landing on its own (a reliable
-//! tunnel HOL-blocks under loss like TCP). See `docs/rdp-udp-multitransport-feasibility.md`
-//! ("P2.4b").
+//! negotiation is fine).
+//!
+//! **KEY FINDING #2 (P2.4b-2, the linchpin de-risk) — mstsc ACCEPTS a *lossy* Soft-Sync
+//! of the audio DVC without tearing down.** This handler now opens the lossy DVC and
+//! returns NO formats from `start()` (defer over TCP — finding #1), then the server
+//! Soft-Syncs the channel onto the lossy (`TUNNELTYPE_UDPFECL=0x03`) tunnel. Live mstsc
+//! result: `lossy audio DVC opened — deferring Server Audio Formats` → Soft-Sync sent →
+//! `SoftSyncResponsePdu { tunnels: [3] }` (UDPFECL accepted) → session stayed alive to a
+//! graceful disconnect. So the #54 blocker was specifically **format data over TCP**, NOT
+//! the lossy Soft-Sync itself. The path forward (the opposite of EGFX, which migrates to
+//! the RELIABLE tunnel *after* a TCP handshake): Soft-Sync the lossy DVC FIRST, then run
+//! the MS-RDPEA handshake (formats → quality → training) over the lossy tunnel (2b-iii),
+//! then stream AAC waves over it (2b-iv). The reliable-DVC path that works over TCP isn't
+//! worth landing on its own (a reliable tunnel HOL-blocks under loss like TCP). See
+//! `docs/rdp-udp-multitransport-feasibility.md` ("P2.4b").
 //!
 //! **Sequence (MS-RDPEA Initialization Sequence, confirmed live):** for v6+ the client
 //! sends a Quality Mode PDU immediately after Client Audio Formats, and the server
@@ -127,6 +135,18 @@ impl DvcProcessor for AudioLossyDvc {
     }
 
     fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        // The lossy-named DVC must NOT receive format data over TCP/DRDYNVC — mstsc
+        // tears down the whole TCP socket if it does (the P2.4b-1 finding). Defer the
+        // MS-RDPEA handshake until the channel is Soft-Synced onto the lossy tunnel;
+        // the formats then ride the tunnel (2b-iii). The reliable diagnostic name
+        // (MACRDP_AUDIO_DVC_RELIABLE) keeps the proven over-TCP handshake.
+        if self.channel_name == AUDIO_PLAYBACK_LOSSY_DVC {
+            debug!(
+                channel = self.channel_name,
+                "lossy audio DVC opened — deferring Server Audio Formats until Soft-Sync onto the lossy tunnel"
+            );
+            return Ok(Vec::new());
+        }
         debug!(
             channel = self.channel_name,
             formats = self.formats.len(),
@@ -165,7 +185,10 @@ impl DvcProcessor for AudioLossyDvc {
                             "P2.4b: audio DVC client formats received — awaiting Quality Mode"
                         );
                     }
-                    None => warn!(channel = self.channel_name, "audio DVC: client accepted none of the server formats"),
+                    None => warn!(
+                        channel = self.channel_name,
+                        "audio DVC: client accepted none of the server formats"
+                    ),
                 }
                 Ok(Vec::new())
             }

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -587,10 +587,7 @@ impl RdpServer {
     /// [`UdpMultitransportListener::bind`](crate::UdpMultitransportListener::bind).
     /// Must be called before any client connects.
     #[cfg(feature = "multitransport")]
-    pub fn set_multitransport_cookie_registry(
-        &mut self,
-        registry: Option<crate::multitransport::CookieRegistry>,
-    ) {
+    pub fn set_multitransport_cookie_registry(&mut self, registry: Option<crate::multitransport::CookieRegistry>) {
         self.multitransport_cookies = registry;
     }
 
@@ -609,10 +606,7 @@ impl RdpServer {
     /// formats (the caller passes a PCM+AAC list matching what its wave path
     /// encodes); `None` (default) leaves it unregistered.
     #[cfg(feature = "multitransport")]
-    pub fn set_multitransport_lossy_audio_formats(
-        &mut self,
-        formats: Option<Vec<ironrdp_rdpsnd::pdu::AudioFormat>>,
-    ) {
+    pub fn set_multitransport_lossy_audio_formats(&mut self, formats: Option<Vec<ironrdp_rdpsnd::pdu::AudioFormat>>) {
         self.multitransport_lossy_audio_formats = formats;
     }
 
@@ -1074,9 +1068,7 @@ impl RdpServer {
                 let mut rdpdr: Vec<ServerEvent> = Vec::new();
                 for ev in events.drain(..) {
                     match ev {
-                        ServerEvent::Clipboard(_) | ServerEvent::ClipboardFileCopy(_) => {
-                            clipboard.push(ev)
-                        }
+                        ServerEvent::Clipboard(_) | ServerEvent::ClipboardFileCopy(_) => clipboard.push(ev),
                         ServerEvent::Rdpdr(_) => rdpdr.push(ev),
                         _ => middle.push(ev),
                     }
@@ -1112,7 +1104,9 @@ impl RdpServer {
                             // hasn't overridden `set_audio_sender` — drop
                             // gracefully and warn once so the maintainer
                             // notices.
-                            warn!("Wave event on unified ServerEvent channel; backend should override set_audio_sender");
+                            warn!(
+                                "Wave event on unified ServerEvent channel; backend should override set_audio_sender"
+                            );
                             continue;
                         }
                         RdpsndServerMessage::SetVolume { left, right } => rdpsnd.set_volume(left, right),
@@ -1509,10 +1503,7 @@ impl RdpServer {
     /// Multitransport Response. M1 has no UDP transport, so this only logs the
     /// outcome and clears the in-flight request; the session stays on TCP.
     #[cfg(feature = "multitransport")]
-    fn handle_multitransport_response(
-        &mut self,
-        resp: &ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu,
-    ) {
+    fn handle_multitransport_response(&mut self, resp: &ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu) {
         match self.multitransport_migration.take() {
             Some(state) if state.request_id == resp.request_id => {
                 if resp.is_success() {
@@ -1605,7 +1596,8 @@ impl RdpServer {
         // Secondary TCP gate (a client that *does* send an Initiate Response S_OK
         // — mstsc never does). Keep it an empty spike: EGFX migration is driven by
         // the listener-bound gate (`maybe_soft_sync_on_egfx`), not this path.
-        self.send_soft_sync_request(writer, user_channel_id, Vec::new()).await?;
+        self.send_soft_sync_request(writer, user_channel_id, dvc::pdu::TUNNELTYPE_UDPFECR, Vec::new())
+            .await?;
         Ok(true)
     }
 
@@ -1616,11 +1608,7 @@ impl RdpServer {
     /// This (not a TCP Initiate Response) is the real success gate: mstsc signals
     /// multitransport success by creating the tunnel, never by a TCP response.
     #[cfg(feature = "multitransport")]
-    async fn maybe_soft_sync_on_egfx(
-        &mut self,
-        writer: &mut impl FramedWrite,
-        user_channel_id: u16,
-    ) -> Result<()> {
+    async fn maybe_soft_sync_on_egfx(&mut self, writer: &mut impl FramedWrite, user_channel_id: u16) -> Result<()> {
         let bound = self
             .udp_tunnel_bound
             .as_ref()
@@ -1628,6 +1616,34 @@ impl RdpServer {
         if !bound {
             return Ok(());
         }
+
+        // P2.4b (2b-ii): if a lossy audio DVC is registered, migrate IT onto the
+        // LOSSY tunnel (`TUNNELTYPE_UDPFECL`) — the inverse of EGFX, which (when
+        // enabled) migrates onto the RELIABLE tunnel. The lossy audio handshake
+        // can't run over TCP at all (the P2.4b-1 finding: mstsc tears the socket
+        // down), so the Soft-Sync MUST precede any audio data. Look the channel up
+        // BEFORE consuming the one-time guard, so if its DVC Create Response hasn't
+        // arrived yet we just retry on the next EGFX frame (guard intact).
+        if self.multitransport_lossy_audio_formats.is_some() {
+            let Some(audio_id) = self
+                .get_svc_processor::<dvc::DrdynvcServer>()
+                .and_then(|d| d.get_channel_id_by_name(crate::multitransport::audio_dvc::AUDIO_PLAYBACK_LOSSY_DVC))
+            else {
+                return Ok(());
+            };
+            match self.multitransport_migration.as_mut() {
+                Some(state) if !state.soft_sync_sent => state.soft_sync_sent = true,
+                _ => return Ok(()),
+            }
+            debug!(
+                audio_channel_id = audio_id,
+                "UDP lossy tunnel bound + audio DVC open — Soft-Sync migrating audio onto the LOSSY (UdpFecL) tunnel"
+            );
+            return self
+                .send_soft_sync_request(writer, user_channel_id, dvc::pdu::TUNNELTYPE_UDPFECL, vec![audio_id])
+                .await;
+        }
+
         // One-time guard (drops the &mut borrow before the get_svc_processor below).
         match self.multitransport_migration.as_mut() {
             Some(state) if !state.soft_sync_sent => state.soft_sync_sent = true,
@@ -1660,19 +1676,22 @@ impl RdpServer {
             Vec::new()
         };
         debug!("UDP tunnel bound + EGFX active — Soft-Sync gate open");
-        self.send_soft_sync_request(writer, user_channel_id, channel_ids).await
+        self.send_soft_sync_request(writer, user_channel_id, dvc::pdu::TUNNELTYPE_UDPFECR, channel_ids)
+            .await
     }
 
     /// (M5c) Send a `DYNVC_SOFT_SYNC_REQUEST` over the DRDYNVC static channel on
-    /// TCP. `channel_ids` are the DVC channels to migrate onto the reliable UDP
-    /// tunnel — **empty** is the safe spike (TCP_FLUSHED only, migrate nothing, so
-    /// everything stays on TCP); a non-empty list (the EGFX id) commits those
-    /// channels' data to the tunnel.
+    /// TCP. `tunnel_type` selects the target tunnel (`TUNNELTYPE_UDPFECR` reliable /
+    /// `TUNNELTYPE_UDPFECL` lossy); `channel_ids` are the DVC channels to migrate onto
+    /// it — **empty** is the safe spike (TCP_FLUSHED only, migrate nothing, so
+    /// everything stays on TCP); a non-empty list commits those channels' data to the
+    /// tunnel (the EGFX id for the reliable tunnel, the lossy audio DVC id for FECL).
     #[cfg(feature = "multitransport")]
     async fn send_soft_sync_request(
         &mut self,
         writer: &mut impl FramedWrite,
         user_channel_id: u16,
+        tunnel_type: u32,
         channel_ids: Vec<u32>,
     ) -> Result<()> {
         let Some(drdynvc_channel_id) = self.get_channel_id_by_type::<dvc::DrdynvcServer>() else {
@@ -1681,17 +1700,30 @@ impl RdpServer {
         };
 
         let migrating = !channel_ids.is_empty();
-        let req = dvc::pdu::SoftSyncRequestPdu::switch_to_udpfecr(channel_ids);
+        let req = dvc::pdu::SoftSyncRequestPdu::switch_to_tunnel(tunnel_type, channel_ids);
         let pdu = dvc::pdu::DrdynvcServerPdu::SoftSyncRequest(req);
         // Soft-Sync is a top-level DRDYNVC PDU (not sub-channel DATA), so it ships
         // as a plain SvcMessage on the drdynvc static channel.
         let msg = ironrdp_svc::SvcMessage::from(pdu).with_flags(ChannelFlags::SHOW_PROTOCOL);
         let data = server_encode_svc_messages(vec![msg], drdynvc_channel_id, user_channel_id)?;
         writer.write_all(&data).await?;
+        let tunnel_name = match tunnel_type {
+            t if t == dvc::pdu::TUNNELTYPE_UDPFECL => "lossy (UdpFecL)",
+            t if t == dvc::pdu::TUNNELTYPE_UDPFECR => "reliable (UdpFecR)",
+            _ => "unknown",
+        };
         if migrating {
-            debug!("Sent DYNVC_SOFT_SYNC_REQUEST (migrating EGFX onto the UDP tunnel)");
+            debug!(
+                tunnel_type,
+                tunnel = tunnel_name,
+                "Sent DYNVC_SOFT_SYNC_REQUEST (migrating channels onto the UDP tunnel)"
+            );
         } else {
-            debug!("Sent DYNVC_SOFT_SYNC_REQUEST (empty channel list — EGFX stays on TCP)");
+            debug!(
+                tunnel_type,
+                tunnel = tunnel_name,
+                "Sent DYNVC_SOFT_SYNC_REQUEST (empty channel list — nothing migrated, stays on TCP)"
+            );
         }
         Ok(())
     }
@@ -1996,9 +2028,9 @@ impl RdpServer {
         let control: rdp::headers::ShareControlHeader = match decode(data.user_data.as_ref()) {
             Ok(control) => control,
             Err(e) => {
-                if let Ok(resp) = decode::<ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu>(
-                    data.user_data.as_ref(),
-                ) {
+                if let Ok(resp) =
+                    decode::<ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu>(data.user_data.as_ref())
+                {
                     self.handle_multitransport_response(&resp);
                     return Ok(false);
                 }


### PR DESCRIPTION
## What

The **linchpin de-risk** for lossy audio over UDP (Phase 2, P2.4b-2). PR #54 left open whether a *lossy* Soft-Sync itself trips mstsc, or only audio **format data sent over TCP**. Answer, **verified live on real mstsc**: only the latter.

## Changes

- **`audio_dvc.rs`**: `AudioLossyDvc::start()` now returns **no formats** for the `AUDIO_PLAYBACK_LOSSY_DVC` name — defer the MS-RDPEA handshake (over-TCP format data is the #54 teardown trigger), so the channel can be migrated *first*. The reliable diagnostic name (`MACRDP_AUDIO_DVC_RELIABLE`) keeps the proven over-TCP handshake.
- **`server.rs`**: `send_soft_sync_request` gains a `tunnel_type` param (uses `SoftSyncRequestPdu::switch_to_tunnel`); `maybe_soft_sync_on_egfx` gains a lossy-audio branch that resolves the lossy DVC's channel id and Soft-Syncs it onto the lossy (`TUNNELTYPE_UDPFECL`) tunnel. The two pre-existing callers pass `TUNNELTYPE_UDPFECR`. The send log now names the tunnel type (was always "migrating EGFX").

## Verification (real mstsc, Win11/WiFi LAN)

```
lossy audio DVC opened — deferring Server Audio Formats until Soft-Sync onto the lossy tunnel
UDP lossy tunnel bound + audio DVC open — Soft-Sync migrating audio onto the LOSSY (UdpFecL) tunnel audio_channel_id=4
Sent DYNVC_SOFT_SYNC_REQUEST ... tunnel=lossy (UdpFecL)
Got DVC Soft-Sync Response PDU: SoftSyncResponsePdu { ... tunnels: [3] }   ← UDPFECL accepted
... (13s, EGFX acking) ...
Got disconnect request   ← graceful
```

mstsc **accepted** the lossy Soft-Sync (`tunnels: [3]` = `TUNNELTYPE_UDPFECL`) and did **not** tear down. So the #54 blocker is format-data-over-TCP, not the lossy Soft-Sync — the migration topology is proven.

## Scope / safety

- Gated off by default (`MACRDP_UDP_OFFER_FECL` + `MACRDP_UDP_LOSSY_AUDIO`); default build byte-unchanged.
- This run needs `--enable-h264` (the Soft-Sync trigger rides the EGFX dispatch arm); EGFX itself stays on TCP (`MACRDP_UDP_MIGRATE_EGFX` off).
- No audio data rides the tunnel yet — that's the next step (2b-iii: run the MS-RDPEA handshake over the tunnel; 2b-iv: stream AAC waves + reconcile the drop-stale lag model).

Docs updated: feasibility P2.4b, vendor `ironrdp-server` divergence (12), `audio_dvc.rs` module doc.