### PR TITLE
docs(multitransport): P2.3 FEC capture-first spike + fec-scan.sh

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -595,15 +595,73 @@ Each milestone is its own gated PR, real-client-verified, feature-flagged
   may need the response re-sent idempotently (or a handshake-phase retransmit). That's
   the next thing the netshape soak should probe.
 
-- **P2.3 — FEC encoder (optional, deferrable).** Researched: MS-RDPEUDP FEC is
-  **GF(256) Reed–Solomon**, not XOR parity; each FEC packet recovers exactly **one** lost
-  source packet within its range; the wire header is `RDPUDP_FEC_PAYLOAD_HEADER`
-  (`snCoded`, `snSourceStart`, `uRange`, `uFecIndex`). A **send-only server needs only the
-  *encoder***, and **even that is optional** — it's a loss-recovery *optimization*, not
-  required for the lossy transport to function. So **ship lossy-without-FEC first**
-  (P2.4/P2.5 below work without it), then add the RS encoder as a measurable
-  loss-resilience improvement. This de-risks: we get a working lossy audio path before
-  taking on a Reed–Solomon implementation.
+- **P2.3 — FEC encoder — CAPTURE-BLOCKED (spec research 2026-06-27, [MS-RDPEUDP] rev 19.0).**
+  A deeper read of the spec turned the lossy-audio soak's "needs FEC" conclusion into four
+  hard blockers, so before any encoder we do a **capture-first go/no-go spike** (see the
+  "P2.3 FEC capture runbook" below):
+  1. **Receiver decode is OPTIONAL.** The spec is explicit — "the receiver … can ignore the
+     FEC Packet and not use it for any decoding operations"; **retransmission (ARQ) is the
+     actual reliability mechanism**, FEC is only an opportunistic latency-saver. So a perfect
+     encoder may be *ignored* by mstsc. (§ "UDP Data Transfer".)
+  2. **The GF(256) coefficient table is UNDOCUMENTED.** It's a Reed–Solomon / Vandermonde
+     code over GF(2^8), NOT XOR parity (spec example coefficients `[1 142 244 71 167]`), but
+     the generator polynomial, primitive element, and `uFecIndex`→coefficient-row mapping are
+     **not published**. Emitting packets a Windows receiver would decode requires
+     reverse-engineering the table **from a packet capture of a real Windows RDP *server*
+     sending FEC**. (§2.2.2.2/2.2.2.3.)
+  3. **FEC is v1/v2-only — RDPEUDP2 (v3+) has no FEC** (delay-based rate control instead), and
+     mstsc prefers v2-carrying-TLS / RDPEUDP2. So even on a lossy flow mstsc may negotiate a
+     version where FEC never applies.
+  4. **No OSS reference** — FreeRDP's prototype explicitly skipped FEC, never merged.
+
+  Wire facts (confirmed, for when/if we build it): an FEC packet is an ACK datagram with
+  `uFlags = FEC|DATA|ACK (0x1C)`, layout `RDPUDP_FEC_HEADER(8) + AckVector + RDPUDP_FEC_PAYLOAD_HEADER(12) + parity`.
+  `RDPUDP_FEC_PAYLOAD_HEADER` = `snCoded u32`, `snSourceStart u32`, `uRange u8` (covers
+  `[snSourceStart .. snSourceStart+uRange]`, ≤255), `uFecIndex u8` (selects the parity/coefficient
+  row — multiple FEC packets w/ distinct `uFecIndex` recover >1 loss; one packet = one loss),
+  `uPadding u16` (=0). Each source packet enters the FEC math prefixed with a 2-byte
+  `RDPUDP_PAYLOAD_PREFIX` (`cbPayloadSize`) and zero-padded to the longest member of the range.
+  `snCoded` advances for **every** datagram (source AND FEC); `snSourceStart` only for source.
+
+  **Decision (user, 2026-06-27): capture-first.** Build NO encoder until a capture proves
+  (a) a real Windows server actually sends FEC to a client on a lossy flow under loss, and
+  (b) yields the coefficient table. If the capture shows FEC isn't used in practice (likely,
+  given #1/#3), lossy-audio-over-mstsc has no clean FEC win and the conclusion is documented
+  as such — the retransmission-ARQ path (fix server→client RTO + the tunnel-backlog-blind lag
+  model) becomes the alternative.
+
+### P2.3 FEC capture runbook (the go/no-go spike)
+
+Goal: a `.pcap` of a **real Windows RDP server** sending RDPEUDP **FEC packets** to a client
+over a **lossy** link, to answer (a) *does it happen at all?* and (b) *what are the GF(256)
+coefficients?* Only build the encoder if (a) is yes.
+
+**Topology (use what's on hand — one Windows box + the Mac):**
+- **Server:** enable Remote Desktop on the Windows box (System → Remote Desktop). Ensure UDP
+  multitransport is on (default; GPO "Select RDP transport protocols" = Use both / leave default).
+- **Client + capture host:** the Mac, via **Microsoft Remote Desktop.app** (it can open a UDP
+  flow). Capture on the Mac with Wireshark/tcpdump on the RDP UDP flow.
+- **Loss:** `sudo scripts/netshape.sh on --loss 8 --delay 80 --port 3389` on the Mac (shape the
+  *server's* RDP port so the path is lossy → the server's RDPEUDP reacts; 8% to make FEC, if
+  used, frequent). Higher loss than the audio soak on purpose — we want to *provoke* FEC.
+- If the Mac client never triggers FEC, fall back to a **second Windows box running mstsc** to
+  the same server (Windows↔Windows is the most likely to negotiate a FEC-capable version), with
+  a lossy router/`clumsy` in between, captured on either end.
+
+**Capture + first look:**
+```
+# on the Mac, capture the UDP flow (RDP UDP rides the same 3389 by default):
+sudo tcpdump -i any -w /tmp/rdpfec.pcap 'udp and port 3389'
+# …connect MS Remote Desktop to the Windows server, exercise it ~30s under loss, stop tcpdump.
+scripts/fec-scan.sh /tmp/rdpfec.pcap     # summarizes RDPUDP flags; flags FEC datagrams
+```
+`scripts/fec-scan.sh` (added with this) tallies the RDPUDP `uFlags` per datagram and prints any
+with the **FEC bit (0x10)** set, with `snCoded`/`snSourceStart`/`uRange`/`uFecIndex` and the
+parity bytes. **Go/no-go:** any FEC datagrams at all → (a) is YES, capture-spike green, proceed
+to coefficient extraction (paste the pcap and I'll work the GF(256) table from the covered
+source packets + parity). **Zero FEC datagrams over a lossy link** (only retransmits) → (a) is
+NO: a real Windows server doesn't use FEC here either, so we don't build the encoder, and the
+ARQ-fix path is the only lever. Either outcome is a decisive result.
 
 - **P2.4a — MS-RDPEMT tunnel over DTLS (DONE, GREEN 2026-06-26).** The prerequisite
   for any lossy channel: decrypt the client's DTLS application records, answer its

--- a/scripts/fec-scan.sh
+++ b/scripts/fec-scan.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# fec-scan.sh — scan an RDP UDP capture for RDPEUDP **FEC packets**, the P2.3
+# go/no-go spike (see docs/rdp-udp-multitransport-feasibility.md → "P2.3 FEC
+# capture runbook").
+#
+# The question this answers: does a *real Windows RDP server* actually emit FEC
+# (parity) packets to a client on a lossy UDP flow? If YES, FEC is worth
+# implementing and the capture also gives us the source+parity bytes to reverse-
+# engineer the (undocumented) GF(256) coefficient table. If NO — only DATA/ACK and
+# retransmits, no FEC datagrams over a lossy link — then a Windows server doesn't
+# use FEC here either, so we don't build the encoder (MS-RDPEUDP makes FEC decode
+# OPTIONAL and uses retransmission as the real reliability mechanism).
+#
+#   scripts/fec-scan.sh <capture.pcap>
+#
+# How it reads the wire: every RDPUDP datagram begins with RDPUDP_FEC_HEADER
+# (8 bytes, big-endian): snSourceAck u32, uReceiveWindowSize u16, uFlags u16. The
+# FEC bit is 0x10 (RDPUDP_FLAG_FEC); an FEC packet also sets DATA (0x08) + ACK
+# (0x04) → uFlags 0x1C. We classify each UDP payload by uFlags, print a flag
+# histogram, and dump every FEC datagram's full hex for offline analysis.
+#
+# Requires tshark (Wireshark CLI): brew install wireshark
+set -eu
+
+PCAP="${1:-}"
+if [ -z "$PCAP" ] || [ ! -f "$PCAP" ]; then
+    echo "usage: $0 <capture.pcap>" >&2
+    exit 1
+fi
+if ! command -v tshark >/dev/null 2>&1; then
+    echo "error: tshark (Wireshark CLI) not found — install with: brew install wireshark" >&2
+    exit 1
+fi
+
+# Dump per-UDP-datagram: frame number, src→dst, and the raw UDP payload hex. We do
+# NOT rely on Wireshark's rdpudp dissector (field names vary by version) — we parse
+# the RDPUDP header ourselves from the payload bytes, which is version-stable.
+#
+# tshark output goes to a temp file passed to python by path: `python3 - <<heredoc`
+# makes the heredoc python's *stdin*, so a piped `tshark | python3 -` would leave
+# sys.stdin pointing at the program text, not the data — the data would be lost.
+TMPOUT="$(mktemp)"
+trap 'rm -f "$TMPOUT"' EXIT
+tshark -r "$PCAP" -Y 'udp && udp.payload' \
+    -T fields -e frame.number -e ip.src -e ip.dst -e udp.srcport -e udp.dstport -e udp.payload \
+    2>/dev/null > "$TMPOUT"
+
+python3 - "$TMPOUT" <<'PY'
+import sys
+
+SYN, FIN, ACK, DATA, FEC = 0x01, 0x02, 0x04, 0x08, 0x10
+# Higher RDPUDP flag bits seen in the wild (SYNEX/ACK_OF_ACKS/CORRELATIONID/CWR/etc.)
+NAMES = [(SYN,"SYN"),(FIN,"FIN"),(ACK,"ACK"),(DATA,"DATA"),(FEC,"FEC"),
+         (0x20,"SYNLOSSY"),(0x40,"ACKDELAYED"),(0x80,"CORRID"),(0x100,"SYNEX")]
+
+def flagstr(f):
+    parts = [n for b, n in NAMES if f & b]
+    extra = f & ~sum(b for b, _ in NAMES)
+    if extra:
+        parts.append("0x%x" % extra)
+    return "|".join(parts) if parts else "0"
+
+total = 0
+hist = {}
+fec = []
+
+with open(sys.argv[1]) as _f:
+    lines = _f.readlines()
+
+for line in lines:
+    cols = line.rstrip("\n").split("\t")
+    if len(cols) < 6:
+        continue
+    frame, src, dst, sport, dport, payhex = cols[:6]
+    payhex = payhex.replace(":", "").strip()
+    if len(payhex) < 16:  # need at least the 8-byte FEC_HEADER
+        continue
+    try:
+        pay = bytes.fromhex(payhex)
+    except ValueError:
+        continue
+    uflags = int.from_bytes(pay[6:8], "big")
+    sn_source_ack = int.from_bytes(pay[0:4], "big")
+    total += 1
+    hist[uflags] = hist.get(uflags, 0) + 1
+    if uflags & FEC:
+        fec.append((frame, src, sport, dst, dport, sn_source_ack, uflags, payhex))
+
+print("=== RDPUDP datagrams: %d ===" % total)
+print("--- uFlags histogram (count  flags  =hex) ---")
+for f in sorted(hist, key=lambda k: -hist[k]):
+    print("  %6d  %-28s =0x%04x" % (hist[f], flagstr(f), f))
+
+print()
+if not fec:
+    print(">>> NO FEC datagrams found (uFlags & 0x10 never set).")
+    print(">>> go/no-go = NO-GO: the server is not sending FEC on this flow.")
+    print(">>>   (Expected if it negotiated RDPEUDP2/v3, or chose retransmit-only.)")
+    print(">>>   Conclusion: don't build the FEC encoder; the ARQ path is the lever.")
+else:
+    print(">>> FOUND %d FEC datagram(s) — go/no-go = GO." % len(fec))
+    print(">>> Paste this pcap back so the GF(256) coefficient table can be worked")
+    print(">>> out from the covered source packets + these parity bytes.")
+    print("--- FEC datagrams (frame  src:port -> dst:port  snSourceAck  uFlags) ---")
+    for frame, src, sport, dst, dport, sa, uf, payhex in fec[:50]:
+        print("  frame %s  %s:%s -> %s:%s  snSourceAck=%d  uFlags=0x%04x" %
+              (frame, src, sport, dst, dport, sa, uf))
+        print("    payload: %s" % payhex)
+    if len(fec) > 50:
+        print("  … and %d more (showing first 50)" % (len(fec) - 50))
+PY


### PR DESCRIPTION
## Summary

Spec research ([MS-RDPEUDP] rev 19.0) turned the lossy-audio soak's "needs FEC" conclusion into four blockers that make a blind FEC encoder a non-starter — so P2.3 becomes a **capture-first go/no-go spike**, not an implementation, until a packet capture proves it's worth (and possible) to build.

### Why not just build it
1. **Receiver decode is OPTIONAL.** The spec: the receiver "can ignore the FEC Packet and not use it for any decoding operations" — **retransmission (ARQ) is the actual reliability mechanism**; FEC is an opportunistic latency-saver. mstsc may ignore a perfect encoder.
2. **The GF(256) Reed–Solomon coefficient table is UNDOCUMENTED** (only an example vector `[1 142 244 71 167]` is shown). Decodable packets require reverse-engineering the table from a capture of a real Windows server sending FEC.
3. **FEC is RDPEUDP v1/v2-only** — RDPEUDP2 (v3+, which mstsc prefers) has no FEC.
4. **No OSS reference** (FreeRDP skipped FEC, never merged).

### What's in this PR (docs + tooling only)
- **"P2.3 FEC capture runbook"** in the feasibility doc: a topology using just the one Windows box (as RDP server) + the Mac (MS Remote Desktop client + capture host), `netshape.sh` to provoke loss, `tcpdump` to capture, and the exact `RDPUDP_FEC_PAYLOAD_HEADER` wire layout for when/if we build the encoder.
- **`scripts/fec-scan.sh`** — a tshark-based analyzer that parses the RDPUDP header itself (version-stable, no dissector dependency), prints a `uFlags` histogram, and flags any FEC datagrams (bit 0x10), printing a clear **GO** (FEC present → paste the pcap to extract coefficients) or **NO-GO** (no FEC over a lossy link → don't build the encoder; the ARQ path is the lever).

No code/behavior change. (Fixed a heredoc-stdin bug in the analyzer during testing; validated against a synthetic FEC datagram.)