### PR TITLE
feat(multitransport): P2.3 1+1 lossy redundancy (FEC pivot) behind MACRDP_UDP_LOSSY_AUDIO_DUP

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -684,12 +684,44 @@ Tooling note: the first `fec-scan.sh` hand-parsed uFlags at a fixed offset and m
 packets as "495 FEC datagrams" (a false GO). Rewritten to use the dissector's `rdpudp.flags.fec` +
 `rdpudp.synex.version`; it now reports the negotiated version and emits the structural NO-GO for `0x0101`.
 
-**Remaining lossy-audio levers (neither depends on RDPEUDP FEC):** (1) application-level **duplicate-AU
-redundancy** — send each AAC Wave2 PDU twice over the lossy tunnel (mstsc sees ordinary audio PDUs, no FEC
-decode; relies on it deduping by `block_no`); else (2) accept that lossy-audio-over-mstsc has no clean win
+**Remaining lossy-audio levers (neither depends on RDPEUDP FEC):** (1) **1+1 transport-level
+redundancy** — built, see P2.3 below; else (2) accept that lossy-audio-over-mstsc has no clean win
 (reliable HOL-blocks; send-once loses AUs) and document it. The ARQ path does **not** rescue *audio*
 (reliable = HOL-block = the very problem), so "fix ARQ" is not a lossy-audio fix — it's only relevant if a
 *reliable* tunnel payload is ever wanted.
+
+### P2.3 redundancy stand-in — 1+1 lossy duplicate sends (built 2026-06-27, soak pending)
+
+With real FEC ruled out, the protocol-safe redundancy is a **1+1 repetition code at the RDPEUDP
+transport**: on a lossy flow, ship each source datagram **twice** — byte-identical, same sequence number.
+On an independent-loss link of rate `p`, a payload is then lost only at `p²` (5% → 0.25%).
+
+- **Why transport-level, not "send each Wave2 PDU twice" (app-level).** App-level duplication would put
+  two Wave2 PDUs with the **same `block_no`** on the wire and *rely on mstsc deduping by `block_no`* at the
+  RDPSND layer — which MS-RDPEA never specifies, so it risks **double-play**. The transport copy is instead
+  de-duplicated by **DTLS anti-replay**: the lossy tunnel is DTLS-encrypted (P2.4a), the duplicate datagram
+  carries the *identical encrypted bytes* = the same DTLS record sequence number, and mstsc's DTLS replay
+  window drops it before it ever reaches RDPSND. So the audio layer sees each AU exactly once, guaranteed
+  by a standard DTLS property rather than an unspecified client behavior. (The RDPEUDP layer itself does
+  **not** dedup in lossy mode — deliver-on-arrival is the whole point — so dedup *must* live above it; DTLS
+  is exactly that layer.)
+- **Implementation.** `ironrdp-rdpeudp` `Config` gained `duplicate_lossy_sends: bool` (default false); when
+  set and `mode == Lossy`, `pump()` emits each new source datagram twice. The listener
+  (`vendor/ironrdp-server/src/multitransport/listener.rs`) sets it on a lossy peer behind the experimental
+  env **`MACRDP_UDP_LOSSY_AUDIO_DUP`** (default OFF; needs `MACRDP_UDP_LOSSY_DELIVERY` so the flow is on the
+  lossy SM). Reliable flow + default build are byte-unchanged. Unit-tested in `ironrdp-rdpeudp` (duplicate
+  emitted byte-identical; controls for flag-off and reliable-mode; a test documenting that the receiver
+  does not dedup, i.e. why DTLS must).
+- **Cost / caveat.** Doubles the lossy flow's egress bandwidth (audio only today — AAC ~128 kbit/s, so the
+  doubling is cheap). It protects against *independent* single-packet loss; it does **not** help against a
+  burst that takes out both copies (they ship back-to-back, so a burst longer than the inter-copy gap can
+  still drop both — staggering the copies in time would harden that, deferred). It is a stand-in, not FEC:
+  no cross-packet recovery, just repetition.
+- **Status: built + unit-tested, real-link soak PENDING.** `scripts/soak-lossy-audio.sh` exposes
+  `MACRDP_UDP_LOSSY_AUDIO_DUP` as a second A/B axis (dup vs no-dup at a fixed `--loss`). The open question
+  the soak answers: does 1+1 redundancy actually close the 5%-loss audio gap on mstsc (audio stays smooth),
+  or does the residual `p²` loss / burst loss still stall the AAC decoder? If yes → keep it (gated); if no →
+  fall back to lever (2), document lossy-audio-over-mstsc as having no clean win.
 
 - **P2.4a — MS-RDPEMT tunnel over DTLS (DONE, GREEN 2026-06-26).** The prerequisite
   for any lossy channel: decrypt the client's DTLS application records, answer its

