### PR TITLE
feat(h264): Long-Term Reference (LTR) loss recovery for EGFX over the lossy UDP tunnel (env-gated, default OFF)

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -889,6 +889,59 @@ status:** real-link soak PENDING (the user's call, like P2.3) — verify on msts
 + `MACRDP_UDP_EGFX_ACK_RECOVERY` + induced loss (A/B vs the feature off; confirm the recovery-IDR marker
 fires and recovery beats the periodic interval).
 
+### LTR recovery (Long-Term Reference frames) — the cheap upgrade to the IDR recovery (implemented 2026-06-27)
+
+The ack-driven IDR recovery above heals a lost frame, but its recovery action is a **full IDR** — large,
+itself loss-vulnerable, and a bitrate spike. The standard RTC fix (WebRTC/Zoom) is **Long-Term Reference
+frames**: the encoder periodically marks frames as LTR, the receiver's per-frame ACKs tell the encoder which
+LTRs actually arrived, and on detected loss the encoder codes a **P-frame referencing the last *acknowledged*
+LTR** instead of an IDR — a fraction of the bytes, far more likely to survive the lossy link. RDP is a
+natural fit: `RDPGFX_FRAME_ACKNOWLEDGE` *is* the per-frame received-signal LTR needs, and we already track it
+(for the IDR recovery). This is a strict upgrade — same ack-stall trigger, cheaper recovery.
+
+**Why LTR (temporal) and not spatial resilience.** On the lossy tunnel, RDPEUDP-lossy delivers a **whole-frame
+gap**, not a corrupt frame (a frame's fragments either fully reassemble or the frame is never delivered) — so
+the decoder sees a *missing* frame, never a *damaged* one. That moots every spatial H.264 tool (slices,
+data-partitioning, redundant slices, constrained-intra): they only help a decoder doing partial-frame
+concealment, which never happens here. Only **temporal** recovery (reference an older good frame, or refresh)
+addresses a missing frame. GDR / cyclic intra-refresh — the ideal "no IDR spike" tool — is **not reachable**:
+VideoToolbox exposes no public intra-refresh property (verified against the SDK headers).
+
+**VideoToolbox API (macOS 12+, confirmed in the SDK).** `kVTCompressionPropertyKey_EnableLTR` turns it on;
+each LTR frame emits `kVTSampleAttachmentKey_RequireLTRAcknowledgementToken` (a CFNumber); acked tokens are
+fed back via `kVTEncodeFrameOptionKey_AcknowledgedLTRTokens`; `kVTEncodeFrameOptionKey_ForceLTRRefresh` codes
+the recovery P-frame (VT falls back to an IDR itself if no LTR has been acked yet — so a cold start is safe).
+
+**Implementation (all in macrdp — no vendor change), behind `MACRDP_UDP_EGFX_LTR` (default OFF):**
+- `src/videotoolbox.rs`: `Encoder::new` gains `enable_ltr` + `ltr_low_latency`; `create_session` sets
+  `EnableLTR` (best-effort — if a VT/HW combo rejects it, the encoder still works and recovery degrades to a
+  normal IDR) and, when `ltr_low_latency`, builds the encoder spec with
+  `EnableLowLatencyRateControl`. `EncodedFrame` gains `ltr_token: Option<i64>` read from the sample
+  attachment. New methods `acknowledge_ltr_tokens` / `request_ltr_refresh` / `ltr_enabled` feed per-frame
+  options into the next encode. Frame-properties dict generalized to carry ForceKeyFrame + ForceLTRRefresh +
+  AcknowledgedLTRTokens together (null dict on the default path → byte-identical).
+- `src/h264.rs`: `Gfx` reads `MACRDP_UDP_EGFX_LTR` (implies `recovery_enabled` — LTR needs the same ack-stall
+  trigger) + `MACRDP_UDP_EGFX_LTR_LOWLATENCY`. `ConnectionContext` gains `ltr_tokens: BTreeMap<frame_id,
+  token>` (bounded `MAX_TRACKED_LTR_TOKENS=64`): `ship_frames` records the map when a shipped frame carried a
+  token; `on_frame_ack(frame_id)` feeds the matching token back to the encoder as acknowledged. The
+  `submit_bgra` recovery action becomes `request_ltr_refresh()` when LTR is on (logs `EGFX ack-stall on lossy
+  tunnel — forcing LTR refresh`), else the existing IDR.
+- No `main.rs` change — entirely env-driven inside `h264.rs`.
+
+**Tests:** 2 new `videotoolbox` unit tests — LTR-enabled encoder still produces valid frames (ack-arbitrary +
+force-refresh are safe), and LTR-off frames never carry a token (default path unaffected). VT accepts
+`EnableLTR` and keeps encoding on the dev/CI macOS.
+
+**The make-or-break risk (must be live-tested):** whether mstsc's / FreeRDP's **AVC420** decoder correctly
+handles a P-frame that references a long-term reference (ref-pic-list modification + MMCO marking). LTR is
+standard-conformant H.264, but AVC420-over-EGFX is a constrained profile and the MS decoder *may* assume each
+P references the immediately-previous frame; if it chokes → corruption, and we revert to the IDR path. The
+`MACRDP_UDP_EGFX_LTR_LOWLATENCY` lever exists in case a given VT/HW only emits LTR tokens under the
+low-latency rate controller. **Verify status:** real-client soak PENDING (the user's call) — mstsc +
+`MACRDP_UDP_MIGRATE_EGFX_LOSSY` + `MACRDP_UDP_EGFX_LTR` + induced loss; watch for `forcing LTR refresh` +
+`EGFX LTR frame acknowledged to encoder` and confirm the picture stays clean under loss (and doesn't corrupt,
+which would mean the decoder rejects LTR refs → fall back to the IDR recovery).
+
 - **P2.4a — MS-RDPEMT tunnel over DTLS (DONE, GREEN 2026-06-26).** The prerequisite
   for any lossy channel: decrypt the client's DTLS application records, answer its
   `RDP_TUNNEL_CREATEREQUEST` with a `CREATERESPONSE(S_OK)` re-encrypted through DTLS,

--- a/src/h264.rs
+++ b/src/h264.rs
@@ -48,6 +48,7 @@
 
 #![cfg(target_os = "macos")]
 
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -97,6 +98,11 @@ impl WireFormat {
     }
 }
 
+/// Cap on the `frame_id → LTR token` map (LTR mode). LTR frames are emitted by
+/// VideoToolbox only periodically, so this is generous; it exists purely so a
+/// client that never acks can't grow the map without bound.
+const MAX_TRACKED_LTR_TOKENS: usize = 64;
+
 /// Per-connection state, shared between the `Gfx` factory/handle (capture
 /// side) and the `GfxHandler` callbacks (protocol side) via `Arc<Mutex<>>`.
 struct ConnectionContext {
@@ -143,6 +149,13 @@ struct ConnectionContext {
     acks_suspended: bool,
     last_ship_at: Instant,
     last_recovery_at: Instant,
+    /// LTR mode (`MACRDP_UDP_EGFX_LTR`): maps an EGFX `frame_id` (what the client
+    /// acks) → the VideoToolbox LTR token the encoder emitted for that frame.
+    /// Populated in `ship_frames` when a shipped frame carried a token; on
+    /// `on_frame_ack(frame_id)` the matching token is fed back to the encoder as
+    /// acknowledged and removed. Bounded (LTR frames are rare; pruned in
+    /// `ship_frames`). Empty on the default LTR-off path.
+    ltr_tokens: BTreeMap<u32, i64>,
 }
 
 /// Tunables for ack-driven IDR recovery (EGFX-on-lossy). See
@@ -243,6 +256,16 @@ pub struct Gfx {
     recovery_enabled: bool,
     recovery_params: RecoveryParams,
     egfx_on_lossy: Arc<AtomicBool>,
+    /// Long-Term Reference recovery (`MACRDP_UDP_EGFX_LTR`). When set, the encoder
+    /// is created with LTR enabled, received frames' LTR tokens are acked back to
+    /// VT, and the ack-stall recovery action becomes a cheap `ForceLTRRefresh`
+    /// (P-frame against the last acked LTR) instead of a full IDR. Implies
+    /// `recovery_enabled` (LTR needs the same ack-stall trigger). `ltr_low_latency`
+    /// (`MACRDP_UDP_EGFX_LTR_LOWLATENCY`) additionally co-enables VT's low-latency
+    /// rate controller — a test lever for VT/HW combos that only emit LTR tokens
+    /// in that mode. Both default off → byte-identical to the pre-feature path.
+    ltr_enabled: bool,
+    ltr_low_latency: bool,
 }
 
 impl Gfx {
@@ -255,7 +278,14 @@ impl Gfx {
         egfx_on_lossy: Arc<AtomicBool>,
     ) -> Self {
         let wire_format = WireFormat::from_env();
-        let (recovery_enabled, recovery_params) = recovery_config_from_env();
+        let (mut recovery_enabled, recovery_params) = recovery_config_from_env();
+        // LTR mode implies the ack-stall recovery trigger (it's what fires the
+        // LTR refresh). Reading it here keeps all the EGFX-on-lossy env in one place.
+        let ltr_enabled = crate::multitransport::env_truthy("MACRDP_UDP_EGFX_LTR");
+        let ltr_low_latency = crate::multitransport::env_truthy("MACRDP_UDP_EGFX_LTR_LOWLATENCY");
+        if ltr_enabled {
+            recovery_enabled = true;
+        }
         let (width, height) = desktop_size.get();
         info!(
             ?wire_format,
@@ -264,8 +294,10 @@ impl Gfx {
         if recovery_enabled {
             info!(
                 ?recovery_params,
-                "EGFX ack-driven IDR recovery ENABLED (MACRDP_UDP_EGFX_ACK_RECOVERY) — \
-                 active only while EGFX is on the lossy UDP tunnel"
+                ltr_enabled,
+                ltr_low_latency,
+                "EGFX ack-driven recovery ENABLED — active only while EGFX is on the lossy UDP \
+                 tunnel; recovery action is an LTR refresh when MACRDP_UDP_EGFX_LTR is set, else IDR"
             );
         }
         Self {
@@ -280,6 +312,8 @@ impl Gfx {
             recovery_enabled,
             recovery_params,
             egfx_on_lossy,
+            ltr_enabled,
+            ltr_low_latency,
         }
     }
 
@@ -335,12 +369,26 @@ impl Gfx {
                     self.egfx_on_lossy.load(Ordering::Relaxed),
                     &self.recovery_params,
                 ) {
-                    ctx.need_keyframe = true;
                     ctx.last_recovery_at = now;
-                    info!(
-                        since_ack_ms = since_ack.as_millis() as u64,
-                        "EGFX ack-stall on lossy tunnel — forcing recovery IDR"
-                    );
+                    if self.ltr_enabled {
+                        // Cheap recovery: a P-frame against the last acked LTR (VT
+                        // falls back to an IDR itself if nothing's been acked yet).
+                        // Consumed on the next encode; persists across a dropped
+                        // capture just like need_keyframe.
+                        if let Some(enc) = ctx.encoder.as_mut() {
+                            enc.request_ltr_refresh();
+                        }
+                        info!(
+                            since_ack_ms = since_ack.as_millis() as u64,
+                            "EGFX ack-stall on lossy tunnel — forcing LTR refresh"
+                        );
+                    } else {
+                        ctx.need_keyframe = true;
+                        info!(
+                            since_ack_ms = since_ack.as_millis() as u64,
+                            "EGFX ack-stall on lossy tunnel — forcing recovery IDR"
+                        );
+                    }
                 }
             }
             // Lazy one-time setup on the first ready frame (creates the encoder
@@ -469,6 +517,8 @@ impl Gfx {
                 self.fps,
                 self.bitrate_bps,
                 self.keyframe_secs,
+                self.ltr_enabled,
+                self.ltr_low_latency,
             )?;
             // Hand VT's output channel to a dedicated ship thread (push model),
             // so encoded frames are sent the instant they're ready, off the
@@ -477,6 +527,9 @@ impl Gfx {
             let rx = encoder
                 .take_receiver()
                 .ok_or_else(|| anyhow!("EGFX: encoder receiver already taken"))?;
+            if encoder.ltr_enabled() {
+                info!("EGFX encoder created with Long-Term Reference (LTR) mode enabled");
+            }
             ctx.encoder = Some(encoder);
             // Fresh throttle counters for this connection.
             ctx.submitted.store(0, Ordering::Relaxed);
@@ -534,19 +587,22 @@ impl Gfx {
                 // the surface stays blank.
                 let ps_count = f.parameter_sets.len();
                 let ps_bytes: usize = f.parameter_sets.iter().map(Vec::len).sum();
-                match server.send_avc420_frame(surface_id, &payload, &[region], ts_ms) {
+                let shipped_id = server.send_avc420_frame(surface_id, &payload, &[region], ts_ms);
+                match shipped_id {
                     Some(frame_id) if f.is_keyframe => debug!(
                         frame_id,
                         ?self.wire_format,
                         param_sets = ps_count,
                         param_bytes = ps_bytes,
                         payload_bytes = payload.len(),
+                        ltr = ?f.ltr_token,
                         "EGFX shipped keyframe (IDR)"
                     ),
                     Some(frame_id) => trace!(
                         frame_id,
                         keyframe = false,
                         payload_bytes = payload.len(),
+                        ltr = ?f.ltr_token,
                         "EGFX shipped frame"
                     ),
                     None => debug!(
@@ -555,6 +611,20 @@ impl Gfx {
                         bytes = payload.len(),
                         "send_avc420_frame returned None"
                     ),
+                }
+                // LTR mode: remember which EGFX frame_id carried which VT LTR token,
+                // so the matching client ack can acknowledge it to the encoder. Bound
+                // the map (LTR frames are rare, but never let a misbehaving peer grow
+                // it unboundedly): drop the oldest once it gets large.
+                if let (Some(frame_id), Some(token)) = (shipped_id, f.ltr_token) {
+                    ctx.ltr_tokens.insert(frame_id, token);
+                    while ctx.ltr_tokens.len() > MAX_TRACKED_LTR_TOKENS {
+                        if let Some(&oldest) = ctx.ltr_tokens.keys().next() {
+                            ctx.ltr_tokens.remove(&oldest);
+                        } else {
+                            break;
+                        }
+                    }
                 }
             }
             (server.drain_output(), egfx_channel_id)
@@ -659,6 +729,7 @@ impl GfxServerFactory for Gfx {
             acks_suspended: false,
             last_ship_at: Instant::now(),
             last_recovery_at: Instant::now(),
+            ltr_tokens: BTreeMap::new(),
         });
         Some((GfxDvcBridge::new(handle.clone()), handle))
     }
@@ -762,6 +833,15 @@ impl GraphicsPipelineHandler for GfxHandler {
         if let Some(ctx) = self.ctx.lock().unwrap().as_mut() {
             ctx.last_ack_at = Instant::now();
             ctx.acks_suspended = queue_depth == 0xFFFF_FFFF;
+            // LTR mode: if this acked frame was an LTR frame, tell the encoder its
+            // token is now confirmed-received so a later ForceLTRRefresh can
+            // reference it. (No-op on the default path — the map is always empty.)
+            if let Some(token) = ctx.ltr_tokens.remove(&frame_id) {
+                if let Some(enc) = ctx.encoder.as_mut() {
+                    enc.acknowledge_ltr_tokens(&[token]);
+                    trace!(frame_id, token, "EGFX LTR frame acknowledged to encoder");
+                }
+            }
         }
     }
 

--- a/src/videotoolbox.rs
+++ b/src/videotoolbox.rs
@@ -41,6 +41,14 @@ pub struct EncodedFrame {
     /// SPS / PPS NAL units (raw, no length prefix and no start code).
     /// Populated only on keyframes — empty on non-keyframes.
     pub parameter_sets: Vec<Vec<u8>>,
+    /// VideoToolbox Long-Term Reference acknowledgement token, present only when
+    /// LTR is enabled (`MACRDP_UDP_EGFX_LTR`) AND this frame was coded as an LTR
+    /// frame. The pipeline records `egfx_frame_id → token` when this frame ships
+    /// and feeds the token back via [`Encoder::acknowledge_ltr_tokens`] once the
+    /// client acks that frame, so a later `ForceLTRRefresh` can recover from loss
+    /// with a P-frame against this known-good reference instead of a full IDR.
+    /// `None` on the default (LTR-off) path and on non-LTR frames.
+    pub ltr_token: Option<i64>,
 }
 
 pub struct Encoder {
@@ -67,18 +75,34 @@ pub struct Encoder {
     /// blacks there. FreeRDP honors the range flag so it stays correct either
     /// way. Opt back out to video-range with `MACRDP_H264_FULL_RANGE=0`.
     full_range: bool,
+    /// Long-Term Reference mode (`MACRDP_UDP_EGFX_LTR`). When true the session was
+    /// created with `EnableLTR`, output frames may carry an LTR token, and the two
+    /// pending-state fields below feed per-frame LTR options into the next encode.
+    /// When false every LTR method is a no-op and the path is byte-identical.
+    enable_ltr: bool,
+    /// LTR tokens the client has acknowledged since the last encode, to hand VT via
+    /// `kVTEncodeFrameOptionKey_AcknowledgedLTRTokens` so it may reference them.
+    /// Drained on each `encode_bgra`.
+    pending_acked_ltr: Vec<i64>,
+    /// One-shot: force the next encoded frame to be an LTR refresh (a P-frame
+    /// referencing the most recent acknowledged LTR, or an IDR if none acked yet)
+    /// via `kVTEncodeFrameOptionKey_ForceLTRRefresh`. Consumed on the next encode.
+    pending_ltr_refresh: bool,
 }
 
 impl Encoder {
     /// Create a new H.264 encoder. `bitrate_bps` is the target average
     /// bitrate; `fps` sets the frame-duration hint used by VT's rate
     /// controller. The first encoded frame will always be a keyframe.
+    #[allow(clippy::too_many_arguments)] // tightly-coupled encoder params; a struct adds no clarity
     pub fn new(
         width: u16,
         height: u16,
         fps: u32,
         bitrate_bps: u32,
         keyframe_secs: f32,
+        enable_ltr: bool,
+        ltr_low_latency: bool,
     ) -> Result<Self> {
         let (tx, rx) = mpsc::channel::<EncodedFrame>();
         // The callback receives the raw `*mut Sender` and clones it per
@@ -97,7 +121,15 @@ impl Encoder {
         // Keyframe interval is a frame count; derive it from the requested
         // seconds and the frame rate. At least 1 (every frame an IDR).
         let keyframe_frames = (f64::from(fps) * f64::from(keyframe_secs)).round().max(1.0) as u32;
-        let session = ffi::create_session(width, height, bitrate_bps, keyframe_frames, tx_ptr)?;
+        let session = ffi::create_session(
+            width,
+            height,
+            bitrate_bps,
+            keyframe_frames,
+            enable_ltr,
+            ltr_low_latency,
+            tx_ptr,
+        )?;
         Ok(Self {
             inner: session,
             rx: Some(rx),
@@ -107,7 +139,36 @@ impl Encoder {
             next_pts: 0,
             fps,
             full_range,
+            enable_ltr,
+            pending_acked_ltr: Vec::new(),
+            pending_ltr_refresh: false,
         })
+    }
+
+    /// Whether Long-Term Reference mode is active for this encoder
+    /// (`MACRDP_UDP_EGFX_LTR`). When false the LTR methods below are no-ops.
+    pub fn ltr_enabled(&self) -> bool {
+        self.enable_ltr
+    }
+
+    /// Record LTR tokens the client has acknowledged (via `RDPGFX_FRAME_ACKNOWLEDGE`
+    /// mapped back to the token VT emitted for that frame). They're handed to VT on
+    /// the next `encode_bgra` so it may use those frames as references. No-op when
+    /// LTR is off.
+    pub fn acknowledge_ltr_tokens(&mut self, tokens: &[i64]) {
+        if self.enable_ltr {
+            self.pending_acked_ltr.extend_from_slice(tokens);
+        }
+    }
+
+    /// Request that the next encoded frame be an **LTR refresh**: a P-frame
+    /// referencing the most recently acknowledged LTR (or an IDR if none has been
+    /// acked yet — VT's documented fallback). This is the cheap loss-recovery
+    /// action that replaces a full forced IDR when LTR is on. No-op when LTR is off.
+    pub fn request_ltr_refresh(&mut self) {
+        if self.enable_ltr {
+            self.pending_ltr_refresh = true;
+        }
     }
 
     /// Take the VideoToolbox output receiver, to run it on a dedicated ship
@@ -148,6 +209,10 @@ impl Encoder {
         }
         let pts = self.next_pts;
         self.next_pts = self.next_pts.wrapping_add(1);
+        // Drain the one-shot LTR options into this encode (empty / false on the
+        // default LTR-off path → byte-identical frame properties).
+        let acked_ltr = std::mem::take(&mut self.pending_acked_ltr);
+        let force_ltr_refresh = std::mem::replace(&mut self.pending_ltr_refresh, false);
         ffi::encode_frame(
             &self.inner,
             bgra,
@@ -158,6 +223,8 @@ impl Encoder {
             self.fps,
             force_keyframe,
             self.full_range,
+            force_ltr_refresh,
+            &acked_ltr,
         )
     }
 
@@ -237,6 +304,9 @@ mod ffi {
     pub(super) const K_CM_TIME_FLAGS_VALID: u32 = 1;
 
     pub(super) const KCF_NUMBER_INT32_TYPE: i32 = 3;
+    // kCFNumberSInt64Type — for LTR acknowledgement tokens (CFNumber). Used both
+    // to build tokens we hand back to VT and to read the token VT attaches.
+    pub(super) const KCF_NUMBER_SINT64_TYPE: i32 = 4;
 
     /// Opaque stand-in for `CFDictionaryKeyCallBacks` /
     /// `CFDictionaryValueCallBacks`. We never read these structs — we
@@ -276,6 +346,18 @@ mod ffi {
             the_type: i32,
             value_ptr: *const c_void,
         ) -> CFNumberRef;
+        pub(super) fn CFNumberGetValue(
+            number: CFNumberRef,
+            the_type: i32,
+            value_ptr: *mut c_void,
+        ) -> Boolean;
+        pub(super) fn CFArrayCreate(
+            allocator: CFAllocatorRef,
+            values: *const *const c_void,
+            num_values: isize,
+            callbacks: *const c_void,
+        ) -> CFArrayRef;
+        pub(super) static kCFTypeArrayCallBacks: CFCallbacksOpaque;
 
         // Constant string handles for VT property keys + profile levels.
         // These are global symbols, dereferenced for the actual CFStringRef.
@@ -287,6 +369,17 @@ mod ffi {
         pub(super) static kVTCompressionPropertyKey_MaxFrameDelayCount: CFStringRef;
         pub(super) static kVTProfileLevel_H264_Baseline_AutoLevel: CFStringRef;
         pub(super) static kVTEncodeFrameOptionKey_ForceKeyFrame: CFStringRef;
+        // Long-Term Reference (LTR) keys — macOS 12+. Enabled only on the
+        // MACRDP_UDP_EGFX_LTR path; the symbols are resolved at load regardless,
+        // but they exist on every macOS macrdp targets.
+        pub(super) static kVTCompressionPropertyKey_EnableLTR: CFStringRef;
+        pub(super) static kVTEncodeFrameOptionKey_AcknowledgedLTRTokens: CFStringRef;
+        pub(super) static kVTEncodeFrameOptionKey_ForceLTRRefresh: CFStringRef;
+        pub(super) static kVTSampleAttachmentKey_RequireLTRAcknowledgementToken: CFStringRef;
+        // Low-latency rate controller — co-enabled with LTR when
+        // MACRDP_UDP_EGFX_LTR_LOWLATENCY is set (a test lever in case a given
+        // VT/HW combo only emits LTR tokens under the low-latency encoder).
+        pub(super) static kVTVideoEncoderSpecification_EnableLowLatencyRateControl: CFStringRef;
         // Color-space signaling so the encoded SPS VUI describes its color
         // space explicitly instead of leaving the decoder to guess (which is
         // why mstsc washed the image lighter while FreeRDP guessed right).
@@ -437,13 +530,36 @@ mod ffi {
     // The session itself is documented as thread-safe.
     unsafe impl Send for SessionGuard {}
 
+    #[allow(clippy::too_many_arguments)] // internal FFI session builder; grouping adds no clarity
     pub(super) fn create_session(
         width: u16,
         height: u16,
         bitrate_bps: u32,
         keyframe_frames: u32,
+        enable_ltr: bool,
+        ltr_low_latency: bool,
         tx_ctx: *mut c_void,
     ) -> Result<SessionGuard> {
+        // Optional encoder specification. Only built when LTR is requested AND the
+        // low-latency lever is on (MACRDP_UDP_EGFX_LTR_LOWLATENCY) — some VT/HW
+        // combos only emit LTR tokens under the low-latency rate controller. The
+        // default path passes a null spec (byte-identical to before).
+        let spec: CFDictionaryRef = if enable_ltr && ltr_low_latency {
+            unsafe {
+                let key = kVTVideoEncoderSpecification_EnableLowLatencyRateControl;
+                let value = kCFBooleanTrue;
+                CFDictionaryCreate(
+                    ptr::null(),
+                    &key as *const *const c_void,
+                    &value as *const *const c_void,
+                    1,
+                    &kCFTypeDictionaryKeyCallBacks as *const _ as *const c_void,
+                    &kCFTypeDictionaryValueCallBacks as *const _ as *const c_void,
+                )
+            }
+        } else {
+            ptr::null()
+        };
         let mut session: VTCompressionSessionRef = ptr::null();
         let status = unsafe {
             VTCompressionSessionCreate(
@@ -451,7 +567,7 @@ mod ffi {
                 i32::from(width),
                 i32::from(height),
                 K_CM_VIDEO_CODEC_TYPE_H264,
-                ptr::null(),
+                spec,
                 ptr::null(),
                 ptr::null(),
                 Some(output_callback),
@@ -459,6 +575,9 @@ mod ffi {
                 &mut session,
             )
         };
+        if !spec.is_null() {
+            unsafe { CFRelease(spec) };
+        }
         if status != 0 || session.is_null() {
             bail!("VTCompressionSessionCreate failed: OSStatus {status}");
         }
@@ -529,6 +648,22 @@ mod ffi {
                 kVTCompressionPropertyKey_MaxKeyFrameInterval,
                 keyframe_frames.max(1) as i32,
             )?;
+            // Long-Term Reference (LTR) mode (MACRDP_UDP_EGFX_LTR). Best-effort: if
+            // a VT/HW combo rejects it the encoder still works (recovery just falls
+            // back to a normal IDR, since no LTR tokens are ever emitted). The
+            // default path never sets it, so it's byte-identical when off.
+            if enable_ltr {
+                let st = VTSessionSetProperty(
+                    session,
+                    kVTCompressionPropertyKey_EnableLTR,
+                    kCFBooleanTrue,
+                );
+                if st != 0 {
+                    // No tracing in this FFI module; the h264 layer logs the request
+                    // at INFO. A non-zero status here means LTR didn't take.
+                    eprintln!("warning: VT EnableLTR not accepted (OSStatus {st}); LTR inactive");
+                }
+            }
         }
 
         let prepared = unsafe { VTCompressionSessionPrepareToEncodeFrames(session) };
@@ -955,6 +1090,8 @@ mod ffi {
         fps: u32,
         force_keyframe: bool,
         full_range: bool,
+        force_ltr_refresh: bool,
+        acked_ltr_tokens: &[i64],
     ) -> Result<()> {
         // Full-range path feeds VT a `420f` (full-range NV12) buffer we fill
         // ourselves; otherwise hand VT BGRA and let it produce video-range YUV.
@@ -1054,19 +1191,59 @@ mod ffi {
                 flags: K_CM_TIME_FLAGS_VALID,
                 epoch: 0,
             };
-            let frame_props: CFDictionaryRef = if force_keyframe {
-                let key = kVTEncodeFrameOptionKey_ForceKeyFrame;
-                let value = kCFBooleanTrue;
+            // Build the per-frame options dict from up to three entries:
+            // ForceKeyFrame, ForceLTRRefresh, AcknowledgedLTRTokens. On the default
+            // path (no keyframe, LTR off) all are absent → null dict, byte-identical
+            // to before. `ltr_tokens_array` is kept alive (and released) alongside
+            // the dict because it's referenced by it.
+            let mut keys: Vec<*const c_void> = Vec::new();
+            let mut values: Vec<*const c_void> = Vec::new();
+            if force_keyframe {
+                keys.push(kVTEncodeFrameOptionKey_ForceKeyFrame);
+                values.push(kCFBooleanTrue);
+            }
+            if force_ltr_refresh {
+                keys.push(kVTEncodeFrameOptionKey_ForceLTRRefresh);
+                values.push(kCFBooleanTrue);
+            }
+            // CFArray of CFNumber(SInt64) for the acknowledged LTR tokens, if any.
+            let mut token_numbers: Vec<CFNumberRef> = Vec::new();
+            let mut ltr_tokens_array: CFArrayRef = ptr::null();
+            if !acked_ltr_tokens.is_empty() {
+                for &tok in acked_ltr_tokens {
+                    let n = CFNumberCreate(
+                        ptr::null(),
+                        KCF_NUMBER_SINT64_TYPE,
+                        &tok as *const i64 as *const c_void,
+                    );
+                    if !n.is_null() {
+                        token_numbers.push(n);
+                    }
+                }
+                if !token_numbers.is_empty() {
+                    ltr_tokens_array = CFArrayCreate(
+                        ptr::null(),
+                        token_numbers.as_ptr(),
+                        token_numbers.len() as isize,
+                        &kCFTypeArrayCallBacks as *const _ as *const c_void,
+                    );
+                    if !ltr_tokens_array.is_null() {
+                        keys.push(kVTEncodeFrameOptionKey_AcknowledgedLTRTokens);
+                        values.push(ltr_tokens_array);
+                    }
+                }
+            }
+            let frame_props: CFDictionaryRef = if keys.is_empty() {
+                ptr::null()
+            } else {
                 CFDictionaryCreate(
                     ptr::null(),
-                    &key as *const *const c_void,
-                    &value as *const *const c_void,
-                    1,
+                    keys.as_ptr(),
+                    values.as_ptr(),
+                    keys.len() as isize,
                     &kCFTypeDictionaryKeyCallBacks as *const _ as *const c_void,
                     &kCFTypeDictionaryValueCallBacks as *const _ as *const c_void,
                 )
-            } else {
-                ptr::null()
             };
 
             let mut info_flags: VTEncodeInfoFlags = 0;
@@ -1081,6 +1258,14 @@ mod ffi {
             );
             if !frame_props.is_null() {
                 CFRelease(frame_props);
+            }
+            // The dict retained the array; the array retained each number. Release
+            // our own references now that the dict (if any) holds them.
+            if !ltr_tokens_array.is_null() {
+                CFRelease(ltr_tokens_array);
+            }
+            for n in token_numbers {
+                CFRelease(n);
             }
             if encode_status != 0 {
                 Err(anyhow!(
@@ -1153,6 +1338,9 @@ mod ffi {
         // sample-attachments array. Per Apple docs, if the attachments
         // array is missing or empty, the sample is a sync (keyframe).
         let mut is_keyframe = true;
+        // LTR acknowledgement token, present only when this sample was coded as an
+        // LTR frame (LTR mode on). Read from the same per-sample attachment dict.
+        let mut ltr_token: Option<i64> = None;
         let attachments = CMSampleBufferGetSampleAttachmentsArray(sbuf, 0);
         if !attachments.is_null() && CFArrayGetCount(attachments) > 0 {
             let dict = CFArrayGetValueAtIndex(attachments, 0) as CFDictionaryRef;
@@ -1162,6 +1350,21 @@ mod ffi {
                     // A present "NotSync" attachment means this is a
                     // non-keyframe. (Apple's API encodes the negation.)
                     is_keyframe = not_sync != kCFBooleanTrue;
+                }
+                let tok = CFDictionaryGetValue(
+                    dict,
+                    kVTSampleAttachmentKey_RequireLTRAcknowledgementToken,
+                ) as CFNumberRef;
+                if !tok.is_null() {
+                    let mut v: i64 = 0;
+                    if CFNumberGetValue(
+                        tok,
+                        KCF_NUMBER_SINT64_TYPE,
+                        &mut v as *mut i64 as *mut c_void,
+                    ) != 0
+                    {
+                        ltr_token = Some(v);
+                    }
                 }
             }
         }
@@ -1206,6 +1409,7 @@ mod ffi {
             is_keyframe,
             pts,
             parameter_sets,
+            ltr_token,
         })
     }
 }
@@ -1513,12 +1717,12 @@ mod tests {
         // Warm up VT (first session boot is expensive; we don't want it skewing
         // the baseline).
         {
-            let mut warm = Encoder::new(W, H, FPS, BITRATE_BPS, KEYFRAME_S).unwrap();
+            let mut warm = Encoder::new(W, H, FPS, BITRATE_BPS, KEYFRAME_S, false, false).unwrap();
             drive_one(&mut warm);
         }
 
         // Baseline: single session, N frames.
-        let mut e1 = Encoder::new(W, H, FPS, BITRATE_BPS, KEYFRAME_S).unwrap();
+        let mut e1 = Encoder::new(W, H, FPS, BITRATE_BPS, KEYFRAME_S, false, false).unwrap();
         let t = Instant::now();
         drive_one(&mut e1);
         let t_single = t.elapsed();
@@ -1526,8 +1730,8 @@ mod tests {
         // Dual: two sessions, N frames each, submissions interleaved, then both
         // flushed. If VT parallelizes, e_b's frames overlap with e_a's flush
         // wait and the second flush returns nearly instantly.
-        let mut e_a = Encoder::new(W, H, FPS, BITRATE_BPS, KEYFRAME_S).unwrap();
-        let mut e_b = Encoder::new(W, H, FPS, BITRATE_BPS, KEYFRAME_S).unwrap();
+        let mut e_a = Encoder::new(W, H, FPS, BITRATE_BPS, KEYFRAME_S, false, false).unwrap();
+        let mut e_b = Encoder::new(W, H, FPS, BITRATE_BPS, KEYFRAME_S, false, false).unwrap();
         let t = Instant::now();
         for i in 0..N_FRAMES {
             e_a.encode_bgra(black_box(&frame), stride, i == 0).unwrap();
@@ -1628,7 +1832,7 @@ mod tests {
             px[3] = 0xff; // A
         }
 
-        let mut enc = Encoder::new(w, h, 30, 4_000_000, 5.0)?;
+        let mut enc = Encoder::new(w, h, 30, 4_000_000, 5.0, false, false)?;
         enc.encode_bgra(&frame, stride, false)?;
         let frames = enc.flush()?;
         assert!(!frames.is_empty(), "expected at least one encoded frame");
@@ -1641,6 +1845,69 @@ mod tests {
         assert!(
             !first.parameter_sets.is_empty(),
             "keyframe should carry SPS/PPS parameter sets"
+        );
+        Ok(())
+    }
+
+    /// LTR mode (MACRDP_UDP_EGFX_LTR path) must not break basic encoding, and the
+    /// LTR control methods must be safe to call. We don't assert tokens *appear*
+    /// (whether VT emits LTR tokens depends on the encoder/HW and isn't
+    /// deterministic in a short CI run) — only that enabling LTR, acking arbitrary
+    /// tokens, and forcing an LTR refresh all keep producing valid frames.
+    #[test]
+    fn ltr_enabled_encoder_still_produces_frames() -> Result<()> {
+        let w: u16 = 320;
+        let h: u16 = 240;
+        let stride = usize::from(w) * 4;
+        let mut frame = vec![0u8; stride * usize::from(h)];
+        for (i, px) in frame.chunks_exact_mut(4).enumerate() {
+            px[0] = (i & 0xff) as u8; // B — vary so P-frames have content
+            px[1] = 0x77;
+            px[2] = 0xcc;
+            px[3] = 0xff;
+        }
+
+        let mut enc = Encoder::new(w, h, 30, 4_000_000, 5.0, true, false)?;
+        assert!(enc.ltr_enabled(), "LTR should report enabled");
+        // First frame (keyframe).
+        enc.encode_bgra(&frame, stride, false)?;
+        // Acking a token VT never issued must be a harmless no-op.
+        enc.acknowledge_ltr_tokens(&[12345]);
+        // A few more frames, then force an LTR refresh (VT falls back to IDR if no
+        // LTR has been acked — either way it must produce a frame).
+        for _ in 0..3 {
+            enc.encode_bgra(&frame, stride, false)?;
+        }
+        enc.request_ltr_refresh();
+        enc.encode_bgra(&frame, stride, false)?;
+        let frames = enc.flush()?;
+        assert!(
+            !frames.is_empty(),
+            "LTR-enabled encoder should still emit frames"
+        );
+        assert!(frames[0].is_keyframe, "first frame should be a keyframe");
+        Ok(())
+    }
+
+    /// With LTR OFF, the control methods are no-ops and tokens are never present —
+    /// the default path is unaffected.
+    #[test]
+    fn ltr_disabled_methods_are_noops() -> Result<()> {
+        let w: u16 = 320;
+        let h: u16 = 240;
+        let stride = usize::from(w) * 4;
+        let frame = vec![0x40u8; stride * usize::from(h)];
+
+        let mut enc = Encoder::new(w, h, 30, 4_000_000, 5.0, false, false)?;
+        assert!(!enc.ltr_enabled(), "LTR should report disabled");
+        enc.acknowledge_ltr_tokens(&[1, 2, 3]); // no-op
+        enc.request_ltr_refresh(); // no-op
+        enc.encode_bgra(&frame, stride, false)?;
+        let frames = enc.flush()?;
+        assert!(!frames.is_empty());
+        assert!(
+            frames.iter().all(|f| f.ltr_token.is_none()),
+            "LTR-off frames must never carry a token"
         );
         Ok(())
     }


### PR DESCRIPTION
## What

Builds on the ack-driven IDR recovery (#75). That heals a lost EGFX frame, but its recovery action is a **full IDR** — large, itself loss-vulnerable, and a bitrate spike. This adds the standard RTC fix: **VideoToolbox Long-Term Reference frames**. The encoder periodically marks frames as LTR; the client's `RDPGFX_FRAME_ACKNOWLEDGE` tells us which LTRs arrived; on detected loss the encoder codes a **P-frame against the last *acknowledged* LTR** (VT falls back to an IDR if none acked yet) instead of a full IDR — a fraction of the bytes, far likelier to survive the lossy link. Same ack-stall trigger as #75, cheaper recovery.

## Why temporal (LTR), not spatial

On the lossy tunnel, RDPEUDP-lossy delivers a **whole-frame gap**, not a corrupt frame (fragments either fully reassemble or the frame is never delivered) — the decoder sees a *missing* frame, never a *damaged* one. That moots every spatial H.264 tool (slices, data-partitioning, redundant-slices, constrained-intra — they only help partial-frame concealment, which never happens here). GDR / cyclic intra-refresh — the ideal "no IDR spike" tool — **isn't reachable**: VideoToolbox exposes no public intra-refresh property (verified against the SDK headers). LTR is the one VT-supported lever matched to whole-frame-gap loss.

## How

**`src/videotoolbox.rs`**
- `Encoder::new` gains `enable_ltr` + `ltr_low_latency`. `create_session` sets `kVTCompressionPropertyKey_EnableLTR` (best-effort — if a VT/HW combo rejects it the encoder still works and recovery degrades to a normal IDR) and, when `ltr_low_latency`, builds the encoder spec with `EnableLowLatencyRateControl`.
- `EncodedFrame` gains `ltr_token: Option<i64>` read from `kVTSampleAttachmentKey_RequireLTRAcknowledgementToken`.
- New `acknowledge_ltr_tokens` / `request_ltr_refresh` / `ltr_enabled` feed per-frame options (`AcknowledgedLTRTokens` / `ForceLTRRefresh`) into the next encode. The frame-properties dict generalizes to carry `ForceKeyFrame` + `ForceLTRRefresh` + `AcknowledgedLTRTokens` together (null dict on the default path → byte-identical).

**`src/h264.rs`**
- `Gfx` reads `MACRDP_UDP_EGFX_LTR` (implies `recovery_enabled` — LTR needs the same ack-stall trigger) and `MACRDP_UDP_EGFX_LTR_LOWLATENCY`.
- `ConnectionContext` gains a bounded `frame_id → token` map (`MAX_TRACKED_LTR_TOKENS=64`): `ship_frames` records it when a shipped frame carried a token; `on_frame_ack(frame_id)` feeds the matching token back to the encoder as acknowledged.
- The `submit_bgra` recovery action becomes `request_ltr_refresh()` when LTR is on (logs `forcing LTR refresh`), else the existing IDR.

No `main.rs` change — entirely env-driven inside `h264.rs`.

## Gating / safety

- Behind `MACRDP_UDP_EGFX_LTR` (default **OFF**). Feature-off path is byte-identical (null frame-props dict, no `EnableLTR`, map always empty).
- `MACRDP_UDP_EGFX_LTR_LOWLATENCY` is a test lever in case a given VT/HW only emits LTR tokens under the low-latency rate controller.

## Tests

2 new `videotoolbox` unit tests: LTR-enabled encoder still produces valid frames (ack-arbitrary + force-refresh are safe), and LTR-off frames never carry a token (default path unaffected). VT accepts `EnableLTR` and keeps encoding on the dev/CI macOS. Build + `clippy --all-targets -D warnings` clean; 79 tests pass; release (LTO) build verified.

## The make-or-break risk (real-client soak PENDING — user's call)

Whether mstsc's / FreeRDP's **AVC420** decoder correctly handles a P-frame referencing a long-term reference (ref-pic-list modification + MMCO). LTR is standard-conformant H.264, but AVC420-over-EGFX is a constrained profile and the MS decoder *may* assume each P references the immediately-previous frame. If it chokes → corruption, and we revert to the IDR recovery. Verify on mstsc + `MACRDP_UDP_MIGRATE_EGFX_LOSSY` + `MACRDP_UDP_EGFX_LTR` + induced loss; watch for `forcing LTR refresh` + `EGFX LTR frame acknowledged to encoder`, and confirm the picture stays clean (no corruption) under loss.