### PR TITLE
chore(multitransport): lossy-audio soak harness + runbook (P2.4b 2b-iv)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -309,11 +309,67 @@ finding #3 documents (same structural limit, on TCP). The lossy tunnel establish
 but carries no payload yet.
 
 **Takeaway:** the P2.2 lossy *transport* is validated under loss (handshake robust), but
-the soak structurally **cannot demonstrate a lossy *win* until a real payload rides the
-tunnel** — and the intended payload, **lossy audio (P2.4b), is paused** on the
-Soft-Sync-first / lossy-DVC-name finding. So lossy delivery is "built + robust" but its
-payoff is gated on P2.4b, not on more transport work. (Video-over-lossy is out of scope —
-H.264-under-loss needs intra-refresh, P2.6.)
+this transport soak structurally **cannot demonstrate a lossy *win* until a real payload
+rides the tunnel**. That payload — **lossy audio (P2.4b 2b-iv)** — is now built and
+verified on a clean link (audio renders over the lossy DTLS tunnel; see "P2.4b 2b-iv
+result" below), so the *win* can finally be soaked: see the **lossy-audio soak (runbook)**
+next. (Video-over-lossy stays out of scope — H.264-under-loss needs intra-refresh, P2.6.)
+
+### Lossy-audio soak (runbook)
+
+This is the soak that can show the lossy **win** the P2.2 transport soak couldn't (it had
+no payload on the tunnel). It rides AAC audio on the lossy `UdpFecL`/DTLS tunnel and
+contrasts it against the same audio on TCP under identical shaping. Harness:
+`scripts/soak-lossy-audio.sh` (the audio sibling of `soak-lossy.sh`; it sets
+`MACRDP_UDP_OFFER_FECL=1` + `MACRDP_UDP_LOSSY_DELIVERY=1` + `MACRDP_UDP_LOSSY_AUDIO=1`,
+requires `--enable-aac`, and live-prints the audio-DVC + tunnel markers).
+
+**The A/B (this is the whole point — listen, don't just read logs):** play steady audio on
+the Mac (music / a YouTube tab) and listen on the client while shaping the link.
+- **CONTROL** — `MACRDP_UDP_LOSSY_AUDIO=0 scripts/soak-lossy-audio.sh …` → audio on the
+  static RDPSND **TCP** channel. Expect audible gaps / desync that worsen as `--loss`
+  climbs (the one TCP stream HOL-blocks audio behind every other channel).
+- **TREATMENT** — default (`=1`) → audio on the lossy UDP/DTLS tunnel. Expect it to stay
+  smooth where the control degraded: a lost wave is simply dropped (correct + free on a
+  live stream), no HOL stall, no growing backlog.
+
+```
+# 1) shape both directions of TCP+UDP on the port:
+sudo scripts/netshape.sh on --loss 5 --delay 100
+
+# 2a) TREATMENT — audio over the lossy tunnel (default):
+scripts/soak-lossy-audio.sh --enable-udp-multitransport --enable-aac --enable-h264 \
+    --username "$USER" --password 'PASS' --bind 0.0.0.0:3390
+
+# 2b) CONTROL — same everything, audio on TCP:
+MACRDP_UDP_LOSSY_AUDIO=0 scripts/soak-lossy-audio.sh --enable-udp-multitransport \
+    --enable-aac --enable-h264 --username "$USER" --password 'PASS' --bind 0.0.0.0:3390
+
+# …connect mstsc, play audio, listen, then restore:
+sudo scripts/netshape.sh off
+```
+
+**Read the markers** (the script highlights them; full log in the file). In treatment they
+fire roughly in this order, and all of them appearing = audio is on the tunnel:
+- `offering AUDIO_PLAYBACK_LOSSY_DVC` (gate on) → `reliable audio DVC negotiated` (AAC
+  handshake done over TCP) → `lossy audio DVC opened` → `DYNVC_SOFT_SYNC_REQUEST` +
+  `Soft-Sync Response` (mstsc accepts UDPFECL) → `P2.1 GREEN` / `P2.4 GREEN` (DTLS + tunnel
+  up under loss) → **`streaming Wave2 audio over the LOSSY UDP/DTLS tunnel`** (the payoff;
+  fires once, static rdpsnd then silent).
+- Failure tells: `lossy audio wave route over UDP tunnel failed`, `cookie not recognized`,
+  `Broken pipe` / `Connection reset`. `RTO retransmit` should be ~0 for the genuine lossy
+  flow (any value = the reliable SM is still carrying it; check `MACRDP_UDP_LOSSY_DELIVERY`).
+
+**Sweep** loss `0 → 2 → 5 → 10 %` × latency `+60 / +150 ms`, in both modes. Record the cell
+where the control becomes unacceptable and confirm the treatment is still smooth there —
+that gap is the user-noticeable result that justifies the phase. Also watch (per the P2.2
+caveat) whether, at higher loss, the lossy handshake stalls before `P2.4 GREEN` (one-shot
+`CREATERESPONSE`/DTLS flight lost); if it does, the idempotent-`CREATERESPONSE` /
+DTLS-timeout-driven-retransmit fix becomes warranted (still handshake-only — data stays
+send-once). A useful tie-breaker if the lossy handshake is the limiter: run the treatment
+with `MACRDP_UDP_LOSSY_DELIVERY=0` (audio still on the tunnel, but the flow rides the
+**reliable** SM that retransmits) — if audio is smooth there but the genuine lossy mode
+stalls to establish, the gap is purely handshake retransmission, not the steady-state path.
 
 ## Audio belongs on the lossy transport, not the reliable one
 

--- a/scripts/soak-lossy-audio.sh
+++ b/scripts/soak-lossy-audio.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+# soak-lossy-audio.sh — run macrdp configured for the P2.4b *lossy-audio* UDP soak
+# and surface the audio-DVC / tunnel markers that tell you whether AAC audio rides
+# the lossy (`UdpFecL`) DTLS tunnel cleanly over an emulated lossy link.
+#
+# This is the test that justifies the whole lossy phase: on a pure-TCP session
+# every channel (video, input, audio, clipboard) multiplexes onto ONE TCP stream,
+# so a single dropped segment head-of-line-blocks audio until it's retransmitted —
+# you hear gaps / desync that grow with loss. With audio migrated onto the lossy
+# UDP tunnel (this script), a lost wave is just *gone* (drop-stale is correct AND
+# free on a live stream — no retransmit to wait on), so playback stays smooth.
+#
+# Pairs with scripts/netshape.sh (the traffic shaper). It is the audio sibling of
+# scripts/soak-lossy.sh (which soaks the *transport* establishment); this one adds
+# the lossy-audio gate (MACRDP_UDP_LOSSY_AUDIO=1), requires AAC, and watches the
+# audio-DVC lifecycle markers + the A/B knob below.
+#
+# Two terminals:
+#
+#   # terminal 1 — shape the link (both directions, TCP+UDP on the port):
+#   sudo scripts/netshape.sh on --loss 5 --delay 100
+#
+#   # terminal 2 — run the server under the lossy-AUDIO soak config:
+#   scripts/soak-lossy-audio.sh --enable-udp-multitransport --enable-aac \
+#       --enable-h264 --username "$USER" --password 'PASS' --bind 0.0.0.0:3390
+#
+#   # …connect mstsc from another machine, play steady audio (music/YouTube) on the
+#   #   Mac, listen on the client, then:
+#   sudo scripts/netshape.sh off
+#
+# --enable-aac AND --enable-h264 are REQUIRED: the lossy audio DVC negotiates AAC
+# (MS-RDPEA needs v8 + AAC), and the Soft-Sync trigger rides the EGFX dispatch arm,
+# so H.264 must be on for the migration to fire. Without --enable-aac the lossy
+# audio DVC is never offered and audio simply stays on TCP (the control case).
+#
+# THE A/B (what makes this a soak, not just a smoke test):
+#   * TREATMENT (default): MACRDP_UDP_LOSSY_AUDIO=1 → audio rides the lossy tunnel.
+#       Expect: smooth audio under loss; the "streaming Wave2 audio over the LOSSY
+#       UDP/DTLS tunnel" marker fires once; static rdpsnd goes silent.
+#   * CONTROL: run with MACRDP_UDP_LOSSY_AUDIO=0 in front of this script → audio
+#       stays on the static RDPSND TCP channel. Expect: audible gaps / desync that
+#       worsen as --loss climbs. Same shaping, same content — only the transport
+#       differs. That contrast IS the result.
+#
+# Override knobs (env):
+#   MACRDP   — path to the binary (default: target/release/macrdp)
+#   RUST_LOG — logging filter (default: the soak filter below)
+#   SOAK_LOG — full-log output path (default: ./soak-lossy-audio-<timestamp>.log)
+#   MACRDP_UDP_LOSSY_AUDIO    — 1 = treatment (default), 0 = control (audio on TCP)
+#   MACRDP_UDP_LOSSY_DELIVERY — 1 = genuine send-once/no-retransmit lossy SM
+#                               (default); 0 = lossy flow rides the reliable SM
+#                               (retransmits — robust handshake, but the audio
+#                               waves then HOL-block like TCP, so the win shrinks).
+#                               NOTE the P2.2 caveat: in genuine lossy mode a
+#                               dropped one-shot CREATERESPONSE/DTLS flight is not
+#                               resent, so under heavy loss the tunnel may fail to
+#                               establish at all — watch for "P2.4 GREEN" / the
+#                               CREATERESPONSE marker to confirm it came up.
+
+set -eu
+
+MACRDP="${MACRDP:-target/release/macrdp}"
+
+if [ ! -x "$MACRDP" ]; then
+    echo "error: macrdp binary not found / not executable at: $MACRDP" >&2
+    echo "  build it first: cargo build --release" >&2
+    echo "  (or set MACRDP=/path/to/macrdp)" >&2
+    exit 1
+fi
+
+# Friendly nudge: the lossy audio DVC is only offered when --enable-aac is passed.
+case " $* " in
+    *" --enable-aac "*) ;;
+    *)
+        echo "warning: --enable-aac not in args — the lossy audio DVC will NOT be offered" >&2
+        echo "         (audio will ride TCP; that's the CONTROL case, not the treatment)." >&2
+        ;;
+esac
+
+# The lossy path is experimental + env-gated; the soak turns the gates on.
+export MACRDP_UDP_OFFER_FECL=1
+export MACRDP_UDP_LOSSY_DELIVERY="${MACRDP_UDP_LOSSY_DELIVERY:-1}"
+export MACRDP_UDP_LOSSY_AUDIO="${MACRDP_UDP_LOSSY_AUDIO:-1}"
+
+# Enough to see the audio-DVC lifecycle + the tunnel/DTLS milestones + the
+# reliability counters, without per-keystroke input spam. The audio-DVC "opened"
+# line + the Soft-Sync send + the client's Soft-Sync Response are debug-level, so
+# raise those targets; the GREEN/streaming markers are warn-level and always show.
+export RUST_LOG="${RUST_LOG:-info,ironrdp_server::multitransport=debug,ironrdp_server::server=debug,ironrdp_dvc=debug,ironrdp_acceptor=info,macrdp::h264=info,macrdp::audio=info}"
+
+ts="$(date +%Y%m%d-%H%M%S)"
+SOAK_LOG="${SOAK_LOG:-./soak-lossy-audio-${ts}.log}"
+
+# The lines worth watching during a lossy-audio soak, roughly in lifecycle order:
+#   * the offer + reliable handshake (it must negotiate AAC over TCP first),
+#   * the lossy DVC opening + the Soft-Sync onto UDPFECL + the client's response,
+#   * the DTLS/tunnel establishment under loss (P2.1/P2.4 GREEN = it survived),
+#   * THE payoff marker: "streaming Wave2 audio over the LOSSY UDP/DTLS tunnel",
+#   * the failure tells (route failed / broken pipe / reset / cookie reject), and
+#   * RTO retransmits (should be ~0 for a genuine lossy flow; any value here means
+#     the reliable SM is still carrying it — check MACRDP_UDP_LOSSY_DELIVERY).
+MARKERS='offering AUDIO_PLAYBACK_LOSSY_DVC|reliable audio DVC negotiated|lossy audio DVC opened|DYNVC_SOFT_SYNC_REQUEST|Soft-Sync Response|streaming Wave2 audio over the LOSSY|lossy audio wave route over UDP tunnel failed|LOSSY delivery|SPIKE GREEN|P2\.1 GREEN|P2\.4 GREEN|CREATEREQUEST|CREATERESPONSE|cookie not recognized|RTO retransmit|Broken pipe|Connection reset|Connection error'
+
+echo "soak-lossy-audio: MACRDP_UDP_OFFER_FECL=$MACRDP_UDP_OFFER_FECL MACRDP_UDP_LOSSY_DELIVERY=$MACRDP_UDP_LOSSY_DELIVERY MACRDP_UDP_LOSSY_AUDIO=$MACRDP_UDP_LOSSY_AUDIO"
+if [ "$MACRDP_UDP_LOSSY_AUDIO" = "1" ]; then
+    echo "soak-lossy-audio: mode = TREATMENT (audio over the lossy UDP/DTLS tunnel)"
+else
+    echo "soak-lossy-audio: mode = CONTROL (audio on the static RDPSND TCP channel)"
+fi
+echo "soak-lossy-audio: binary=$MACRDP"
+echo "soak-lossy-audio: full log -> $SOAK_LOG (paste this if reporting)"
+echo "soak-lossy-audio: live view below is filtered to soak markers; the file has everything."
+echo "soak-lossy-audio: shape the link in another terminal: sudo scripts/netshape.sh on --loss 5 --delay 100"
+echo "---"
+
+# Full output to the file; live console filtered to the markers. `grep -E` is line
+# buffered on a pipe under macOS, so lines appear as they happen.
+"$MACRDP" "$@" 2>&1 | tee "$SOAK_LOG" | grep -E --line-buffered "$MARKERS" || true


