### PR TITLE
fix(multitransport): make experimental UDP env toggles value-aware (=0 means off)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2190,7 +2190,7 @@ async fn async_main() -> Result<()> {
         .await
         {
             Ok(listener) => {
-                let migrate_egfx = std::env::var_os("MACRDP_UDP_MIGRATE_EGFX").is_some();
+                let migrate_egfx = multitransport::env_truthy("MACRDP_UDP_MIGRATE_EGFX");
                 info!(
                     addr = %args.bind,
                     migrate_egfx,
@@ -2210,7 +2210,7 @@ async fn async_main() -> Result<()> {
                 // Requires AAC (the lossy DVC needs version >= 8 + AAC,
                 // MS-RDPEA Appendix A note <2>). Advertises the SAME format list
                 // the static RDPSND path encodes.
-                if std::env::var_os("MACRDP_UDP_LOSSY_AUDIO").is_some() && args.enable_aac {
+                if multitransport::env_truthy("MACRDP_UDP_LOSSY_AUDIO") && args.enable_aac {
                     let formats = audio::server_audio_formats(args.enable_aac, args.aac_bitrate);
                     info!(
                         formats = formats.len(),

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -17,6 +17,23 @@
 use ironrdp_pdu::rdp::multitransport::RequestedProtocol;
 use ironrdp_server::MultitransportProvider;
 
+/// Interpret an experimental on/off environment toggle by *value*, not mere
+/// presence. `true` only for a truthy value; unset, empty, and the common falsey
+/// spellings (`0`/`false`/`no`/`off`, case-insensitive, trimmed) are `false`. A
+/// bare `.is_some()` check treated `FLAG=0` as "on", which silently contaminated
+/// the lossy-audio soak A/B (`MACRDP_UDP_LOSSY_AUDIO=0` still offered the lossy
+/// DVC) — so the experimental UDP toggles route through here. Mirrors the vendored
+/// `ironrdp_server::multitransport::env_truthy`.
+pub fn env_truthy(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
+}
+
 /// M1 provider: offer reliable UDP multitransport. Reliable (`UdpFecR`) rides
 /// the connection's existing rustls TLS, so no DTLS / new crypto dependency is
 /// needed. Lossy (`UdpFecL`, which needs DTLS) is a later milestone.
@@ -35,7 +52,7 @@ impl MultitransportProvider for MacMultitransport {
     fn requested_protocol(&self) -> RequestedProtocol {
         // P2.0 spike toggle: offer lossy instead of reliable. Read per call (the
         // provider is process-wide; this is cheap and avoids extra plumbing).
-        if std::env::var_os("MACRDP_UDP_OFFER_FECL").is_some_and(|v| v == "1") {
+        if env_truthy("MACRDP_UDP_OFFER_FECL") {
             RequestedProtocol::UdpFecL
         } else {
             RequestedProtocol::UdpFecR

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -442,7 +442,7 @@ async fn run_recv_loop(
     // instead of the reliable policy. Default OFF — the lossy flow keeps riding the
     // reliable SM (the proven P2.1a/P2.4a path), so this is a one-env-var A/B and a
     // clean fallback. The reliable (`UdpFecR`) flow is never affected.
-    let lossy_delivery = std::env::var_os("MACRDP_UDP_LOSSY_DELIVERY").is_some();
+    let lossy_delivery = super::env_truthy("MACRDP_UDP_LOSSY_DELIVERY");
     if lossy_delivery {
         debug!("MACRDP_UDP_LOSSY_DELIVERY set — lossy (SYN_LOSSY) flows will use DeliveryMode::Lossy");
     }

--- a/vendor/ironrdp-server/src/multitransport/mod.rs
+++ b/vendor/ironrdp-server/src/multitransport/mod.rs
@@ -50,6 +50,23 @@ pub trait MultitransportProvider: Send {
     fn requested_protocol(&self) -> RequestedProtocol;
 }
 
+/// Interpret an experimental on/off environment toggle by *value*, not mere
+/// presence. Returns `true` only for a truthy value; unset, empty, and the common
+/// falsey spellings (`0`/`false`/`no`/`off`, case-insensitive, trimmed) are
+/// `false`. A bare `.is_some()` check treated `FLAG=0` as "on", which silently
+/// contaminated the lossy-soak A/B (setting `MACRDP_UDP_LOSSY_DELIVERY=0` to revert
+/// to reliable delivery left it lossy) — so all the experimental UDP toggles route
+/// through here.
+pub(crate) fn env_truthy(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
+}
+
 /// Encode a Server Initiate Multitransport Request (MS-RDPBCGR 2.2.15.1) as a
 /// `SendDataIndication` on the IO channel. The Initiate Request is a
 /// `BasicSecurityHeader`-wrapped PDU, **not** a ShareControl PDU — so this

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -294,7 +294,7 @@ const EGFX_DVC_CHANNEL_NAME: &str = "Microsoft::Windows::RDS::Graphics";
 fn migrate_egfx_enabled() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("MACRDP_UDP_MIGRATE_EGFX").is_some())
+    *ENABLED.get_or_init(|| crate::multitransport::env_truthy("MACRDP_UDP_MIGRATE_EGFX"))
 }
 
 /// (P2.4b diagnostic) EXPERIMENTAL: migrate EGFX onto the LOSSY (UdpFecL/DTLS)
@@ -309,7 +309,7 @@ fn migrate_egfx_enabled() -> bool {
 fn migrate_egfx_lossy() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("MACRDP_UDP_MIGRATE_EGFX_LOSSY").is_some())
+    *ENABLED.get_or_init(|| crate::multitransport::env_truthy("MACRDP_UDP_MIGRATE_EGFX_LOSSY"))
 }
 
 pub struct RdpServer {


### PR DESCRIPTION
## Summary

The experimental UDP multitransport toggles used bare `std::env::var_os(..).is_some()`, so **`FLAG=0` read as "on"**. This silently contaminated the lossy-audio soak A/B:
- `MACRDP_UDP_LOSSY_AUDIO=0` (control — audio on TCP) still offered the lossy DVC.
- `MACRDP_UDP_LOSSY_DELIVERY=0` (revert to reliable delivery) stayed send-once lossy.

So both "control" runs were actually the treatment — the A/B told us nothing (a real soak surfaced this).

## Fix

Add an `env_truthy(name)` helper (one per crate: vendored `ironrdp-server::multitransport` + `src/multitransport.rs`) that interprets the **value**: unset, empty, and the common falsey spellings (`0`/`false`/`no`/`off`, case-insensitive, trimmed) → off; anything else → on. Route the experimental toggles through it:

- `MACRDP_UDP_LOSSY_DELIVERY` (listener)
- `MACRDP_UDP_LOSSY_AUDIO` (main.rs)
- `MACRDP_UDP_MIGRATE_EGFX` / `MACRDP_UDP_MIGRATE_EGFX_LOSSY` (server)
- `MACRDP_UDP_OFFER_FECL` (already did `== "1"`; folded in for consistency)

Now `=0` reliably means off, so the soak runbook's A/B knobs work as documented.

## Notes

- **No default-path behavior change** — every toggle is default-off / experimental, and a truthy `=1` still enables exactly as before.
- Focused diff (5 files, ~40 lines); no formatting churn.