--- a/scripts/soak-lossy-audio.sh
+++ b/scripts/soak-lossy-audio.sh
@@ -56,6 +56,16 @@
 #                               resent, so under heavy loss the tunnel may fail to
 #                               establish at all — watch for "P2.4 GREEN" / the
 #                               CREATERESPONSE marker to confirm it came up.
+#   MACRDP_UDP_LOSSY_AUDIO_DUP — 1 = 1+1 redundancy: ship each lossy source
+#                               datagram TWICE (same seq, byte-identical) so an
+#                               independent-loss link costs us only at p². mstsc's
+#                               DTLS anti-replay drops the duplicate (no double-
+#                               play). The P2.3 FEC pivot (real Reed-Solomon FEC is
+#                               structurally unavailable — modern Windows is
+#                               RDPUDP2/no-FEC). Default 0 (off). Needs LOSSY
+#                               delivery (it has no effect on the reliable SM).
+#                               This is the second A/B axis: dup vs no-dup at a
+#                               fixed loss to see if redundancy closes the gap.
 
 set -eu
 
@@ -81,6 +91,7 @@ esac
 export MACRDP_UDP_OFFER_FECL=1
 export MACRDP_UDP_LOSSY_DELIVERY="${MACRDP_UDP_LOSSY_DELIVERY:-1}"
 export MACRDP_UDP_LOSSY_AUDIO="${MACRDP_UDP_LOSSY_AUDIO:-1}"
+export MACRDP_UDP_LOSSY_AUDIO_DUP="${MACRDP_UDP_LOSSY_AUDIO_DUP:-0}"
 
 # Enough to see the audio-DVC lifecycle + the tunnel/DTLS milestones + the
 # reliability counters, without per-keystroke input spam. The audio-DVC "opened"
@@ -99,13 +110,16 @@ SOAK_LOG="${SOAK_LOG:-./soak-lossy-audio-${ts}.log}"
 #   * the failure tells (route failed / broken pipe / reset / cookie reject), and
 #   * RTO retransmits (should be ~0 for a genuine lossy flow; any value here means
 #     the reliable SM is still carrying it — check MACRDP_UDP_LOSSY_DELIVERY).
-MARKERS='offering AUDIO_PLAYBACK_LOSSY_DVC|reliable audio DVC negotiated|lossy audio DVC opened|DYNVC_SOFT_SYNC_REQUEST|Soft-Sync Response|streaming Wave2 audio over the LOSSY|lossy audio wave route over UDP tunnel failed|LOSSY delivery|SPIKE GREEN|P2\.1 GREEN|P2\.4 GREEN|CREATEREQUEST|CREATERESPONSE|cookie not recognized|RTO retransmit|Broken pipe|Connection reset|Connection error'
+MARKERS='offering AUDIO_PLAYBACK_LOSSY_DVC|reliable audio DVC negotiated|lossy audio DVC opened|DYNVC_SOFT_SYNC_REQUEST|Soft-Sync Response|streaming Wave2 audio over the LOSSY|lossy audio wave route over UDP tunnel failed|LOSSY delivery|duplicate source datagrams|SPIKE GREEN|P2\.1 GREEN|P2\.4 GREEN|CREATEREQUEST|CREATERESPONSE|cookie not recognized|RTO retransmit|Broken pipe|Connection reset|Connection error'
 
-echo "soak-lossy-audio: MACRDP_UDP_OFFER_FECL=$MACRDP_UDP_OFFER_FECL MACRDP_UDP_LOSSY_DELIVERY=$MACRDP_UDP_LOSSY_DELIVERY MACRDP_UDP_LOSSY_AUDIO=$MACRDP_UDP_LOSSY_AUDIO"
+echo "soak-lossy-audio: MACRDP_UDP_OFFER_FECL=$MACRDP_UDP_OFFER_FECL MACRDP_UDP_LOSSY_DELIVERY=$MACRDP_UDP_LOSSY_DELIVERY MACRDP_UDP_LOSSY_AUDIO=$MACRDP_UDP_LOSSY_AUDIO MACRDP_UDP_LOSSY_AUDIO_DUP=$MACRDP_UDP_LOSSY_AUDIO_DUP"
 if [ "$MACRDP_UDP_LOSSY_AUDIO" = "1" ]; then
     echo "soak-lossy-audio: mode = TREATMENT (audio over the lossy UDP/DTLS tunnel)"
 else
     echo "soak-lossy-audio: mode = CONTROL (audio on the static RDPSND TCP channel)"