### PR DESCRIPTION
## Summary

Adds the soak harness to test the **P2.4b 2b-iv lossy-audio** path under an emulated lossy link, so the lossy *win* — smooth audio under loss where TCP audio desyncs — can be heard and measured. Follows #61 (which landed the feature).

- **`scripts/soak-lossy-audio.sh`** — the audio sibling of `soak-lossy.sh`. Sets the three gates (`MACRDP_UDP_OFFER_FECL` + `MACRDP_UDP_LOSSY_DELIVERY` + `MACRDP_UDP_LOSSY_AUDIO`), requires `--enable-aac` (warns if missing), tees the full log + live-prints the audio-DVC / tunnel markers, and exposes the **A/B knob**:
  - `MACRDP_UDP_LOSSY_AUDIO=1` (default) — **treatment**: audio over the lossy DTLS tunnel.
  - `MACRDP_UDP_LOSSY_AUDIO=0` — **control**: audio on the static RDPSND TCP channel.
- **Docs** — new "Lossy-audio soak (runbook)" section in `docs/rdp-udp-multitransport-feasibility.md`: the A/B procedure, the marker lifecycle, the loss×latency sweep, and the P2.2 handshake-stall tie-breaker. Also refreshes the now-stale P2.2 takeaway ("lossy audio paused") since a real payload now rides the tunnel.

## How to run

```
# terminal 1 — shape the link:
sudo scripts/netshape.sh on --loss 5 --delay 100

# terminal 2 — treatment (audio over the lossy tunnel):
scripts/soak-lossy-audio.sh --enable-udp-multitransport --enable-aac --enable-h264 \
    --username "$USER" --password 'PASS' --bind 0.0.0.0:3390

# …or control (same everything, audio on TCP):
MACRDP_UDP_LOSSY_AUDIO=0 scripts/soak-lossy-audio.sh --enable-udp-multitransport \
    --enable-aac --enable-h264 --username "$USER" --password 'PASS' --bind 0.0.0.0:3390
```

## Notes

- **No code change** — shell script + prose only; the build/tests are unaffected.
- Validated `sh -n` syntax + dry-ran both modes (treatment/control banners, the missing-`--enable-aac` warning).