### PR TITLE
feat(multitransport): P2.4b 2b-iv — stream AAC audio over the lossy UDP/DTLS tunnel (verified mstsc)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -592,6 +592,41 @@ Each milestone is its own gated PR, real-client-verified, feature-flagged
   data path next.** The verified groundwork (`audio_dvc.rs` + defer + lossy Soft-Sync) is
   kept in-tree, gated off by default (`MACRDP_UDP_OFFER_FECL` + `MACRDP_UDP_LOSSY_AUDIO`).
 
+  **P2.4b 2b-iv result (2026-06-27): audio RENDERS over the lossy UDP/DTLS tunnel —
+  VERIFIED end-to-end on real mstsc.** This closes the data path the 2b-ii de-risk pointed
+  to. Two sub-steps:
+  - **2b-iv-A — dual audio-DVC topology.** Rather than run the MS-RDPEA handshake over the
+    tunnel (which would need 2b-iii's tunnel-side handshake plumbing), the build uses **both**
+    audio DVCs at once: the RELIABLE `AUDIO_PLAYBACK_DVC` runs the full format/quality/training
+    handshake over TCP (the only thing mstsc tolerates — see the P2.4b-1 finding), and the LOSSY
+    `AUDIO_PLAYBACK_LOSSY_DVC` is data-only and Soft-Synced onto the UDPFECL/DTLS tunnel. The
+    lossy channel **inherits the reliable channel's negotiated `wFormatNo`** via a shared
+    `NegotiatedAudioFormat(Arc<AtomicU32>)` (reliable publishes it on TrainingConfirm; the
+    server reads it back to stamp Wave2 PDUs). This sidesteps 2b-iii entirely — the handshake
+    stays on the channel mstsc accepts it on, and only Wave2 data rides the tunnel. (A "video
+    freezes on connect" seen once here was transient mstsc state — a byte-identical retry
+    rendered fine; the documented "mstsc caches bad RDP state until reboot" behavior, not a
+    topology bug.)
+  - **2b-iv-B — AAC Wave2 over the tunnel.** `dispatch_audio` ships each wave as a `Wave2Pdu`
+    on `AUDIO_PLAYBACK_LOSSY_DVC` (bare DRDYNVC PDU → `RDP_TUNNEL_DATA`, DTLS-encrypted) once
+    all preconditions hold (reliable handshake done + tunnel bound + lossy DVC open), and
+    **skips the static rdpsnd TCP write** — exactly one playback path at a time, clean handover,
+    no double-play. **Verified live on mstsc:** reliable handshake GREEN → lossy Soft-Sync
+    accepted (`tunnels: [3]`) → one-shot marker `streaming Wave2 audio over the LOSSY UDP/DTLS
+    tunnel … static rdpsnd now silent` (format_no=0, channel 5) → **audio plays**, lossy UDP
+    flow shows continuous client ACKs (growing ACK-vector = steady Wave2 traffic acked), EGFX
+    (TCP) keeps rendering, session alive to a graceful disconnect, no teardown. **As far as is
+    known this is the first open-source RDP server streaming audio over a UDP multitransport
+    tunnel.**
+  - **Lag-model reconciliation (the P2.5 item below): no code change needed.** The tunnel
+    branch sits after the cross-batch lag model (vendor divergence (2)/(3)/(8)). The drop-stale
+    guard still rightly trims stale audio before it floods the tunnel (correct + free on a lossy
+    transport — no retransmit to cancel, exactly the property TCP audio lacks); the
+    resync-on-stall is moot but harmless (the tunnel send is non-blocking); and
+    `audio_shipped_ms += wave_ms` runs on both paths so the model stays coherent. Verified clean
+    audio in the live run. The remaining work is the loss soak (P2.2/P2.3 underneath) to prove
+    audio stays smooth where TCP audio desyncs — the user-noticeable win.
+
 - **P2.5 — route audio to the lossy tunnel + reconcile the lag model.** Point the audio
   path at the lossy tunnel and reconcile with the existing audio-lag / drop-stale model
   (vendor server divergence (2)/(3)/(8)) — on a lossy transport, dropping a stale wave is

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -669,3 +669,61 @@ AND released — #1276 landing is NOT sufficient.
     stall the tunnel; making the response idempotent (re-answer on retransmit in lossy
     mode) or adding a handshake-phase retransmit is the next soak fix. See feasibility
     doc "P2.2".
+
+    P2.4b 2b-iv-A — dual audio-DVC topology (2026-06-27, `audio_dvc.rs` + `server.rs`;
+    verified on real mstsc). The lossy-audio design uses BOTH audio DVCs at once: the
+    RELIABLE `AUDIO_PLAYBACK_DVC` runs the full MS-RDPEA format/quality/training
+    handshake over TCP/DRDYNVC (this is what mstsc tolerates — the P2.4b-1 finding:
+    Server Audio Formats on a `_LOSSY_`-named channel makes mstsc tear down the whole
+    TCP socket), and the LOSSY `AUDIO_PLAYBACK_LOSSY_DVC` is data-only (no formats) and
+    Soft-Synced onto the UDPFECL/DTLS tunnel (P2.4b-2). The lossy channel **inherits the
+    reliable channel's negotiated format index**: `AudioLossyDvc` carries a shared
+    `NegotiatedAudioFormat(Arc<AtomicU32>)` — the reliable instance publishes the chosen
+    `wFormatNo` via `shared.set(idx)` on TrainingConfirm ("P2.4b GREEN: reliable audio
+    DVC negotiated + training confirmed over TCP"); the server reads it back through
+    `lossy_audio_format.get()`. Two constructors: `AudioLossyDvc::reliable(formats,
+    negotiated)` (defer_formats=false, sends formats, runs the handshake) and
+    `::lossy()` (defer_formats=true, `start()` returns empty). Both registered in
+    `attach_channels` when `set_multitransport_lossy_audio_formats(Some(..))` is set
+    (macrdp gates that behind `MACRDP_UDP_LOSSY_AUDIO` + `--enable-aac`, so the default
+    build is byte-unchanged). The "video freezes on connect" seen once during this work
+    was transient mstsc state (Run A, byte-identical, rendered fine next attempt — the
+    documented "mstsc caches bad RDP state until reboot" behavior), NOT a topology bug.
+
+    P2.4b 2b-iv-B — AAC Wave2 streamed over the lossy tunnel; audio RENDERS over UDP
+    (2026-06-27, `audio_dvc.rs` + `server.rs`; **VERIFIED end-to-end on real mstsc**).
+    Once 2b-iv-A's preconditions all hold, the `dispatch_audio` task ships each wave as
+    a `Wave2Pdu` on `AUDIO_PLAYBACK_LOSSY_DVC` over the bound UDP/DTLS tunnel instead of
+    the static rdpsnd TCP write — exactly one playback path at a time (no double-play).
+    Pieces:
+    - `audio_dvc::lossy_wave_dvc_message(block_no, audio_timestamp, format_no, data)`
+      builds `ServerAudioOutputPdu::Wave2(Wave2Pdu { block_no, timestamp: 0,
+      audio_timestamp, format_no, data })` wrapped in the `OwnedAudioPdu`
+      (`Encode`+`DvcEncode`) the DVC path uses.
+    - `RdpServer::lossy_audio_target() -> Option<(format_no, lossy_channel_id)>` returns
+      `Some` only when ALL hold: lossy formats registered, `lossy_audio_format.get()`
+      Some (reliable handshake done), tunnel sender + migration cookie present,
+      `udp_tunnel_bound` true, and `DrdynvcServer::get_channel_id_by_name(
+      AUDIO_PLAYBACK_LOSSY_DVC)` Some. Until then audio stays on static rdpsnd → clean
+      handover, no double-play.
+    - `RdpServer::route_lossy_audio_wave(..)` (one-shot WARN marker "P2.4b 2b-iv-B:
+      streaming Wave2 audio over the LOSSY UDP/DTLS tunnel … static rdpsnd now silent")
+      → `encode_dvc_messages(lossy_id, [wave], empty)` → `route_dvc_over_udp` (bare
+      DRDYNVC PDU as `RDP_TUNNEL_DATA`, DTLS-encrypted, shipped reliably-or-lossy over
+      the SM). New per-connection fields `lossy_audio_block_no: u8` (wrapping) +
+      `lossy_audio_streaming: bool` (one-shot marker), init 0/false in `new()`.
+    The `dispatch_audio` branch sits AFTER the cross-batch lag model (resync +
+    drop-stale): the drop-stale guard still rightly protects the tunnel from flooding
+    with stale audio (correct for any live stream), the resync-on-stall is moot but
+    harmless (the tunnel send is non-blocking), and `audio_shipped_ms += wave_ms` runs
+    on both paths so the model stays coherent — so the lag model needs no tunnel-specific
+    change (verified: clean audio in the live run). **VERIFIED on real mstsc 2026-06-27:**
+    reliable `AUDIO_PLAYBACK_DVC` handshake GREEN → lossy `AUDIO_PLAYBACK_LOSSY_DVC`
+    Soft-Synced onto UDPFECL (`SoftSyncResponsePdu { tunnels: [3] }`) → the one-shot
+    marker fired (format_no=0, lossy_channel_id=5) → **audio plays**, the lossy UDP flow
+    shows continuous client ACKs with a growing ACK-vector, EGFX (TCP) keeps acking +
+    rendering, session alive to a graceful disconnect, no teardown. As far as is known
+    this is the first open-source RDP server streaming **audio** over a UDP
+    multitransport tunnel. All gated default-off (`MACRDP_UDP_OFFER_FECL` +
+    `MACRDP_UDP_LOSSY_AUDIO`, + `--enable-aac` + `--enable-h264` since the Soft-Sync
+    trigger rides the EGFX dispatch arm). See feasibility doc "P2.4b".

--- a/vendor/ironrdp-server/src/multitransport/audio_dvc.rs
+++ b/vendor/ironrdp-server/src/multitransport/audio_dvc.rs
@@ -4,10 +4,19 @@
 //!
 //! MS-RDPEA §2.1: the audio output channel is named `AUDIO_PLAYBACK_DVC` over a
 //! reliable transport and **`AUDIO_PLAYBACK_LOSSY_DVC` over an unreliable UDP
-//! transport**. The server opens it (DRDYNVC Create Request), runs the normal
-//! RDPSND format/training handshake over it (on the main TCP connection), and then
-//! — via MS-RDPEDYC Soft-Sync — migrates it onto the lossy (`UDPFECL`) tunnel, over
-//! which the Wave2 audio PDUs flow.
+//! transport**.
+//!
+//! **DUAL-CHANNEL TOPOLOGY (P2.4b-iv — corrects the earlier "handshake over the
+//! tunnel" plan).** mstsc tears the whole session down if it receives Server Audio
+//! Formats on the `_LOSSY_`-named channel — verified BOTH over TCP/DRDYNVC
+//! (P2.4b-1) AND over the migrated lossy/DTLS tunnel (P2.4b-iii). The transport is
+//! not the discriminator; the channel *name* is. So the server opens BOTH channels:
+//! the format/quality/training handshake runs on the reliable `AUDIO_PLAYBACK_DVC`
+//! over TCP, while `AUDIO_PLAYBACK_LOSSY_DVC` is Soft-Synced onto the lossy
+//! (`UDPFECL`) tunnel and carries **only `Wave2` audio data**, stamped with the
+//! format index the reliable channel negotiated (the lossy channel inherits that
+//! negotiation — it never negotiates its own). This matches how Windows' own RDP
+//! server drives lossy audio.
 //!
 //! **Gating (MS-RDPEA Appendix A note <2>):** a client uses the lossy DVC only when
 //! all of (a) a lossy UDP transport is available, (b) both ends are protocol
@@ -35,15 +44,16 @@
 //! of the audio DVC without tearing down.** This handler now opens the lossy DVC and
 //! returns NO formats from `start()` (defer over TCP — finding #1), then the server
 //! Soft-Syncs the channel onto the lossy (`TUNNELTYPE_UDPFECL=0x03`) tunnel. Live mstsc
-//! result: `lossy audio DVC opened — deferring Server Audio Formats` → Soft-Sync sent →
-//! `SoftSyncResponsePdu { tunnels: [3] }` (UDPFECL accepted) → session stayed alive to a
-//! graceful disconnect. So the #54 blocker was specifically **format data over TCP**, NOT
-//! the lossy Soft-Sync itself. The path forward (the opposite of EGFX, which migrates to
-//! the RELIABLE tunnel *after* a TCP handshake): Soft-Sync the lossy DVC FIRST, then run
-//! the MS-RDPEA handshake (formats → quality → training) over the lossy tunnel (2b-iii),
-//! then stream AAC waves over it (2b-iv). The reliable-DVC path that works over TCP isn't
-//! worth landing on its own (a reliable tunnel HOL-blocks under loss like TCP). See
-//! `docs/rdp-udp-multitransport-feasibility.md` ("P2.4b").
+//! result: `SoftSyncResponsePdu { tunnels: [3] }` (UDPFECL accepted), session stayed alive.
+//! So the lossy Soft-Sync itself is fine.
+//!
+//! **KEY FINDING #3 (P2.4b-iii) — formats over the lossy tunnel ALSO tear mstsc down.**
+//! Running the handshake over the tunnel (the earlier plan) was verified to fail with the
+//! identical 3–4 s teardown as over TCP, while an EGFX-over-DTLS isolation test rendered
+//! cleanly (so the tunnel data path is correct). Conclusion: the `_LOSSY_` channel must
+//! never carry formats at all — hence the dual-channel topology above (handshake on the
+//! reliable DVC, waves on the lossy one). See `docs/rdp-udp-multitransport-feasibility.md`
+//! ("P2.4b").
 //!
 //! **Sequence (MS-RDPEA Initialization Sequence, confirmed live):** for v6+ the client
 //! sends a Quality Mode PDU immediately after Client Audio Formats, and the server
@@ -55,11 +65,15 @@
 //! `ServerAudioOutputPdu` / `ClientAudioOutputPdu` codecs verbatim; only the channel
 //! envelope (DVC vs the static SVC) differs.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use ironrdp_core::{Encode, EncodeResult, WriteCursor, decode, impl_as_any};
 use ironrdp_dvc::{DvcEncode, DvcMessage, DvcProcessor, DvcServerProcessor};
 use ironrdp_pdu::{PduResult, decode_err};
 use ironrdp_rdpsnd::pdu::{
-    AudioFormat, ClientAudioOutputPdu, ServerAudioFormatPdu, ServerAudioOutputPdu, TrainingPdu, Version, WaveFormat,
+    AudioFormat, ClientAudioOutputPdu, ServerAudioFormatPdu, ServerAudioOutputPdu, TrainingPdu, Version, Wave2Pdu,
+    WaveFormat,
 };
 use tracing::{debug, warn};
 
@@ -67,6 +81,42 @@ use tracing::{debug, warn};
 pub const AUDIO_PLAYBACK_LOSSY_DVC: &str = "AUDIO_PLAYBACK_LOSSY_DVC";
 /// Channel name for the reliable audio output DVC (MS-RDPEA §2.1).
 pub const AUDIO_PLAYBACK_DVC: &str = "AUDIO_PLAYBACK_DVC";
+
+/// The client-list index of the audio format negotiated on the RELIABLE
+/// `AUDIO_PLAYBACK_DVC`, shared with the lossy wave path so it can stamp the
+/// `Wave2` PDUs it ships over the lossy/DTLS tunnel with the right `wFormatNo`
+/// (MS-RDPEA: the lossy channel inherits the reliable channel's format
+/// negotiation — it never negotiates its own). `u32::MAX` = not yet negotiated.
+#[derive(Clone)]
+pub struct NegotiatedAudioFormat(Arc<AtomicU32>);
+
+impl NegotiatedAudioFormat {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicU32::new(u32::MAX)))
+    }
+
+    /// Publish the negotiated client-list format index (called by the reliable
+    /// handler once the client confirms training).
+    pub fn set(&self, format_no: u16) {
+        self.0.store(u32::from(format_no), Ordering::Relaxed);
+    }
+
+    /// The negotiated client-list format index, or `None` until the reliable
+    /// handshake completes. Read by the lossy wave path (2b-iv-B, not yet wired).
+    #[allow(dead_code)]
+    pub fn get(&self) -> Option<u16> {
+        match self.0.load(Ordering::Relaxed) {
+            u32::MAX => None,
+            v => Some(v as u16),
+        }
+    }
+}
+
+impl Default for NegotiatedAudioFormat {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// An owned RDPSND server PDU (Format/Training — no borrowed wave data) wrapped as
 /// a `DvcMessage`. `ironrdp_rdpsnd`'s PDUs implement `SvcEncode` (for the static
@@ -95,34 +145,77 @@ fn dvc_msg(pdu: ServerAudioOutputPdu<'static>) -> DvcMessage {
     Box::new(OwnedAudioPdu(pdu))
 }
 
-/// MS-RDPEA server handler for the audio output dynamic channel.
+/// (2b-iv-B) Build one `Wave2` audio-data DVC message for the lossy
+/// `AUDIO_PLAYBACK_LOSSY_DVC` channel: the same `Wave2Pdu` the static rdpsnd path
+/// ships (`RdpsndServer::wave`), but wrapped as a `DvcMessage` so the server can
+/// `encode_dvc_messages` it onto channel 5 and route it over the lossy/DTLS tunnel.
+/// `format_no` is the client-list index the RELIABLE `AUDIO_PLAYBACK_DVC` handshake
+/// negotiated (read from [`NegotiatedAudioFormat::get`]); `block_no` is a per-wave
+/// sequence the caller advances. `data` is the codec payload (an AAC access unit for
+/// the AAC path). MS-RDPEA v8 → `Wave2`.
+pub fn lossy_wave_dvc_message(block_no: u8, audio_timestamp: u32, format_no: u16, data: Vec<u8>) -> DvcMessage {
+    let pdu = Wave2Pdu {
+        block_no,
+        timestamp: 0,
+        audio_timestamp,
+        format_no,
+        data: data.into(),
+    };
+    dvc_msg(ServerAudioOutputPdu::Wave2(pdu))
+}
+
+/// MS-RDPEA server handler for an audio output dynamic channel.
+///
+/// **Dual-channel topology (P2.4b):** mstsc tears the session down if it receives
+/// Server Audio Formats on the `_LOSSY_`-named channel — over TCP *or* over the
+/// migrated lossy tunnel (verified). So the format/quality/training handshake runs
+/// on the RELIABLE `AUDIO_PLAYBACK_DVC` (over TCP) while `AUDIO_PLAYBACK_LOSSY_DVC`
+/// carries only `Wave2` data, Soft-Synced onto the lossy/DTLS tunnel and stamped
+/// with the format index the reliable channel negotiated. One handler type, two
+/// roles, selected at construction.
 pub struct AudioLossyDvc {
-    /// Channel name. Defaults to `AUDIO_PLAYBACK_LOSSY_DVC`; the diagnostic env
-    /// `MACRDP_AUDIO_DVC_RELIABLE=1` switches it to the reliable
-    /// `AUDIO_PLAYBACK_DVC` to test whether mstsc rejects the format handshake
-    /// specifically on a *lossy*-named channel over TCP (vs. any audio DVC).
+    /// Channel name: `AUDIO_PLAYBACK_DVC` (reliable) or `AUDIO_PLAYBACK_LOSSY_DVC`.
     channel_name: &'static str,
-    /// The server audio format list to advertise (PCM + AAC). Passed in by the
-    /// application so it matches exactly what the wave path will encode.
+    /// When `true` (the lossy channel) `start()` sends NO formats — the channel is
+    /// data-only and never negotiates (doing so tears mstsc down).
+    defer_formats: bool,
+    /// The server audio format list to advertise (PCM + AAC). Only the reliable
+    /// channel sends these; passed in so it matches what the wave path encodes.
     formats: Vec<AudioFormat>,
     /// The client-list index of the format we'll send waves in, once negotiated.
     chosen_format_no: Option<u16>,
     /// Whether the client confirmed our Training PDU (handshake complete).
     training_confirmed: bool,
+    /// Shared cell the RELIABLE handler publishes the negotiated format index to,
+    /// for the lossy wave path to read (`None` on the lossy handler).
+    negotiated: Option<NegotiatedAudioFormat>,
 }
 
 impl AudioLossyDvc {
-    pub fn new(formats: Vec<AudioFormat>) -> Self {
-        let channel_name = if std::env::var_os("MACRDP_AUDIO_DVC_RELIABLE").is_some() {
-            AUDIO_PLAYBACK_DVC
-        } else {
-            AUDIO_PLAYBACK_LOSSY_DVC
-        };
+    /// The RELIABLE `AUDIO_PLAYBACK_DVC`: runs the full MS-RDPEA handshake over its
+    /// transport (TCP) and publishes the negotiated client-list format index to
+    /// `negotiated` for the lossy wave path.
+    pub fn reliable(formats: Vec<AudioFormat>, negotiated: NegotiatedAudioFormat) -> Self {
         Self {
-            channel_name,
+            channel_name: AUDIO_PLAYBACK_DVC,
+            defer_formats: false,
             formats,
             chosen_format_no: None,
             training_confirmed: false,
+            negotiated: Some(negotiated),
+        }
+    }
+
+    /// The LOSSY `AUDIO_PLAYBACK_LOSSY_DVC`: data-only (Wave2 over the lossy/DTLS
+    /// tunnel). Never sends formats — mstsc tears the socket down if it does.
+    pub fn lossy() -> Self {
+        Self {
+            channel_name: AUDIO_PLAYBACK_LOSSY_DVC,
+            defer_formats: true,
+            formats: Vec::new(),
+            chosen_format_no: None,
+            training_confirmed: false,
+            negotiated: None,
         }
     }
 }
@@ -135,15 +228,14 @@ impl DvcProcessor for AudioLossyDvc {
     }
 
     fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
-        // The lossy-named DVC must NOT receive format data over TCP/DRDYNVC — mstsc
-        // tears down the whole TCP socket if it does (the P2.4b-1 finding). Defer the
-        // MS-RDPEA handshake until the channel is Soft-Synced onto the lossy tunnel;
-        // the formats then ride the tunnel (2b-iii). The reliable diagnostic name
-        // (MACRDP_AUDIO_DVC_RELIABLE) keeps the proven over-TCP handshake.
-        if self.channel_name == AUDIO_PLAYBACK_LOSSY_DVC {
+        // The lossy-named DVC must NOT receive format data — mstsc tears down the
+        // whole TCP socket if it does, over TCP *or* over the migrated tunnel
+        // (verified). It's data-only; the handshake runs on the reliable
+        // AUDIO_PLAYBACK_DVC instead, and this channel inherits its format index.
+        if self.defer_formats {
             debug!(
                 channel = self.channel_name,
-                "lossy audio DVC opened — deferring Server Audio Formats until Soft-Sync onto the lossy tunnel"
+                "lossy audio DVC opened — data-only (no format handshake; it runs on the reliable AUDIO_PLAYBACK_DVC)"
             );
             return Ok(Vec::new());
         }
@@ -204,10 +296,17 @@ impl DvcProcessor for AudioLossyDvc {
             }
             ClientAudioOutputPdu::TrainingConfirm(_) => {
                 self.training_confirmed = true;
+                // Publish the negotiated client-list format index so the lossy wave
+                // path can stamp Wave2 PDUs with it (the lossy channel inherits this
+                // reliable channel's negotiation — it never negotiates its own).
+                if let (Some(shared), Some(idx)) = (self.negotiated.as_ref(), self.chosen_format_no) {
+                    shared.set(idx);
+                }
                 warn!(
                     channel = self.channel_name,
                     chosen_wformatno = ?self.chosen_format_no,
-                    "P2.4b GREEN: audio DVC negotiated + training confirmed over TCP — ready for Soft-Sync wave migration"
+                    "P2.4b GREEN: reliable audio DVC negotiated + training confirmed over TCP — \
+                     lossy wave path can now stream Wave2 over the tunnel with this format index"
                 );
                 Ok(Vec::new())
             }

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -271,26 +271,40 @@ async fn ship_outbound(
         trace!(%peer_addr, "tunnel data for an unknown peer; dropping");
         return;
     };
-    let Peer { sm, tls, .. } = peer;
-    let Some(tls) = tls.as_mut() else {
-        warn!(%peer_addr, "tunnel data to a peer with no TLS; dropping");
-        return;
-    };
-
     let pdu = emt::encode_tunnel_data(higher_layer);
-    if tls.writer().write_all(&pdu).is_err() {
-        warn!(%peer_addr, "failed to write RDP_TUNNEL_DATA into TLS");
-        return;
-    }
-    let mut tls_out = Vec::new();
-    while tls.wants_write() {
-        if tls.write_tls(&mut tls_out).is_err() {
-            break;
+    let Peer { sm, tls, dtls, .. } = peer;
+
+    // The flow is secured by exactly one of rustls (reliable UdpFecR) or DTLS
+    // (lossy UdpFecL). Encrypt the RDP_TUNNEL_DATA through whichever this peer
+    // holds, then ship the ciphertext reliably over the RDPEUDP SM.
+    if let Some(tls) = tls.as_mut() {
+        if tls.writer().write_all(&pdu).is_err() {
+            warn!(%peer_addr, "failed to write RDP_TUNNEL_DATA into TLS");
+            return;
         }
-    }
-    if !tls_out.is_empty() {
-        let o = sm.enqueue(now_ms, &tls_out);
-        send_datagrams(socket, peer_addr, o.to_send, mtu).await;
+        let mut tls_out = Vec::new();
+        while tls.wants_write() {
+            if tls.write_tls(&mut tls_out).is_err() {
+                break;
+            }
+        }
+        if !tls_out.is_empty() {
+            let o = sm.enqueue(now_ms, &tls_out);
+            send_datagrams(socket, peer_addr, o.to_send, mtu).await;
+        }
+    } else if let Some(dtls) = dtls.as_mut().filter(|c| c.is_handshake_done()) {
+        // P2.4b: lossy (UdpFecL) audio rides the DTLS-secured tunnel.
+        match dtls.send(&pdu) {
+            Ok(dgs) => {
+                for dg in dgs {
+                    let o = sm.enqueue(now_ms, &dg);
+                    send_datagrams(socket, peer_addr, o.to_send, mtu).await;
+                }
+            }
+            Err(e) => warn!(%peer_addr, error = %e, "failed to encrypt RDP_TUNNEL_DATA through DTLS"),
+        }
+    } else {
+        warn!(%peer_addr, "tunnel data to a peer with no TLS/DTLS (or DTLS not ready); dropping");
     }
 }
 

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -297,6 +297,21 @@ fn migrate_egfx_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("MACRDP_UDP_MIGRATE_EGFX").is_some())
 }
 
+/// (P2.4b diagnostic) EXPERIMENTAL: migrate EGFX onto the LOSSY (UdpFecL/DTLS)
+/// tunnel instead of the reliable (UdpFecR/rustls) one. This is an *isolation
+/// test* for the DTLS `RDP_TUNNEL_DATA` egress path (`ship_outbound`'s DTLS
+/// branch): EGFX-over-tunnel is already proven on the reliable tunnel, so if it
+/// also renders over DTLS the framing is correct and any lossy-audio failure is
+/// purely the MS-RDPEA channel model — not our tunnel data path. Requires
+/// `MACRDP_UDP_MIGRATE_EGFX` + `MACRDP_UDP_OFFER_FECL` (so a lossy tunnel exists).
+/// Read once and cached.
+#[cfg(feature = "multitransport")]
+fn migrate_egfx_lossy() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("MACRDP_UDP_MIGRATE_EGFX_LOSSY").is_some())
+}
+
 pub struct RdpServer {
     opts: RdpServerOptions,
     // FIXME: replace with a channel and poll/process the handler?
@@ -398,6 +413,20 @@ pub struct RdpServer {
     /// the channel unregistered. Set via `set_multitransport_lossy_audio_formats`.
     #[cfg(feature = "multitransport")]
     multitransport_lossy_audio_formats: Option<Vec<ironrdp_rdpsnd::pdu::AudioFormat>>,
+    /// (P2.4b dual-channel) The client-list format index negotiated on the RELIABLE
+    /// `AUDIO_PLAYBACK_DVC` over TCP, shared with the lossy wave path so the `Wave2`
+    /// PDUs it ships over the lossy/DTLS tunnel carry the right `wFormatNo`.
+    #[cfg(feature = "multitransport")]
+    lossy_audio_format: crate::multitransport::audio_dvc::NegotiatedAudioFormat,
+    /// (2b-iv-B) Per-wave `block_no` sequence for the lossy `AUDIO_PLAYBACK_LOSSY_DVC`
+    /// `Wave2` PDUs (independent of the static rdpsnd channel's own counter). Bumped
+    /// per wave shipped over the tunnel; wraps at 255.
+    #[cfg(feature = "multitransport")]
+    lossy_audio_block_no: u8,
+    /// (2b-iv-B) One-shot marker so the "now streaming audio over the lossy tunnel"
+    /// log fires exactly once at the static-rdpsnd → lossy-DVC handover (not per wave).
+    #[cfg(feature = "multitransport")]
+    lossy_audio_streaming: bool,
 }
 
 #[derive(Debug)]
@@ -512,6 +541,12 @@ impl RdpServer {
             multitransport_tunnel_inbound_rx: None,
             #[cfg(feature = "multitransport")]
             multitransport_lossy_audio_formats: None,
+            #[cfg(feature = "multitransport")]
+            lossy_audio_format: crate::multitransport::audio_dvc::NegotiatedAudioFormat::new(),
+            #[cfg(feature = "multitransport")]
+            lossy_audio_block_no: 0,
+            #[cfg(feature = "multitransport")]
+            lossy_audio_streaming: false,
         }
     }
 