+fi
+if [ "$MACRDP_UDP_LOSSY_AUDIO_DUP" = "1" ]; then
+    echo "soak-lossy-audio: redundancy = ON (1+1 duplicate source datagrams; P2.3 FEC pivot)"
 fi
 echo "soak-lossy-audio: binary=$MACRDP"
 echo "soak-lossy-audio: full log -> $SOAK_LOG (paste this if reporting)"

--- a/vendor/ironrdp-rdpeudp/CLAUDE.md
+++ b/vendor/ironrdp-rdpeudp/CLAUDE.md
@@ -35,6 +35,26 @@ root `cargo test`/`fmt --all` don't reach a non-member crate). `target/` and
 
 ## Milestone status
 
+- **P2.3 FEC pivot — 1+1 lossy duplicate sends (done, 2026-06-27):** real
+  Reed-Solomon FEC is structurally unavailable (a real-Windows capture shows modern
+  mstsc negotiates RDPUDP2, which has no FEC — see
+  `docs/rdp-udp-multitransport-feasibility.md` "P2.3 FEC capture RESULT"). This is
+  the protocol-safe stand-in: `Config` gained `duplicate_lossy_sends: bool` (default
+  `false`, so every existing caller is byte-identical). When set **and**
+  `mode == Lossy`, `pump()` pushes each new source datagram into `to_send` **twice**
+  — byte-identical, same sequence number — a repetition code so an independent-loss
+  link of rate `p` only costs the payload at `p²`. **De-dup is the upper layer's job,
+  NOT the transport's** (the lossy receiver deliberately does not dedup — it delivers
+  every arrival): in production the payload is a DTLS record and mstsc's DTLS
+  anti-replay window drops the identical-bytes duplicate, so the upper layer (audio)
+  never double-plays. Reliable mode ignores the flag (it has RTO retransmit instead).
+  Unit-tested: `lossy_duplicate_sends_emits_each_source_twice_byte_identical` (two
+  identical copies emitted), `lossy_without_duplicate_flag_sends_once` +
+  `reliable_ignores_duplicate_flag` (controls), and `lossy_receiver_does_not_dedup`
+  (documents *why* dedup must live above the transport). 50 crate tests. Wired in the
+  listener behind `MACRDP_UDP_LOSSY_AUDIO_DUP` (lossy flow only; see ironrdp-server
+  CLAUDE.md (12) P2.3).
+
 - **P2.2 step 1 — lossy delivery mode (done, 2026-06-27; SM logic only, NOT yet
   wired):** `Config` gained `mode: DeliveryMode { Reliable, Lossy }` (default
   `Reliable`, so every existing caller/test is byte-identical). In

--- a/vendor/ironrdp-rdpeudp/src/state.rs
+++ b/vendor/ironrdp-rdpeudp/src/state.rs
@@ -75,6 +75,18 @@ pub struct Config {
     /// Reliable (`UdpFecR`) vs lossy (`UdpFecL`) delivery policy. Defaults to
     /// [`DeliveryMode::Reliable`] so existing callers are unchanged.
     pub mode: DeliveryMode,
+    /// Lossy-only redundancy spike (P2.3 FEC pivot): emit each new source
+    /// datagram **twice** (same sequence number, same bytes) so that on an
+    /// independent-loss link of rate `p` a payload is lost only at `p²`. The
+    /// peer's RDPEUDP receiver de-duplicates by sequence number (the same
+    /// mechanism that drops a normal retransmit), so the upper layer never sees
+    /// the copy — no double-play. A poor-man's 1+1 repetition code standing in
+    /// for the structurally-unavailable Reed-Solomon FEC (modern Windows
+    /// negotiates RDPUDP2, which has no FEC — see
+    /// `docs/rdp-udp-multitransport-feasibility.md` "P2.3 FEC capture RESULT").
+    /// Ignored unless `mode == Lossy`. Default `false` (every existing caller is
+    /// byte-identical).
+    pub duplicate_lossy_sends: bool,
 }
 
 impl Default for Config {
@@ -85,6 +97,7 @@ impl Default for Config {
             initial_seq: 0,
             rto_ms: 300,
             mode: DeliveryMode::Reliable,
+            duplicate_lossy_sends: false,
         }
     }
 }
