### PR TITLE
feat(h264): ack-driven IDR recovery for EGFX over a lossy UDP tunnel (env-gated, default OFF)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -828,6 +828,67 @@ On an independent-loss link of rate `p`, a payload is then lost only at `p²` (5
   or does the residual `p²` loss / burst loss still stall the AAC decoder? If yes → keep it (gated); if no →
   fall back to lever (2), document lossy-audio-over-mstsc as having no clean win.
 
+### Ack-driven IDR recovery (EGFX-on-lossy video) — MVP detection spec (scoped 2026-06-27)
+
+The video analogue of the lossy-audio problem: when EGFX H.264 rides the **lossy** tunnel
+(`MACRDP_UDP_MIGRATE_EGFX_LOSSY`), a dropped frame makes every subsequent P-frame undecodable (they
+reference the lost frame) → freeze/corruption until the next periodic IDR (≤ `--keyframe-interval`, default
+2 s). RDP has **no NACK** and the EGFX decoder expects whole frames, so codec-internal concealment isn't an
+option — but RDP *does* have `RDPGFX_FRAME_ACKNOWLEDGE`, so the server can **infer** loss from ack-staleness
+and force an IDR early (≈ RTT + timeout instead of up to 2 s). This is a *partial* mitigation, not graceful
+loss-tolerance — see caveats. (The real fixes — transport FEC, or LTR+NACK — are blocked/architecturally
+hard; see "P2.3 FEC capture RESULT" and the H.264-under-loss discussion.)
+
+**Why ack-staleness infers loss.** The client only acks frames it successfully decoded+presented. A
+slow-but-healthy client either keeps acking (slowly) or suspends acks under load
+(`queueDepth == 0xFFFFFFFF`). **True loss** is the one case where we keep shipping but acks stop *entirely*
+(the client is stuck on the gap, nothing new to ack). So "actively shipping + acks went silent" ≈ loss.
+
+**MVP detection (wall-clock ack-staleness; no frame-id matching, no timer thread).**
+Per-connection state in `ConnectionContext` (`src/h264.rs`), all reset on reconnect, init to `now`:
+`last_ack_at` (set in `on_frame_ack`), `acks_suspended` (= `queueDepth == 0xFFFFFFFF`, set in
+`on_frame_ack`), `last_ship_at` (set in the ship loop), `last_recovery_at`, and `egfx_on_lossy` (a shared
+`Arc<AtomicBool>` the vendored server sets true when it migrates EGFX onto the **lossy** tunnel — mirrors
+the `udp_tunnel_bound` shared-flag pattern). The pure, unit-testable predicate (takes `Duration`s so tests
+need no real clock):
+
+```
+should_force_recovery_idr(since_ship, since_ack, since_recovery, acks_suspended, egfx_on_lossy, p) =
+       egfx_on_lossy                         // ❶ lossy tunnel only (reliable/TCP: missing ack = congestion)
+    && !acks_suspended                       // ❷ acks must be on to infer loss
+    && since_ship      <= p.active_window     // ❸ we're actively shipping frames
+    && since_ack       >= p.ack_stall         // ❹ but acks went silent → inferred loss
+    && since_recovery  >= p.min_recovery_interval  // ❺ rate-limit IDR storms
+```
+
+Checked in `submit_bgra` (runs per capture tick **and** per flush-burst re-submit — so a loss just before
+the screen goes static still heals during the flush window); on true, set the existing `need_keyframe = true`
+(one-shot, already consumed by the next encode) and `last_recovery_at = now`. No new IDR path or timer
+thread; the periodic `--keyframe-interval` IDR backstops the rare tail.
+
+MVP params (60 fps defaults, env-tunable): `ack_stall` 200 ms (`MACRDP_UDP_EGFX_ACK_STALL_MS`),
+`active_window` 500 ms (`MACRDP_UDP_EGFX_ACK_ACTIVE_MS` — covers the flush window),
+`min_recovery_interval` 1000 ms (`MACRDP_UDP_EGFX_ACK_RECOVERY_MS`). Whole feature behind
+`MACRDP_UDP_EGFX_ACK_RECOVERY` (default OFF) **and** the runtime `egfx_on_lossy` gate; feature-off keeps
+`on_frame_ack` trace-only and the path byte-identical.
+
+**Caveats (why it's a narrow, partial mitigation):** (1) lossy-EGFX-only — on TCP / the reliable tunnel a
+missing ack means congestion and an IDR would *worsen* it, so the `egfx_on_lossy` gate is load-bearing;
+(2) the recovery IDR is itself loss-vulnerable (a big frame on a lossy link), so it can fail and retrigger
+— `min_recovery_interval` bounds the storm; (3) acks ride the same lossy tunnel, so a lost ack is a
+false-positive source — the staleness *window* + rate-limit absorb the occasional one; (4) incremental over
+the periodic IDR (≤2 s → ~RTT+`ack_stall`); (5) mstsc-only. **Build status (2026-06-27):** IMPLEMENTED
+behind the env gate, default OFF. `src/h264.rs` has the pure predicate `should_force_recovery_idr` +
+`recovery_config_from_env` (7 unit tests covering each gate, threshold-inclusivity, and the lossy/reliable
+split), the `ConnectionContext` state (`last_ack_at`/`acks_suspended`/`last_ship_at`/`last_recovery_at`),
+the `on_frame_ack` + `ship_frames` stamping, and the `submit_bgra` check (logs `EGFX ack-stall on lossy
+tunnel — forcing recovery IDR`). The vendored `ironrdp-server` flips the shared `egfx_on_lossy` flag at the
+EGFX→UDPFECL Soft-Sync site (`set_egfx_on_lossy_handle`, server.rs); `main.rs` creates the `Arc<AtomicBool>`
+and wires both ends. Feature-off path is byte-identical (only cheap `Instant::now()` stamps run). **Verify
+status:** real-link soak PENDING (the user's call, like P2.3) — verify on mstsc + `MACRDP_UDP_MIGRATE_EGFX_LOSSY`
++ `MACRDP_UDP_EGFX_ACK_RECOVERY` + induced loss (A/B vs the feature off; confirm the recovery-IDR marker
+fires and recovery beats the periodic interval).
+
 - **P2.4a — MS-RDPEMT tunnel over DTLS (DONE, GREEN 2026-06-26).** The prerequisite
   for any lossy channel: decrypt the client's DTLS application records, answer its
   `RDP_TUNNEL_CREATEREQUEST` with a `CREATERESPONSE(S_OK)` re-encrypted through DTLS,

--- a/src/h264.rs
+++ b/src/h264.rs
@@ -48,9 +48,9 @@
 
 #![cfg(target_os = "macos")]
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use ironrdp_dvc::encode_dvc_messages;
@@ -134,6 +134,79 @@ struct ConnectionContext {
     /// `SharedDesktopSize` read — so a size adoption between setup and ship
     /// can't tear the region away from the surface.
     dims: (u16, u16),
+    /// Ack-driven IDR recovery state (EGFX-on-lossy). Wall-clock; per-connection
+    /// (reset on reconnect), all init to `now` so warmup doesn't false-trigger.
+    /// `last_ack_at` + `acks_suspended` set in `on_frame_ack`; `last_ship_at` set
+    /// in `ship_frames`; `last_recovery_at` set when a recovery IDR is armed in
+    /// `submit_bgra`. See [`should_force_recovery_idr`].
+    last_ack_at: Instant,
+    acks_suspended: bool,
+    last_ship_at: Instant,
+    last_recovery_at: Instant,
+}
+
+/// Tunables for ack-driven IDR recovery (EGFX-on-lossy). See
+/// [`should_force_recovery_idr`] and `docs/rdp-udp-multitransport-feasibility.md`
+/// ("Ack-driven IDR recovery").
+#[derive(Clone, Copy, Debug)]
+struct RecoveryParams {
+    /// We only treat silent acks as loss while we're *actively* shipping — if the
+    /// last ship is older than this, the screen is static and the periodic IDR
+    /// backstops. Sized to cover the flush-burst window so a loss just before the
+    /// screen goes static still heals.
+    active_window: Duration,
+    /// How long acks must stay silent (while shipping) before we infer a lost
+    /// frame. Above normal ack jitter + RTT, below the periodic keyframe interval.
+    ack_stall: Duration,
+    /// Minimum spacing between forced recovery IDRs — the IDR is large and itself
+    /// loss-vulnerable, so don't storm them if it keeps getting lost.
+    min_recovery_interval: Duration,
+}
+
+/// Decide whether to force a recovery IDR from ack-staleness. Pure (takes
+/// `Duration`s, not a clock) so it's unit-testable without timing. See the spec
+/// in `docs/rdp-udp-multitransport-feasibility.md` — each clause guards a distinct
+/// failure mode:
+/// - `egfx_on_lossy`: only on the lossy tunnel; on TCP/reliable a missing ack is
+///   congestion and an IDR would *worsen* it.
+/// - `!acks_suspended`: with acks off (`queueDepth==0xFFFFFFFF`) loss is uninferable.
+/// - `since_ship <= active_window`: only while actively shipping (else: static screen).
+/// - `since_ack >= ack_stall`: the loss signal — acks went silent.
+/// - `since_recovery >= min_recovery_interval`: rate-limit IDR storms.
+fn should_force_recovery_idr(
+    since_ship: Duration,
+    since_ack: Duration,
+    since_recovery: Duration,
+    acks_suspended: bool,
+    egfx_on_lossy: bool,
+    p: &RecoveryParams,
+) -> bool {
+    egfx_on_lossy
+        && !acks_suspended
+        && since_ship <= p.active_window
+        && since_ack >= p.ack_stall
+        && since_recovery >= p.min_recovery_interval
+}
+
+/// Read the ack-recovery config from the environment once. Returns
+/// `(enabled, params)`; disabled (default) keeps the feature off and the path
+/// byte-identical. Tunables: `MACRDP_UDP_EGFX_ACK_STALL_MS` (200),
+/// `MACRDP_UDP_EGFX_ACK_ACTIVE_MS` (500), `MACRDP_UDP_EGFX_ACK_RECOVERY_MS` (1000).
+fn recovery_config_from_env() -> (bool, RecoveryParams) {
+    let ms = |name: &str, default: u64| -> Duration {
+        let v = std::env::var(name)
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .unwrap_or(default);
+        Duration::from_millis(v)
+    };
+    let enabled = crate::multitransport::env_truthy("MACRDP_UDP_EGFX_ACK_RECOVERY");
+    let params = RecoveryParams {
+        active_window: ms("MACRDP_UDP_EGFX_ACK_ACTIVE_MS", 500),
+        ack_stall: ms("MACRDP_UDP_EGFX_ACK_STALL_MS", 200),
+        min_recovery_interval: ms("MACRDP_UDP_EGFX_ACK_RECOVERY_MS", 1000),
+    };
+    (enabled, params)
 }
 
 /// Cloneable factory + frame-submit handle. One clone is boxed into
@@ -162,6 +235,14 @@ pub struct Gfx {
     /// so encoded frames are never dropped, which would break the H.264 chain).
     max_in_flight: u32,
     wire_format: WireFormat,
+    /// Ack-driven IDR recovery (EGFX-on-lossy). `recovery_enabled` is the opt-in
+    /// env gate (`MACRDP_UDP_EGFX_ACK_RECOVERY`); `egfx_on_lossy` is the *runtime*
+    /// gate the vendored server flips true when it migrates EGFX onto the lossy
+    /// tunnel. Both must hold for `submit_bgra` to arm a recovery IDR. Default-off
+    /// → byte-identical to the pre-feature path.
+    recovery_enabled: bool,
+    recovery_params: RecoveryParams,
+    egfx_on_lossy: Arc<AtomicBool>,
 }
 
 impl Gfx {
@@ -171,13 +252,22 @@ impl Gfx {
         bitrate_bps: u32,
         keyframe_secs: f32,
         max_in_flight: u32,
+        egfx_on_lossy: Arc<AtomicBool>,
     ) -> Self {
         let wire_format = WireFormat::from_env();
+        let (recovery_enabled, recovery_params) = recovery_config_from_env();
         let (width, height) = desktop_size.get();
         info!(
             ?wire_format,
             width, height, fps, keyframe_secs, max_in_flight, "EGFX/H.264 pipeline configured"
         );
+        if recovery_enabled {
+            info!(
+                ?recovery_params,
+                "EGFX ack-driven IDR recovery ENABLED (MACRDP_UDP_EGFX_ACK_RECOVERY) — \
+                 active only while EGFX is on the lossy UDP tunnel"
+            );
+        }
         Self {
             sender: Arc::new(Mutex::new(None)),
             ctx: Arc::new(Mutex::new(None)),
@@ -187,6 +277,9 @@ impl Gfx {
             keyframe_secs,
             max_in_flight,
             wire_format,
+            recovery_enabled,
+            recovery_params,
+            egfx_on_lossy,
         }
     }
 
@@ -223,6 +316,32 @@ impl Gfx {
             // frame (the change is still on screen by then).
             if request_keyframe {
                 ctx.need_keyframe = true;
+            }
+            // Ack-driven IDR recovery (opt-in, EGFX-on-lossy only): if acks have
+            // gone silent while we're actively shipping, infer a lost frame and arm
+            // an IDR so the client recovers without waiting for the periodic
+            // keyframe. Armed BEFORE the throttle so a dropped capture still carries
+            // the IDR forward (need_keyframe persists across skips). No-op unless
+            // both the env gate and the runtime lossy-tunnel gate hold → default
+            // path unchanged.
+            if self.recovery_enabled {
+                let now = Instant::now();
+                let since_ack = now.saturating_duration_since(ctx.last_ack_at);
+                if should_force_recovery_idr(
+                    now.saturating_duration_since(ctx.last_ship_at),
+                    since_ack,
+                    now.saturating_duration_since(ctx.last_recovery_at),
+                    ctx.acks_suspended,
+                    self.egfx_on_lossy.load(Ordering::Relaxed),
+                    &self.recovery_params,
+                ) {
+                    ctx.need_keyframe = true;
+                    ctx.last_recovery_at = now;
+                    info!(
+                        since_ack_ms = since_ack.as_millis() as u64,
+                        "EGFX ack-stall on lossy tunnel — forcing recovery IDR"
+                    );
+                }
             }
             // Lazy one-time setup on the first ready frame (creates the encoder
             // and spawns the ship thread).
@@ -384,6 +503,8 @@ impl Gfx {
                 .ok_or_else(|| anyhow!("EGFX: no surface_id"))?;
             let (width, height) = ctx.dims;
             let epoch = ctx.epoch;
+            // Liveness for ack-driven IDR recovery: we're actively shipping.
+            ctx.last_ship_at = Instant::now();
             let mut server = ctx.server_handle.lock().unwrap();
             let egfx_channel_id = server
                 .channel_id()
@@ -534,6 +655,10 @@ impl GfxServerFactory for Gfx {
             submitted: Arc::new(AtomicU64::new(0)),
             shipped: Arc::new(AtomicU64::new(0)),
             dims: (0, 0),
+            last_ack_at: Instant::now(),
+            acks_suspended: false,
+            last_ship_at: Instant::now(),
+            last_recovery_at: Instant::now(),
         });
         Some((GfxDvcBridge::new(handle.clone()), handle))
     }
@@ -631,6 +756,13 @@ impl GraphicsPipelineHandler for GfxHandler {
 
     fn on_frame_ack(&mut self, frame_id: u32, queue_depth: u32) {
         trace!(frame_id, queue_depth, "EGFX frame ack");
+        // Feed ack-driven IDR recovery (EGFX-on-lossy): record liveness, and note
+        // whether the client suspended acks (queueDepth == SUSPEND_FRAME_
+        // ACKNOWLEDGEMENT 0xFFFFFFFF) — with acks off, loss can't be inferred.
+        if let Some(ctx) = self.ctx.lock().unwrap().as_mut() {
+            ctx.last_ack_at = Instant::now();
+            ctx.acks_suspended = queue_depth == 0xFFFF_FFFF;
+        }
     }
 
     /// Inbound `RDPGFX_CACHE_IMPORT_OFFER`. Behavior is UNCHANGED from the trait
@@ -741,6 +873,122 @@ fn avcc_to_annex_b(avcc: &[u8], parameter_sets: &[Vec<u8>], is_keyframe: bool) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn recovery_params() -> RecoveryParams {
+        RecoveryParams {
+            active_window: Duration::from_millis(500),
+            ack_stall: Duration::from_millis(200),
+            min_recovery_interval: Duration::from_millis(1000),
+        }
+    }
+
+    // Convenience: build a Duration in ms for the table below.
+    fn ms(v: u64) -> Duration {
+        Duration::from_millis(v)
+    }
+
+    #[test]
+    fn recovery_fires_on_ack_stall_while_shipping_on_lossy() {
+        let p = recovery_params();
+        // Actively shipping (30ms), acks silent (300ms > 200), past rate-limit
+        // (5s), acks not suspended, EGFX on the lossy tunnel → force a recovery IDR.
+        assert!(should_force_recovery_idr(
+            ms(30),
+            ms(300),
+            ms(5000),
+            false,
+            true,
+            &p
+        ));
+    }
+
+    #[test]
+    fn recovery_suppressed_when_acks_suspended() {
+        let p = recovery_params();
+        // queueDepth==0xFFFFFFFF → acks_suspended: loss can't be inferred.
+        assert!(!should_force_recovery_idr(
+            ms(30),
+            ms(300),
+            ms(5000),
+            true,
+            true,
+            &p
+        ));
+    }
+
+    #[test]
+    fn recovery_never_on_reliable_or_tcp() {
+        let p = recovery_params();
+        // egfx_on_lossy=false (TCP / reliable tunnel): a missing ack is congestion,
+        // not loss — an IDR would worsen it, so never fire.
+        assert!(!should_force_recovery_idr(
+            ms(30),
+            ms(300),
+            ms(5000),
+            false,
+            false,
+            &p
+        ));
+    }
+
+    #[test]
+    fn recovery_not_when_acks_fresh() {
+        let p = recovery_params();
+        // since_ack (50ms) below ack_stall (200ms): acks still flowing, no loss.
+        assert!(!should_force_recovery_idr(
+            ms(30),
+            ms(50),
+            ms(5000),
+            false,
+            true,
+            &p
+        ));
+    }
+
+    #[test]
+    fn recovery_not_when_idle_not_shipping() {
+        let p = recovery_params();
+        // since_ship (2s) above active_window (500ms): static screen, nothing to
+        // lose — the periodic IDR backstops; don't force.
+        assert!(!should_force_recovery_idr(
+            ms(2000),
+            ms(300),
+            ms(5000),
+            false,
+            true,
+            &p
+        ));
+    }
+
+    #[test]
+    fn recovery_rate_limited() {
+        let p = recovery_params();
+        // since_recovery (200ms) below min_recovery_interval (1000ms): just forced
+        // one; don't storm IDRs even if acks are still silent.
+        assert!(!should_force_recovery_idr(
+            ms(30),
+            ms(300),
+            ms(200),
+            false,
+            true,
+            &p
+        ));
+    }
+
+    #[test]
+    fn recovery_thresholds_are_inclusive() {
+        let p = recovery_params();
+        // Exactly at the boundaries: since_ship == active_window (<=), since_ack ==
+        // ack_stall (>=), since_recovery == min_recovery_interval (>=) → fires.
+        assert!(should_force_recovery_idr(
+            ms(500),
+            ms(200),
+            ms(1000),
+            false,
+            true,
+            &p
+        ));
+    }
 
     #[test]
     fn avcc_to_annex_b_rewrites_length_prefixes() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1989,6 +1989,12 @@ async fn async_main() -> Result<()> {
         None
     };
 
+    // Shared flag flipped true when EGFX is Soft-Synced onto a LOSSY UDP tunnel
+    // (UDPFECL). The H.264 pipeline reads it to arm ack-driven IDR recovery; the
+    // server flips it at the migration site. Cross-platform so the UDP listener
+    // wiring below (which hands the same clone to the server) compiles on CI.
+    let egfx_on_lossy_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
     // EGFX/H.264 video pipeline (macOS-only; opt-in via --enable-h264). One
     // clone drives the builder's GfxServerFactory (protocol side); another
     // rides on CaptureDisplay, where the capture loop feeds it BGRA frames.
@@ -2000,6 +2006,7 @@ async fn async_main() -> Result<()> {
             args.bitrate.max(1).saturating_mul(1_000_000),
             args.keyframe_interval,
             args.h264_frames_in_flight.max(1),
+            egfx_on_lossy_flag.clone(),
         )
     });
 
@@ -2202,6 +2209,10 @@ async fn async_main() -> Result<()> {
                     .set_multitransport_provider(Some(Box::new(multitransport::MacMultitransport)));
                 server.set_multitransport_cookie_registry(Some(cookie_registry));
                 server.set_multitransport_tunnel_sender(Some(tunnel_sender));
+                // Ack-driven IDR recovery (EGFX-on-lossy): hand the server the same
+                // flag the H.264 pipeline reads. The server flips it true only when
+                // it migrates EGFX onto the LOSSY tunnel.
+                server.set_egfx_on_lossy_handle(Some(egfx_on_lossy_flag.clone()));
                 // (P2.4b, EXPERIMENTAL) Register the lossy-UDP audio DVC
                 // (AUDIO_PLAYBACK_LOSSY_DVC). Behind its OWN dedicated env gate
                 // (`MACRDP_UDP_LOSSY_AUDIO=1`) — NOT the lossy-offer flag — so the

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -743,3 +743,14 @@ AND released — #1276 landing is NOT sufficient.
     not dedup). This is the second soak A/B axis (dup vs no-dup at a fixed loss);
     `scripts/soak-lossy-audio.sh` exposes it. Verification on a real lossy link is
     pending (the spike is built + unit-tested; the soak run is the user's call).
+
+    Ack-driven IDR recovery support (2026-06-27): `RdpServer` gained
+    `egfx_on_lossy_handle: Option<Arc<AtomicBool>>` + setter
+    `set_egfx_on_lossy_handle` (mirrors the `udp_tunnel_bound` / handle-setter
+    pattern). At the EGFX Soft-Sync site, when EGFX is migrated onto the **lossy**
+    tunnel (`TUNNELTYPE_UDPFECL`, non-empty channel list) the flag is flipped true
+    so macrdp's H.264 pipeline can arm ack-driven IDR recovery (the codec-side
+    detection lives in `src/h264.rs`; the server only publishes the on-lossy state).
+    On the reliable tunnel / TCP the flag stays false. All `multitransport`-gated;
+    feature-off and the no-migration path are byte-unchanged. See the feasibility
+    doc "Ack-driven IDR recovery (EGFX-on-lossy video)".

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -399,6 +399,13 @@ pub struct RdpServer {
     /// path leaves EGFX on TCP (the proven empty-Soft-Sync spike).
     #[cfg(feature = "multitransport")]
     egfx_on_udp: bool,
+    /// Shared flag the macrdp-side EGFX/H.264 pipeline reads for ack-driven IDR
+    /// recovery: set true once EGFX has been migrated onto the **lossy** tunnel
+    /// (`MACRDP_UDP_MIGRATE_EGFX_LOSSY`), where a dropped frame is real loss the
+    /// client can't retransmit away. On the reliable tunnel / TCP it stays false
+    /// (a missing ack there is congestion, not loss). `None` = not wired (default).
+    #[cfg(feature = "multitransport")]
+    egfx_on_lossy_handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     /// (M5c step 3b) Receiver for inbound migrated-channel data the UDP listener
     /// forwards (each item is a bare DRDYNVC PDU — HigherLayerData of an inbound
     /// `RDP_TUNNEL_DATA`, e.g. an EGFX frame ack). Created + registered (with the
@@ -534,6 +541,8 @@ impl RdpServer {
             #[cfg(feature = "multitransport")]
             udp_tunnel_bound: None,
             #[cfg(feature = "multitransport")]
+            egfx_on_lossy_handle: None,
+            #[cfg(feature = "multitransport")]
             multitransport_tunnel_sender: None,
             #[cfg(feature = "multitransport")]
             egfx_on_udp: false,
@@ -634,6 +643,16 @@ impl RdpServer {
     #[cfg(feature = "multitransport")]
     pub fn set_multitransport_tunnel_sender(&mut self, sender: Option<crate::multitransport::TunnelSender>) {
         self.multitransport_tunnel_sender = sender;
+    }
+
+    /// Supply the shared flag that signals "EGFX is migrated onto a **lossy** UDP
+    /// tunnel" (UDPFECL, where datagrams can actually be dropped). macrdp's H.264
+    /// pipeline reads it to arm ack-driven IDR recovery — on a reliable transport
+    /// (TCP or UDPFECR) the flag stays `false` so recovery never fires. The server
+    /// flips it `true` when it Soft-Syncs the EGFX DVC onto the lossy tunnel.
+    #[cfg(feature = "multitransport")]
+    pub fn set_egfx_on_lossy_handle(&mut self, handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>) {
+        self.egfx_on_lossy_handle = handle;
     }
 
     /// (P2.4b) Supply the audio format list for the lossy-UDP `AUDIO_PLAYBACK_LOSSY_DVC`
@@ -1747,6 +1766,16 @@ impl RdpServer {
         } else {
             dvc::pdu::TUNNELTYPE_UDPFECR
         };
+        // Signal macrdp's H.264 pipeline that EGFX is now riding a LOSSY tunnel
+        // (UDPFECL, where datagrams can be dropped) so it can arm ack-driven IDR
+        // recovery. Only when EGFX is actually migrated (non-empty channel list)
+        // AND the target is the lossy tunnel; the reliable tunnel never drops, so
+        // the flag stays false there.
+        if egfx_tunnel_type == dvc::pdu::TUNNELTYPE_UDPFECL && !channel_ids.is_empty() {
+            if let Some(handle) = &self.egfx_on_lossy_handle {
+                handle.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
         debug!("UDP tunnel bound + EGFX active — Soft-Sync gate open");
         self.send_soft_sync_request(writer, user_channel_id, egfx_tunnel_type, channel_ids)
             .await


### PR DESCRIPTION
## What

When EGFX H.264 rides the **lossy** UDP tunnel (`MACRDP_UDP_MIGRATE_EGFX_LOSSY`), a dropped frame makes every subsequent P-frame undecodable (they reference the lost frame) → freeze/corruption until the next periodic IDR (up to `--keyframe-interval`, default 2 s). RDP has **no NACK** and the EGFX decoder expects whole frames, so codec-internal concealment isn't an option — but RDP *does* carry `RDPGFX_FRAME_ACKNOWLEDGE`, so the server can **infer** loss from ack-staleness and force an IDR early (≈ RTT + timeout instead of up to 2 s).

This is a *partial* mitigation, not graceful loss-tolerance (the real fixes — transport FEC, or LTR+NACK — are blocked/architecturally hard; see the feasibility doc).

## How

**Detection (`src/h264.rs`).** Pure, unit-testable predicate (takes `Duration`s so tests need no clock):

```
should_force_recovery_idr(since_ship, since_ack, since_recovery, acks_suspended, egfx_on_lossy, p) =
       egfx_on_lossy                          // lossy tunnel only (reliable/TCP: missing ack = congestion)
    && !acks_suspended                        // acks must be on (queueDepth != 0xFFFFFFFF)
    && since_ship      <= p.active_window      // we're actively shipping
    && since_ack       >= p.ack_stall          // but acks went silent → inferred loss
    && since_recovery  >= p.min_recovery_interval  // rate-limit IDR storms
```

Checked in `submit_bgra` (per capture tick **and** per flush-burst re-submit, so a loss just before the screen goes static still heals during the flush window); on true it sets the existing one-shot `need_keyframe`. No new IDR path, no timer thread; the periodic `--keyframe-interval` IDR backstops the tail.

State lives in `ConnectionContext` (reset on reconnect): `last_ack_at` / `acks_suspended` (set in `on_frame_ack`), `last_ship_at` (ship loop), `last_recovery_at`.

**Wiring.** Vendored `ironrdp-server` gains `egfx_on_lossy_handle` + `set_egfx_on_lossy_handle` and flips the shared `Arc<AtomicBool>` true at the EGFX→`UDPFECL` Soft-Sync site (false on the reliable tunnel / TCP). `main.rs` creates the Arc and hands the same clone to `h264::Gfx::new` and the server.

## Gating / safety

- Whole feature behind `MACRDP_UDP_EGFX_ACK_RECOVERY` (default **OFF**) **and** the runtime `egfx_on_lossy` gate.
- Feature-off path is byte-identical (only cheap `Instant::now()` stamps run; `on_frame_ack` stays trace-only).
- Params env-tunable: `ack_stall` 200 ms (`MACRDP_UDP_EGFX_ACK_STALL_MS`), `active_window` 500 ms (`MACRDP_UDP_EGFX_ACK_ACTIVE_MS`), `min_recovery_interval` 1000 ms (`MACRDP_UDP_EGFX_ACK_RECOVERY_MS`).

## Tests

7 new unit tests in `src/h264.rs` cover each gate, threshold-inclusivity, and the lossy-vs-reliable/TCP split. Full suite green (77 passed), `clippy --all-targets -D warnings` clean, `cargo fmt` applied.

## Verify status

Real-link soak **pending** (the user's call, like P2.3): verify on mstsc + `MACRDP_UDP_MIGRATE_EGFX_LOSSY` + `MACRDP_UDP_EGFX_ACK_RECOVERY` + induced loss (A/B vs the feature off; confirm the recovery-IDR marker fires and recovery beats the periodic interval).