@@ -698,17 +733,22 @@ impl RdpServer {
             dvc
         };
 
-        // (vendored, feature=multitransport, P2.4b) The lossy-UDP audio output DVC
-        // (`AUDIO_PLAYBACK_LOSSY_DVC`). Registered only when the application
-        // supplied a format list (macrdp does so when `--enable-aac` + the lossy
-        // UDP offer are both on). The format handshake runs over the main TCP
-        // connection first; Soft-Sync migration of the wave data onto the DTLS
-        // tunnel is a later sub-step.
+        // (vendored, feature=multitransport, P2.4b) Dual audio output DVC for lossy
+        // UDP audio. Registered only when the application supplied a format list
+        // (macrdp does so when `--enable-aac` + the lossy UDP offer are both on).
+        // mstsc tears down if it receives Server Audio Formats on the `_LOSSY_`
+        // channel (over TCP *or* the tunnel — verified), so we open BOTH: the
+        // reliable `AUDIO_PLAYBACK_DVC` runs the format/quality/training handshake
+        // over TCP and publishes the negotiated format index; the lossy
+        // `AUDIO_PLAYBACK_LOSSY_DVC` is Soft-Synced onto the lossy/DTLS tunnel and
+        // carries only Wave2 data stamped with that index.
         #[cfg(feature = "multitransport")]
         let dvc = {
+            use crate::multitransport::audio_dvc::AudioLossyDvc;
             let mut dvc = dvc;
             if let Some(formats) = self.multitransport_lossy_audio_formats.clone() {
-                dvc = dvc.with_dynamic_channel(crate::multitransport::audio_dvc::AudioLossyDvc::new(formats));
+                dvc = dvc.with_dynamic_channel(AudioLossyDvc::reliable(formats, self.lossy_audio_format.clone()));
+                dvc = dvc.with_dynamic_channel(AudioLossyDvc::lossy());
             }
             dvc
         };