@@ -377,14 +390,22 @@ impl RdpeudpState {
             let payload: Vec<u8> = self.out_queue.drain(..take).collect();
             let seq = self.send_next;
             self.send_next = self.send_next.wrapping_add(1);
-            out.to_send.push(encode_data(
+            let datagram = encode_data(
                 self.recv_next,
                 self.have_peer_seq,
                 self.cfg.recv_window,
                 seq,
                 &payload,
                 ack_vector.clone(),
-            ));
+            );
+            // Lossy redundancy spike: ship a second identical copy (same seq) so
+            // independent loss only costs us at p². The peer de-dups by seq, so
+            // the upper layer never sees it. Reliable mode never duplicates (it
+            // has RTO retransmit instead).
+            if self.cfg.mode == DeliveryMode::Lossy && self.cfg.duplicate_lossy_sends {
+                out.to_send.push(datagram.clone());
+            }
+            out.to_send.push(datagram);
             // Reliable: track for RTO retransmit until acked. Lossy: send once and
             // forget (no retransmit) — `unacked` stays empty, so the window check
             // above never blocks and the retransmit loop is a no-op.
@@ -528,6 +549,7 @@ mod tests {
             initial_seq,
             rto_ms: 100,
             mode: DeliveryMode::Reliable,
+            duplicate_lossy_sends: false,
         }
     }
 
@@ -617,6 +639,7 @@ mod tests {
                 initial_seq: 0x61f7_b6e3,
                 rto_ms: 300,
                 mode: DeliveryMode::Reliable,
+                duplicate_lossy_sends: false,
             },
         );
         let out = server.step(0, Some(&client_syn));
@@ -866,5 +889,104 @@ mod tests {
         let out = server.step(now + rto * 10, None);
         assert_eq!(out.retransmits, 0);
         assert!(out.to_send.is_empty(), "still no resend much later");
+    }
+
+    /// Drive a lossy pair to established with `duplicate_lossy_sends` set on the
+    /// server, so its data emissions are 1+1 redundant.
+    fn handshook_lossy_dup() -> (RdpeudpState, RdpeudpState, u64) {
+        let mut client = RdpeudpState::new(Role::Client, cfg_lossy(1000));
+        let mut server = RdpeudpState::new(
+            Role::Server,
+            Config {
+                duplicate_lossy_sends: true,
+                ..cfg_lossy(9000)
+            },
+        );
+        let mut now = 0;
+        let o = client.start(now);
+        for dg in o.to_send {
+            let so = server.step(now, Some(&dg));
+            for back in so.to_send {
+                client.step(now, Some(&back));
+            }
+        }
+        now += 1;
+        assert!(client.is_established() && server.is_established());
+        (client, server, now)
+    }
+
+    /// P2.3 FEC pivot: with `duplicate_lossy_sends`, each source datagram is emitted
+    /// twice — byte-identical, same sequence number — a 1+1 repetition code so an
+    /// independent-loss link costs us only at p². De-duplication of the surviving
+    /// copy is the **upper layer's** job, not the transport's: in production the
+    /// payload is a DTLS record and mstsc's DTLS anti-replay window drops the
+    /// identical-bytes duplicate (the same self-dedup property `recv_source`'s lossy
+    /// branch relies on — see the control test `lossy_receiver_does_not_dedup`).
+    #[test]
+    fn lossy_duplicate_sends_emits_each_source_twice_byte_identical() {
+        let (_client, mut server, now) = handshook_lossy_dup();
+        // Small enough to be a single source packet, so the duplication is exact.
+        let data = data_only(server.enqueue(now, b"one aac access unit").to_send);
+        assert_eq!(
+            data.len(),
+            2,
+            "one source packet shipped as two identical copies"
+        );
+        assert_eq!(
+            data[0], data[1],
+            "the duplicate is byte-identical (same seq, same payload)"
+        );
+    }
+
+    /// Documents *why* duplication is safe only because the upper layer dedups: the
+    /// lossy receiver itself intentionally does NOT — it delivers every arrival
+    /// (no buffering/ordering is the whole point). So at the wire a duplicate seq is
+    /// delivered twice; the DTLS replay window above it drops the copy in production.
+    #[test]
+    fn lossy_receiver_does_not_dedup() {
+        let (mut client, mut recv, now) = handshook_lossy();
+        let data = data_only(client.enqueue(now, b"one aac access unit").to_send);
+        let first = recv.step(now, Some(&data[0]));
+        assert_eq!(first.delivered.len(), 1, "first copy delivers the payload");
+        let second = recv.step(now, Some(&data[0]));
+        assert_eq!(
+            second.delivered.len(),
+            1,
+            "the transport re-delivers the duplicate — dedup is the upper (DTLS) layer's job"
+        );
+    }
+
+    /// Control: without the flag a lossy sender emits each source packet once
+    /// (the default, byte-identical to every existing caller).
+    #[test]
+    fn lossy_without_duplicate_flag_sends_once() {
+        let (_client, mut server, now) = handshook_lossy();
+        let data = data_only(server.enqueue(now, b"one aac access unit").to_send);
+        assert_eq!(data.len(), 1, "no duplication when the flag is off");
+    }
+
+    /// The flag is lossy-only: a reliable sender never duplicates (it has RTO
+    /// retransmit instead), even if the flag is somehow set.
+    #[test]
+    fn reliable_ignores_duplicate_flag() {
+        let mut client = RdpeudpState::new(Role::Client, cfg(1000));
+        let mut server = RdpeudpState::new(
+            Role::Server,
+            Config {
+                duplicate_lossy_sends: true,
+                ..cfg(9000)
+            },
+        );
+        let mut now = 0;
+        let o = client.start(now);
+        for dg in o.to_send {
+            let so = server.step(now, Some(&dg));
+            for back in so.to_send {
+                client.step(now, Some(&back));
+            }
+        }
+        now += 1;
+        let data = data_only(server.enqueue(now, b"reliable payload").to_send);
+        assert_eq!(data.len(), 1, "reliable mode never duplicates");
     }
 }

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -727,3 +727,19 @@ AND released — #1276 landing is NOT sufficient.
     multitransport tunnel. All gated default-off (`MACRDP_UDP_OFFER_FECL` +
     `MACRDP_UDP_LOSSY_AUDIO`, + `--enable-aac` + `--enable-h264` since the Soft-Sync
     trigger rides the EGFX dispatch arm). See feasibility doc "P2.4b".
