### PR TITLE
docs(multitransport): P2.3 FEC capture RESULT — NO-GO (modern Windows uses RDPUDP2, no FEC)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -663,6 +663,34 @@ source packets + parity). **Zero FEC datagrams over a lossy link** (only retrans
 NO: a real Windows server doesn't use FEC here either, so we don't build the encoder, and the
 ARQ-fix path is the only lever. Either outcome is a decisive result.
 
+### P2.3 FEC capture RESULT (2026-06-27) — NO-GO (structural): modern Windows uses RDPUDP2, no FEC
+
+Captured a **real Windows RDP server** (a VirtualBox Windows VM; host `127.0.0.1:3390` NAT-forwarded to
+the guest's `3389`) ↔ **mstsc on the host**, on the host loopback. Analyzed with the rewritten
+`scripts/fec-scan.sh` driving Wireshark's RDPUDP **dissector** (authoritative — version-aware framing):
+
+- **Negotiated version = `0x0101` (RDPUDP2 / Wireshark "UDPv2")** — read from the SYNEX of both the client
+  SYN and the server SYN+ACK.
+- **`syn-lossy flows = 0`**, **`FEC packets = 0`** of 1912 RDPUDP datagrams (data=1747, ack=634).
+
+**Structural NO-GO, and the no-loss capture is sufficient to prove it.** FEC exists only in RDPEUDP
+**v1/v2**; **RDPUDP2 (0x0101) has no FEC at all** (delay-based rate control). Version negotiation is
+capability-based at SYN time — *before* any data/loss — so a lossy link would **not** downgrade to a
+FEC-capable version; it'd still be RDPUDP2, still zero FEC. A current Windows server relies on RDPUDP2
+retransmission, not FEC. **So mstsc would never decode FEC we emit — building the encoder is pointless.
+P2.3 is closed NO-GO**, confirming the spec research (blocker #3) on real Windows wire.
+
+Tooling note: the first `fec-scan.sh` hand-parsed uFlags at a fixed offset and misread RDPUDP2 data
+packets as "495 FEC datagrams" (a false GO). Rewritten to use the dissector's `rdpudp.flags.fec` +
+`rdpudp.synex.version`; it now reports the negotiated version and emits the structural NO-GO for `0x0101`.
+
+**Remaining lossy-audio levers (neither depends on RDPEUDP FEC):** (1) application-level **duplicate-AU
+redundancy** — send each AAC Wave2 PDU twice over the lossy tunnel (mstsc sees ordinary audio PDUs, no FEC
+decode; relies on it deduping by `block_no`); else (2) accept that lossy-audio-over-mstsc has no clean win
+(reliable HOL-blocks; send-once loses AUs) and document it. The ARQ path does **not** rescue *audio*
+(reliable = HOL-block = the very problem), so "fix ARQ" is not a lossy-audio fix — it's only relevant if a
+*reliable* tunnel payload is ever wanted.
+
 - **P2.4a — MS-RDPEMT tunnel over DTLS (DONE, GREEN 2026-06-26).** The prerequisite
   for any lossy channel: decrypt the client's DTLS application records, answer its
   `RDP_TUNNEL_CREATEREQUEST` with a `CREATERESPONSE(S_OK)` re-encrypted through DTLS,

--- a/scripts/fec-scan.sh
+++ b/scripts/fec-scan.sh
@@ -1,30 +1,36 @@
 #!/bin/sh
-# fec-scan.sh — scan an RDP UDP capture for RDPEUDP **FEC packets**, the P2.3
-# go/no-go spike (see docs/rdp-udp-multitransport-feasibility.md → "P2.3 FEC
-# capture runbook").
+# fec-scan.sh — scan an RDP UDP capture for RDPEUDP **FEC packets** and report the
+# negotiated transport version, the P2.3 go/no-go spike (see
+# docs/rdp-udp-multitransport-feasibility.md → "P2.3 FEC capture runbook").
 #
-# The question this answers: does a *real Windows RDP server* actually emit FEC
-# (parity) packets to a client on a lossy UDP flow? If YES, FEC is worth
-# implementing and the capture also gives us the source+parity bytes to reverse-
-# engineer the (undocumented) GF(256) coefficient table. If NO — only DATA/ACK and
-# retransmits, no FEC datagrams over a lossy link — then a Windows server doesn't
-# use FEC here either, so we don't build the encoder (MS-RDPEUDP makes FEC decode
-# OPTIONAL and uses retransmission as the real reliability mechanism).
+# The question: does a *real Windows RDP server* emit FEC (parity) packets on a UDP
+# flow? If YES, FEC is worth implementing and the capture gives us the source+parity
+# bytes to reverse-engineer the (undocumented) GF(256) coefficient table. If NO,
+# don't build the encoder.
 #
-#   scripts/fec-scan.sh <capture.pcap>
+# IMPORTANT: this uses **Wireshark's RDPUDP dissector** (authoritative) — NOT a
+# hand-rolled header parse. An earlier hand-parser read uFlags at a fixed offset and
+# misread RDPUDP2 (v3) data packets as FEC (the FEC bit isn't where v1 puts it),
+# producing false "GO"s. The dissector knows the per-version framing.
 #
-# How it reads the wire: every RDPUDP datagram begins with RDPUDP_FEC_HEADER
-# (8 bytes, big-endian): snSourceAck u32, uReceiveWindowSize u16, uFlags u16. The
-# FEC bit is 0x10 (RDPUDP_FLAG_FEC); an FEC packet also sets DATA (0x08) + ACK
-# (0x04) → uFlags 0x1C. We classify each UDP payload by uFlags, print a flag
-# histogram, and dump every FEC datagram's full hex for offline analysis.
+# Decisive fact baked into the verdict: FEC exists ONLY in RDPEUDP v1/v2. The
+# second-generation protocol **RDPUDP2 (version 0x0101, Wireshark "UDPv2")** has NO
+# FEC at all (delay-based rate control instead), and modern mstsc/Windows negotiate
+# it. So a capture that shows version 0x0101 is a structural NO-GO regardless of loss.
+#
+#   scripts/fec-scan.sh <capture.pcap> [udp_port]
+#
+# udp_port: the UDP port carrying RDP (multitransport rides the TCP RDP port). Auto-
+# detected if omitted — needed e.g. for a VirtualBox NAT forward where the host side
+# is 3390 forwarding to the guest's 3389.
 #
 # Requires tshark (Wireshark CLI): brew install wireshark
 set -eu
 
 PCAP="${1:-}"
+PORT_ARG="${2:-}"
 if [ -z "$PCAP" ] || [ ! -f "$PCAP" ]; then
-    echo "usage: $0 <capture.pcap>" >&2
+    echo "usage: $0 <capture.pcap> [udp_port]" >&2
     exit 1
 fi
 if ! command -v tshark >/dev/null 2>&1; then
@@ -32,110 +38,74 @@ if ! command -v tshark >/dev/null 2>&1; then
     exit 1
 fi
 
-# Dump per-UDP-datagram: frame number, src→dst, and the raw UDP payload hex. We do
-# NOT rely on Wireshark's rdpudp dissector for field *values* (names vary by
-# version) — we parse the RDPUDP header from the payload bytes, which is
-# version-stable. But we DO use the dissector (or, failing that, the port-3389
-# restriction) to SELECT which datagrams to parse, so unrelated UDP (ZeroTier,
-# Syncthing, QUIC, DNS, mDNS, SSDP …) isn't misread as RDPUDP — every byte triplet
-# looks like "flags" if you squint, which produces garbage histograms and false
-# FEC hits. RDP UDP multitransport rides the SAME port as the TCP listener (3389).
-#
-# Pick the narrowest filter that yields packets: Wireshark-identified `rdpudp`
-# first, else raw UDP on port 3389. If neither yields anything, the capture has no
-# RDP UDP traffic at all (wrong adapter / TCP-only session) — reported as such.
-TMPOUT="$(mktemp)"
-trap 'rm -f "$TMPOUT"' EXIT
+# Resolve how to make tshark dissect the RDP UDP as rdpudp. Prefer the heuristic /
+# default port; else force-decode an explicit or auto-detected port.
+rdpudp_count() { tshark -r "$PCAP" $1 -Y 'rdpudp' 2>/dev/null | grep -c . || true; }
 
-FILTER='rdpudp'
-if [ "$(tshark -r "$PCAP" -Y 'rdpudp' 2>/dev/null | wc -l | tr -d ' ')" = "0" ]; then
-    FILTER='udp.port==3389 && udp.payload'
+DECODE=""
+if [ -n "$PORT_ARG" ]; then
+    DECODE="-d udp.port==$PORT_ARG,rdpudp"
+elif [ "$(rdpudp_count "")" -gt 0 ]; then
+    DECODE=""   # heuristic already dissects it (typically port 3389)
+else
+    # Try the busiest UDP port (covers NAT-forwarded captures, e.g. 3390).
+    CAND="$(tshark -r "$PCAP" -Y 'udp' -T fields -e udp.dstport -e udp.srcport 2>/dev/null \
+        | tr '\t' '\n' | grep -E '^[0-9]+$' | sort | uniq -c | sort -rn | awk 'NR==1{print $2}')"
+    if [ -n "${CAND:-}" ] && [ "$(rdpudp_count "-d udp.port==$CAND,rdpudp")" -gt 0 ]; then
+        DECODE="-d udp.port==$CAND,rdpudp"
+        echo "(auto-detected RDP UDP on port $CAND)"
+    fi
 fi
-tshark -r "$PCAP" -Y "$FILTER" \
-    -T fields -e frame.number -e ip.src -e ip.dst -e udp.srcport -e udp.dstport -e udp.payload \
-    2>/dev/null > "$TMPOUT"
 
-python3 - "$TMPOUT" <<'PY'
-import sys
+TOTAL="$(rdpudp_count "$DECODE")"
+echo "=== RDPUDP datagrams: $TOTAL ==="
 
-SYN, FIN, ACK, DATA, FEC = 0x01, 0x02, 0x04, 0x08, 0x10
-# Higher RDPUDP flag bits seen in the wild (SYNEX/ACK_OF_ACKS/CORRELATIONID/CWR/etc.)
-NAMES = [(SYN,"SYN"),(FIN,"FIN"),(ACK,"ACK"),(DATA,"DATA"),(FEC,"FEC"),
-         (0x20,"SYNLOSSY"),(0x40,"ACKDELAYED"),(0x80,"CORRID"),(0x100,"SYNEX")]
+if [ "$TOTAL" = "0" ]; then
+    echo
+    echo ">>> INCONCLUSIVE: no RDPUDP traffic dissected."
+    echo ">>> NOT a NO-GO — the capture doesn't contain the RDP UDP session."
+    echo ">>>   * pass the port explicitly:  $0 $PCAP <udp_port>"
+    echo ">>>   * sanity: tshark -r $PCAP -q -z io,phs   (is there udp at all?)"
+    echo ">>>   * VirtualBox host<->VM RDP rides the VM's adapter, not the physical"
+    echo ">>>     LAN; NAT usually breaks RDP UDP — use Bridged/Host-Only, or capture"
+    echo ">>>     inside the VM."
+    exit 0
+fi
 
-def flagstr(f):
-    parts = [n for b, n in NAMES if f & b]
-    extra = f & ~sum(b for b, _ in NAMES)
-    if extra:
-        parts.append("0x%x" % extra)
-    return "|".join(parts) if parts else "0"
+# Negotiated version (from the SYNEX). 0x0001/0x0002 = FEC-capable v1/v2;
+# 0x0101 = RDPUDP2 ("UDPv2") which has NO FEC.
+VERSIONS="$(tshark -r "$PCAP" $DECODE -Y 'rdpudp.flags.synex==1' -T fields -e rdpudp.synex.version 2>/dev/null | sort -u | tr '\n' ' ')"
+LOSSY="$(tshark -r "$PCAP" $DECODE -Y 'rdpudp.flags.synlossy==1' 2>/dev/null | grep -c . || true)"
+FEC="$(tshark -r "$PCAP" $DECODE -Y 'rdpudp.flags.fec==1' 2>/dev/null | grep -c . || true)"
+DATA="$(tshark -r "$PCAP" $DECODE -Y 'rdpudp.flags.data==1' 2>/dev/null | grep -c . || true)"
+ACK="$(tshark -r "$PCAP" $DECODE -Y 'rdpudp.flags.ack==1' 2>/dev/null | grep -c . || true)"
 
-total = 0
-hist = {}
-fec = []
+echo "  negotiated version(s): ${VERSIONS:-<none>}   (0x0001/0x0002 = FEC-capable; 0x0101 = RDPUDP2 = NO FEC)"
+echo "  data=$DATA  ack=$ACK  syn-lossy flows=$LOSSY  FEC packets=$FEC"
+echo
 
-with open(sys.argv[1]) as _f:
-    lines = _f.readlines()
+if [ "$FEC" -gt 0 ]; then
+    echo ">>> GO: $FEC FEC datagram(s) found. Extract the coefficient table:"
+    tshark -r "$PCAP" $DECODE -Y 'rdpudp.flags.fec==1' \
+        -T fields -e frame.number -e udp.srcport -e udp.dstport \
+        -e rdpudp.fec.coded -e rdpudp.fec.sourcestart -e rdpudp.fec.range -e rdpudp.fec.fecindex \
+        2>/dev/null | head -40 \
+        | awk -F'\t' '{printf "  frame %-6s %s->%s  snCoded=%s snSourceStart=%s range=%s fecIndex=%s\n",$1,$2,$3,$4,$5,$6,$7}'
+    echo ">>> Paste this pcap back to work out the GF(256) coefficients from the"
+    echo ">>> covered source packets + these parity payloads."
+    exit 0
+fi
 
-for line in lines:
-    cols = line.rstrip("\n").split("\t")
-    if len(cols) < 6:
-        continue
-    frame, src, dst, sport, dport, payhex = cols[:6]
-    payhex = payhex.replace(":", "").strip()
-    if len(payhex) < 16:  # need at least the 8-byte FEC_HEADER
-        continue
-    try:
-        pay = bytes.fromhex(payhex)
-    except ValueError:
-        continue
-    uflags = int.from_bytes(pay[6:8], "big")
-    sn_source_ack = int.from_bytes(pay[0:4], "big")
-    total += 1
-    hist[uflags] = hist.get(uflags, 0) + 1
-    if uflags & FEC:
-        fec.append((frame, src, sport, dst, dport, sn_source_ack, uflags, payhex))
-
-print("=== RDPUDP datagrams: %d ===" % total)
-
-if total == 0:
-    print()
-    print(">>> INCONCLUSIVE: no RDP UDP datagrams (no `rdpudp` and nothing on UDP 3389).")
-    print(">>> This is NOT a NO-GO — the capture didn't contain the RDP UDP session.")
-    print(">>> Sanity-check what IS in the capture:")
-    print(">>>   tshark -r <cap> -q -z io,phs            # protocol breakdown")
-    print(">>>   tshark -r <cap> -Y 'tcp.port==3389' | head   # RDP-over-TCP present?")
-    print(">>>   tshark -r <cap> -Y 'udp.port==3389' | head   # RDP UDP present?")
-    print(">>> Likely causes:")
-    print(">>>   * WRONG ADAPTER — for a VirtualBox host<->VM RDP session the traffic")
-    print(">>>     rides the VM's virtual network (Host-Only / NAT adapter), NOT the")
-    print(">>>     physical LAN. Capture on the VirtualBox Host-Only adapter, or run")
-    print(">>>     Wireshark INSIDE the VM (the server) on its own NIC — most reliable.")
-    print(">>>   * NO UDP MULTITRANSPORT — VirtualBox NAT usually breaks RDP UDP; use")
-    print(">>>     Bridged or Host-Only so the UDP flow can establish. Confirm with the")
-    print(">>>     udp.port==3389 check above before re-running under loss.")
-    print(">>>   * TCP-ONLY session — if only tcp.port==3389 shows, UDP never came up.")
-    sys.exit(0)
-
-print("--- uFlags histogram (count  flags  =hex) ---")
-for f in sorted(hist, key=lambda k: -hist[k]):
-    print("  %6d  %-28s =0x%04x" % (hist[f], flagstr(f), f))
-
-print()
-if not fec:
-    print(">>> NO FEC datagrams found (uFlags & 0x10 never set).")
-    print(">>> go/no-go = NO-GO: the server is not sending FEC on this flow.")
-    print(">>>   (Expected if it negotiated RDPEUDP2/v3, or chose retransmit-only.)")
-    print(">>>   Conclusion: don't build the FEC encoder; the ARQ path is the lever.")
-else:
-    print(">>> FOUND %d FEC datagram(s) — go/no-go = GO." % len(fec))
-    print(">>> Paste this pcap back so the GF(256) coefficient table can be worked")
-    print(">>> out from the covered source packets + these parity bytes.")
-    print("--- FEC datagrams (frame  src:port -> dst:port  snSourceAck  uFlags) ---")
-    for frame, src, sport, dst, dport, sa, uf, payhex in fec[:50]:
-        print("  frame %s  %s:%s -> %s:%s  snSourceAck=%d  uFlags=0x%04x" %
-              (frame, src, sport, dst, dport, sa, uf))
-        print("    payload: %s" % payhex)
-    if len(fec) > 50:
-        print("  … and %d more (showing first 50)" % (len(fec) - 50))
-PY
+# No FEC. Distinguish the structural NO-GO (RDPUDP2) from a clean-link/v1 case.
+case " $VERSIONS " in
+    *" 0x0101 "*)
+        echo ">>> NO-GO (structural): the flow negotiated RDPUDP2 (UDPv2, 0x0101),"
+        echo ">>> which has NO FEC mechanism. A real Windows server/mstsc will never"
+        echo ">>> use FEC on this version, with or without loss. Don't build the FEC"
+        echo ">>> encoder — pivot to the ARQ path." ;;
+    *)
+        echo ">>> NO-GO (this capture): RDPEUDP v1/v2 but zero FEC packets. Either the"
+        echo ">>> link was clean (no loss to recover) or the server chose retransmit."
+        echo ">>> Recapture under induced loss before concluding; if still no FEC, the"
+        echo ">>> server doesn't use it here." ;;
+esac


### PR DESCRIPTION
## What

Records the **decisive result** of the P2.3 capture-first FEC spike, and fixes the scan tool that produced a false GO.

### Capture result: NO-GO (structural)

Captured a **real Windows RDP server** (VirtualBox Windows VM, host `127.0.0.1:3390` NAT-forwarded to guest `3389`) ↔ **mstsc on the host**, on the host loopback. Analyzed with Wireshark's RDPUDP dissector:

- **Negotiated version = `0x0101` (RDPUDP2 / "UDPv2")** — from the SYNEX of both SYN and SYN+ACK.
- **`syn-lossy flows = 0`, `FEC packets = 0`** of 1912 RDPUDP datagrams (data=1747, ack=634).

FEC exists only in RDPEUDP **v1/v2**; **RDPUDP2 has no FEC** (delay-based rate control). Version negotiation is capability-based at SYN time (pre-loss), so a lossy link would **not** downgrade to a FEC-capable version. A modern Windows server uses RDPUDP2 retransmission, not FEC → mstsc would never decode FEC we emit. **Building the encoder is pointless. P2.3 is closed NO-GO**, confirming the spec research (blocker #3) on real Windows wire.

The no-loss capture is sufficient *because the result is structural* (version, not loss, decides FEC availability).

### Tool fix: `scripts/fec-scan.sh`

The first version hand-parsed `uFlags` at a fixed offset and misread RDPUDP2 data packets as "495 FEC datagrams" (a false GO). Rewritten to use Wireshark's dissector (`rdpudp.flags.fec` + `rdpudp.synex.version`), which knows the per-version framing. It now reports the negotiated version and emits the structural NO-GO for `0x0101`.

## Test

`scripts/fec-scan.sh` run against the real-Windows capture correctly outputs the structural NO-GO. Docs-and-tooling only; no code path changes.