@@ -1224,7 +1264,7 @@ impl RdpServer {
                         // channel. Default path is unchanged TCP.
                         #[cfg(feature = "multitransport")]
                         if self.egfx_on_udp {
-                            self.route_egfx_over_udp(messages)?;
+                            self.route_dvc_over_udp(messages)?;
                             continue;
                         }
                         let drdynvc_channel_id = self
@@ -1417,12 +1457,33 @@ impl RdpServer {
                 }
 
                 // Briefly lock Self to build the Wave PDU and look up the
-                // rdpsnd channel id. RdpsndServer::wave() bumps a private
-                // block_no and produces SVC messages — microseconds of
-                // work. Lock released before the (potentially long)
-                // socket write.
+                // channel id. RdpsndServer::wave() bumps a private block_no and
+                // produces SVC messages — microseconds of work. Lock released
+                // before the (potentially long) socket write.
+                let mut this = this.lock().await;
+
+                // (2b-iv-B) Once the lossy-audio-over-UDP path is live (reliable
+                // handshake negotiated + tunnel bound + lossy DVC open), ship the
+                // wave as a Wave2 PDU on AUDIO_PLAYBACK_LOSSY_DVC over the lossy/DTLS
+                // tunnel and SKIP the static rdpsnd write — exactly one playback path
+                // at a time (no double-play). The tunnel send is best-effort and
+                // non-blocking, so no socket-write await here.
+                #[cfg(feature = "multitransport")]
+                if let Some((format_no, lossy_id)) = this.lossy_audio_target() {
+                    let block_no = this.lossy_audio_block_no;
+                    this.lossy_audio_block_no = this.lossy_audio_block_no.wrapping_add(1);
+                    let res = this.route_lossy_audio_wave(block_no, ts, format_no, lossy_id, data);
+                    drop(this);
+                    if let Err(e) = res {
+                        warn!(error = %e, "lossy audio wave route over UDP tunnel failed");
+                    }
+                    audio_shipped_ms += wave_ms;
+                    continue;
+                }
+
+                // Static rdpsnd over TCP (default; also the pre-negotiation path
+                // before the lossy DVC is live).
                 let encoded = {
-                    let mut this = this.lock().await;
                     let Some(rdpsnd) = this.get_svc_processor::<RdpsndServer>() else {
                         warn!("No rdpsnd channel, dropping wave");
                         continue;
@@ -1440,6 +1501,7 @@ impl RdpServer {
                     };
                     server_encode_svc_messages(msgs.into(), channel_id, user_channel_id)?
                 };
+                drop(this);
 
                 audio_writer.write_all(&encoded).await?;
                 audio_shipped_ms += wave_ms;
@@ -1617,13 +1679,14 @@ impl RdpServer {
             return Ok(());
         }
 
-        // P2.4b (2b-ii): if a lossy audio DVC is registered, migrate IT onto the
-        // LOSSY tunnel (`TUNNELTYPE_UDPFECL`) — the inverse of EGFX, which (when
-        // enabled) migrates onto the RELIABLE tunnel. The lossy audio handshake
-        // can't run over TCP at all (the P2.4b-1 finding: mstsc tears the socket
-        // down), so the Soft-Sync MUST precede any audio data. Look the channel up
-        // BEFORE consuming the one-time guard, so if its DVC Create Response hasn't
-        // arrived yet we just retry on the next EGFX frame (guard intact).
+        // P2.4b (dual-channel): if the lossy audio DVCs are registered, Soft-Sync the
+        // LOSSY `AUDIO_PLAYBACK_LOSSY_DVC` onto the LOSSY tunnel (`TUNNELTYPE_UDPFECL`)
+        // — the inverse of EGFX, which migrates onto the RELIABLE tunnel. The lossy
+        // channel carries Wave2 data only; the format/quality/training handshake runs
+        // on the reliable `AUDIO_PLAYBACK_DVC` over TCP (mstsc tears the socket down if
+        // formats arrive on the lossy name — over TCP *or* the tunnel, both verified).
+        // Look the channel up BEFORE consuming the one-time guard, so if its DVC Create
+        // Response hasn't arrived yet we just retry on the next EGFX frame (guard intact).
         if self.multitransport_lossy_audio_formats.is_some() {
             let Some(audio_id) = self
                 .get_svc_processor::<dvc::DrdynvcServer>()
@@ -1637,7 +1700,8 @@ impl RdpServer {
             }
             debug!(
                 audio_channel_id = audio_id,
-                "UDP lossy tunnel bound + audio DVC open — Soft-Sync migrating audio onto the LOSSY (UdpFecL) tunnel"
+                "UDP lossy tunnel bound — Soft-Sync migrating AUDIO_PLAYBACK_LOSSY_DVC onto the LOSSY (UdpFecL) \
+                 tunnel (waves only; the format handshake runs on the reliable AUDIO_PLAYBACK_DVC over TCP)"
             );
             return self
                 .send_soft_sync_request(writer, user_channel_id, dvc::pdu::TUNNELTYPE_UDPFECL, vec![audio_id])
@@ -1675,8 +1739,16 @@ impl RdpServer {
         } else {
             Vec::new()
         };
+        // EGFX normally migrates onto the RELIABLE tunnel. The P2.4b isolation test
+        // (`MACRDP_UDP_MIGRATE_EGFX_LOSSY`) instead targets the LOSSY/DTLS tunnel to
+        // exercise the DTLS `RDP_TUNNEL_DATA` egress path with a proven payload.
+        let egfx_tunnel_type = if migrate_egfx_lossy() {
+            dvc::pdu::TUNNELTYPE_UDPFECL
+        } else {
+            dvc::pdu::TUNNELTYPE_UDPFECR
+        };
         debug!("UDP tunnel bound + EGFX active — Soft-Sync gate open");
-        self.send_soft_sync_request(writer, user_channel_id, dvc::pdu::TUNNELTYPE_UDPFECR, channel_ids)
+        self.send_soft_sync_request(writer, user_channel_id, egfx_tunnel_type, channel_ids)
             .await
     }
 
@@ -1728,37 +1800,99 @@ impl RdpServer {
         Ok(())
     }
 
-    /// (M5c) Route one EGFX frame's DVC messages over the bound UDP tunnel instead
-    /// of TCP: chunk them to SVC channel-data (`CHANNEL_PDU_HEADER` + DRDYNVC PDU,
-    /// the HigherLayerData the tunnel carries) and hand each chunk to the listener
-    /// (keyed by this connection's cookie). Best-effort — if the handoff or cookie
-    /// is missing the frame is dropped (the experimental UDP path; only reached
-    /// when `egfx_on_udp` was set under `MACRDP_UDP_MIGRATE_EGFX`).
+    /// (M5c) Route already-encoded DVC messages (EGFX frames, or the lossy audio
+    /// DVC's handshake/wave PDUs) over the bound UDP tunnel instead of TCP: hand each
+    /// to the listener (keyed by this connection's cookie), which wraps it in
+    /// `RDP_TUNNEL_DATA` and encrypts via the peer's transport (rustls for the
+    /// reliable tunnel, DTLS for the lossy one). Best-effort — if the handoff or
+    /// cookie is missing the data is dropped (the experimental UDP path; only reached
+    /// for a migrated channel: EGFX under `MACRDP_UDP_MIGRATE_EGFX`, or lossy audio
+    /// under `MACRDP_UDP_LOSSY_AUDIO`).
     #[cfg(feature = "multitransport")]
-    fn route_egfx_over_udp(&self, messages: Vec<ironrdp_svc::SvcMessage>) -> Result<()> {
+    fn route_dvc_over_udp(&self, messages: Vec<ironrdp_svc::SvcMessage>) -> Result<()> {
         let Some(sender) = self.multitransport_tunnel_sender.as_ref() else {
-            warn!("egfx_on_udp set but no tunnel sender; dropping EGFX frame");
+            warn!("migrated channel data but no tunnel sender; dropping");
             return Ok(());
         };
         let Some(cookie) = self.multitransport_migration.as_ref().map(|m| m.cookie) else {
-            warn!("egfx_on_udp set but no migration cookie; dropping EGFX frame");
+            warn!("migrated channel data but no migration cookie; dropping");
             return Ok(());
         };
         // The MS-RDPEMT tunnel carries the BARE DRDYNVC PDU (no static-channel
         // CHANNEL_PDU_HEADER) — RDP_TUNNEL_DATA provides the framing, so encode
         // each message unframed (NOT `chunkify`, which prepends CHANNEL_PDU_HEADER
-        // and would make the client misparse the EGFX stream). `encode_dvc_messages`
+        // and would make the client misparse the stream). `encode_dvc_messages`
         // already DVC-chunked these to fit, so one tunnel PDU per message is fine.
         let mut n = 0usize;
         for msg in messages {
             let pdu = msg
                 .encode_unframed_pdu()
-                .map_err(|e| anyhow::anyhow!("encode EGFX PDU for tunnel: {e}"))?;
+                .map_err(|e| anyhow::anyhow!("encode DVC PDU for tunnel: {e}"))?;
             sender.send(cookie, pdu);
             n += 1;
         }
-        trace!(pdus = n, "routed EGFX PDUs over the UDP tunnel");
+        trace!(pdus = n, "routed DVC PDUs over the UDP tunnel");
         Ok(())
+    }
+
+    /// (2b-iv-B) Is the lossy-audio-over-UDP path live right now? Returns
+    /// `(format_no, lossy_channel_id)` only when every precondition holds, so a
+    /// `Some` result guarantees [`route_lossy_audio_wave`](Self::route_lossy_audio_wave)
+    /// can ship: the lossy audio DVCs are registered, the RELIABLE
+    /// `AUDIO_PLAYBACK_DVC` handshake has published a negotiated format index, a UDP
+    /// tunnel sender + migration cookie exist, the tunnel is bound, and the lossy
+    /// `AUDIO_PLAYBACK_LOSSY_DVC` channel is open. Until all of that is true (e.g. at
+    /// connect, before the handshake completes / the tunnel binds) audio stays on the
+    /// static rdpsnd TCP channel, so there is exactly one playback path at any time
+    /// (no double-play) with a clean handover once UDP is ready.
+    #[cfg(feature = "multitransport")]
+    fn lossy_audio_target(&mut self) -> Option<(u16, u32)> {
+        use core::sync::atomic::Ordering;
+        self.multitransport_lossy_audio_formats.as_ref()?;
+        let format_no = self.lossy_audio_format.get()?;
+        self.multitransport_tunnel_sender.as_ref()?;
+        self.multitransport_migration.as_ref()?;
+        if !self
+            .udp_tunnel_bound
+            .as_ref()
+            .is_some_and(|f| f.load(Ordering::Relaxed))
+        {
+            return None;
+        }
+        let lossy_id = self
+            .get_svc_processor::<dvc::DrdynvcServer>()?
+            .get_channel_id_by_name(crate::multitransport::audio_dvc::AUDIO_PLAYBACK_LOSSY_DVC)?;
+        Some((format_no, lossy_id))
+    }
+
+    /// (2b-iv-B) Ship one audio wave as a `Wave2` PDU on the lossy
+    /// `AUDIO_PLAYBACK_LOSSY_DVC` (channel 5) over the bound UDP/DTLS tunnel instead
+    /// of the static rdpsnd TCP channel. Stamps the wave with `format_no` (the index
+    /// the reliable `AUDIO_PLAYBACK_DVC` negotiated) and `block_no`, DVC-frames it for
+    /// `lossy_channel_id`, then hands it to [`route_dvc_over_udp`](Self::route_dvc_over_udp)
+    /// (which sends the bare DRDYNVC PDU as `RDP_TUNNEL_DATA`, DTLS-encrypted).
+    #[cfg(feature = "multitransport")]
+    fn route_lossy_audio_wave(
+        &mut self,
+        block_no: u8,
+        audio_timestamp: u32,
+        format_no: u16,
+        lossy_channel_id: u32,
+        data: Vec<u8>,
+    ) -> Result<()> {
+        if !self.lossy_audio_streaming {
+            self.lossy_audio_streaming = true;
+            warn!(
+                format_no,
+                lossy_channel_id,
+                "P2.4b 2b-iv-B: streaming Wave2 audio over the LOSSY UDP/DTLS tunnel \
+                 (AUDIO_PLAYBACK_LOSSY_DVC) — static rdpsnd now silent"
+            );
+        }
+        let wave = crate::multitransport::audio_dvc::lossy_wave_dvc_message(block_no, audio_timestamp, format_no, data);
+        let msgs = dvc::encode_dvc_messages(lossy_channel_id, vec![wave], ChannelFlags::empty())
+            .map_err(|e| anyhow::anyhow!("encode lossy audio DVC wave: {e}"))?;
+        self.route_dvc_over_udp(msgs)
     }
 
     /// (M5c step 3b) Process one inbound migrated-channel PDU the UDP listener
@@ -1783,7 +1917,7 @@ impl RdpServer {
             }
         };
         if !replies.is_empty() {
-            if let Err(e) = self.route_egfx_over_udp(replies) {
+            if let Err(e) = self.route_dvc_over_udp(replies) {
                 warn!(error = %e, "failed to ship tunnel reply PDUs");
             }
         }


### PR DESCRIPTION
## Summary

Lossy **audio now renders over the UDP multitransport tunnel** on real mstsc — believed to be the **first open-source RDP server streaming audio over a UDP multitransport tunnel**. Behind the experimental env gates `MACRDP_UDP_OFFER_FECL` + `MACRDP_UDP_LOSSY_AUDIO` (+ `--enable-aac`, `--enable-h264`); **default build is byte-unchanged**.

Closes the data path the P2.4b-2 linchpin de-risk (#60) pointed to.

## What's in it

**2b-iv-A — dual audio-DVC topology.** Rather than run the MS-RDPEA handshake over the tunnel (which would need tunnel-side handshake plumbing), use **both** audio DVCs at once:
- The **reliable** `AUDIO_PLAYBACK_DVC` runs the full format/quality/training handshake over TCP — the only thing mstsc tolerates (the P2.4b-1 finding: Server Audio Formats on a `_LOSSY_`-named channel makes mstsc tear down the whole socket).
- The **lossy** `AUDIO_PLAYBACK_LOSSY_DVC` is data-only and Soft-Synced onto the UDPFECL/DTLS tunnel.
- The lossy channel **inherits the reliable channel's negotiated `wFormatNo`** via a shared `NegotiatedAudioFormat(Arc<AtomicU32>)` (reliable publishes on TrainingConfirm; the server reads it back). `AudioLossyDvc` gains `reliable()` / `lossy()` constructors.

**2b-iv-B — AAC Wave2 over the tunnel.** `dispatch_audio` ships each wave as a `Wave2Pdu` on `AUDIO_PLAYBACK_LOSSY_DVC` (bare DRDYNVC PDU → `RDP_TUNNEL_DATA`, DTLS-encrypted via the new `ship_outbound` DTLS branch) once all preconditions hold, and **skips the static rdpsnd TCP write** — exactly one playback path, clean handover, no double-play. New `RdpServer::{lossy_audio_target, route_lossy_audio_wave}` + `audio_dvc::lossy_wave_dvc_message`; new per-connection `lossy_audio_block_no` / `lossy_audio_streaming`.

**Lag model — no change needed.** The tunnel branch sits after the cross-batch audio-lag model (vendor divergence (2)/(3)/(8)): the drop-stale guard still rightly trims stale audio before it floods the tunnel (correct + free on a lossy transport), the resync-on-stall is moot but harmless (the tunnel send is non-blocking), and `audio_shipped_ms` accounting runs on both paths.

## Verification (real mstsc, Win11/WiFi)

Reliable `AUDIO_PLAYBACK_DVC` handshake GREEN → lossy `AUDIO_PLAYBACK_LOSSY_DVC` Soft-Synced onto UDPFECL (`SoftSyncResponsePdu { tunnels: [3] }`) → one-shot marker `streaming Wave2 audio over the LOSSY UDP/DTLS tunnel … static rdpsnd now silent` (format_no=0, channel 5) → **audio plays** with continuous client ACKs (growing ACK-vector = steady Wave2 traffic acked), EGFX (TCP) keeps rendering, session alive to a graceful disconnect, no teardown.

## Notes

- Default-off: with the env gates unset the build is byte-identical to `main` (the multitransport feature is always compiled for macrdp, but the runtime paths are gated).
- Docs: `vendor/ironrdp-server/CLAUDE.md` divergence (12) + `docs/rdp-udp-multitransport-feasibility.md` P2.4b 2b-iv.
- Next: P2.2/P2.3 loss soak (lossy audio's actual payoff = stays smooth where TCP audio desyncs); under-loss handshake idempotency (the P2.2 caveat).