+
+    P2.3 — 1+1 lossy redundancy (the FEC pivot), 2026-06-27, `listener.rs`. Real
+    Reed-Solomon FEC is structurally unavailable (a real-Windows capture proved
+    modern mstsc negotiates RDPUDP2, which has no FEC — see feasibility doc "P2.3 FEC
+    capture RESULT"). The protocol-safe stand-in: behind the experimental env
+    `MACRDP_UDP_LOSSY_AUDIO_DUP` (read once at `run_recv_loop` top, value-aware via
+    `env_truthy`; default OFF), a **lossy** peer is built with the new `RdpeudpState`
+    `Config { duplicate_lossy_sends: true }` (ironrdp-rdpeudp P2.3), so each source
+    datagram it sends ships twice (same seq, byte-identical) → an independent-loss
+    link of rate `p` drops a payload only at `p²`. Scoped to the lossy flow
+    (`use_lossy && lossy_dup`); the reliable flow and the no-env default are
+    byte-unchanged. mstsc's DTLS anti-replay drops the duplicate, so audio never
+    double-plays (dedup lives above the transport — the lossy SM intentionally does
+    not dedup). This is the second soak A/B axis (dup vs no-dup at a fixed loss);
+    `scripts/soak-lossy-audio.sh` exposes it. Verification on a real lossy link is
+    pending (the spike is built + unit-tested; the soak run is the user's call).

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -447,6 +447,20 @@ async fn run_recv_loop(
         debug!("MACRDP_UDP_LOSSY_DELIVERY set — lossy (SYN_LOSSY) flows will use DeliveryMode::Lossy");
     }
 
+    // (P2.3 FEC pivot, EXPERIMENTAL) Real FEC is structurally unavailable (modern
+    // Windows negotiates RDPUDP2, which has no FEC — see the feasibility doc "P2.3
+    // FEC capture RESULT"). This is the protocol-safe stand-in: on a lossy flow,
+    // ship each source datagram twice (same seq) so an independent-loss link costs
+    // us only at p²; the peer de-dups by sequence number, so the upper layer (audio)
+    // never sees the copy. Only meaningful with MACRDP_UDP_LOSSY_DELIVERY (it needs
+    // the lossy SM); default OFF.
+    let lossy_dup = super::env_truthy("MACRDP_UDP_LOSSY_AUDIO_DUP");
+    if lossy_dup {
+        debug!(
+            "MACRDP_UDP_LOSSY_AUDIO_DUP set — lossy flows will duplicate each source datagram (1+1 redundancy)"
+        );
+    }
+
     // (Soak fix) Periodic clock for the reliability state machines. The SM only
     // retransmits / drains its send window when it's pumped (step/enqueue), and
     // those are otherwise driven solely by inbound datagrams or new outbound data.
@@ -555,6 +569,12 @@ async fn run_recv_loop(
             } else {
                 DeliveryMode::Reliable
             };
+            // 1+1 redundancy only applies to the lossy flow (the reliable SM has
+            // RTO retransmit instead and never duplicates).
+            let duplicate_lossy_sends = use_lossy && lossy_dup;
+            if duplicate_lossy_sends {
+                debug!(%peer_addr, "RDPEUDP lossy peer will duplicate source datagrams (MACRDP_UDP_LOSSY_AUDIO_DUP)");
+            }
             Peer {
                 sm: RdpeudpState::new(
                     Role::Server,
@@ -564,6 +584,7 @@ async fn run_recv_loop(
                         initial_seq,
                         rto_ms: cfg.rto_ms,
                         mode,
+                        duplicate_lossy_sends,
                     },
                 ),
                 inbound: Vec::new(),


### PR DESCRIPTION
## What

Real Reed-Solomon FEC is **structurally unavailable** — the P2.3 capture (PR #68) proved modern mstsc negotiates **RDPUDP2, which has no FEC**. This PR adds the protocol-safe stand-in: a **1+1 repetition code at the RDPEUDP transport**, behind the experimental env `MACRDP_UDP_LOSSY_AUDIO_DUP` (default OFF).

## How

- **`ironrdp-rdpeudp`**: `Config` gains `duplicate_lossy_sends: bool` (default `false`). When set **and** `mode == Lossy`, `pump()` emits each new source datagram **twice** — byte-identical, same sequence number. On an independent-loss link of rate `p`, a payload is then lost only at `p²` (5% → 0.25%).
- **`ironrdp-server` listener**: a **lossy** peer is built with the flag set behind `MACRDP_UDP_LOSSY_AUDIO_DUP` (value-aware; needs `MACRDP_UDP_LOSSY_DELIVERY`). Scoped to the lossy flow — the reliable flow and the no-env default build are byte-unchanged.

### Why transport-level, not "send each Wave2 PDU twice" (app-level)

App-level duplication puts two Wave2 PDUs with the **same `block_no`** on the wire and *relies on mstsc deduping by `block_no`* at the RDPSND layer — which MS-RDPEA never specifies, so it risks **double-play**. The transport copy is instead de-duplicated by **DTLS anti-replay**: the lossy tunnel is DTLS-encrypted (P2.4a), the duplicate datagram carries identical encrypted bytes = the same DTLS record seq, and mstsc's replay window drops it before RDPSND. The audio layer sees each AU once, guaranteed by a standard DTLS property. (RDPEUDP itself does **not** dedup in lossy mode — deliver-on-arrival is the point — so dedup must live above it; DTLS is that layer.)

## Tests

4 new `ironrdp-rdpeudp` unit tests: duplicate emitted byte-identical; flag-off + reliable-mode controls; and one documenting that the receiver does **not** dedup (i.e. why DTLS must). **50 crate + 70 workspace tests green**; clippy clean; fmt clean (workspace + standalone crate).

## Status / next

Built + unit-tested. **Real-link soak is the next step** (the user's call). `scripts/soak-lossy-audio.sh` exposes `MACRDP_UDP_LOSSY_AUDIO_DUP` as a second A/B axis (dup vs no-dup at a fixed `--loss`) to answer: does 1+1 redundancy close the 5%-loss audio gap on mstsc, or does residual `p²`/burst loss still stall the decoder?

### Caveat

Doubles the lossy flow's egress (audio only today — AAC ~128 kbit/s, cheap). Protects against *independent* single-packet loss; the two copies ship back-to-back, so a burst longer than the inter-copy gap can still drop both (time-staggering would harden that — deferred). It's repetition, not cross-packet FEC.