### PR TITLE
fix(h264): break lock-order inversion that froze the EGFX ship pipeline

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -248,6 +248,27 @@ reliable-only multitransport.
    same loss sensitivity (matching client resolution to avoid scaling + a capable
    client are the practical mitigations there).
 
+4. **The under-loss freeze is permanent (no recovery after loss stops) — expected,
+   do NOT re-investigate (2026-06-28, mstsc, 8% loss via clumsy, reliable tunnel,
+   `MACRDP_UDP_MIGRATE_EGFX=1`).** A clean ~1-minute run then 8% drop reproduced the
+   structural HOL-block of item 3, plus a terminal state worth recording so it isn't
+   mistaken for a bug later: a loss burst lands on a ~234 KB IDR (~200+ segments);
+   the reliable SM's unacked window fills and **pegs at exactly 1024**, resending the
+   whole backlog every RTO (`RDPEUDP RTO retransmit (timer) retransmits=1024`), while
+   macrdp keeps shipping a fresh 240–270 KB periodic IDR every `--keyframe-interval`
+   (2 s) into the jammed tunnel. The client sends **CN (congestion notification)**,
+   then **stops acking entirely** and abandons the UDP tunnel (the last inbound
+   datagram precedes ~108 s of dead retransmits in the log); **audio keeps playing
+   because it rides TCP.** Because a *reliable* ordered stream cannot drop the stale
+   backlog (it would break the in-order contract) and the client never re-engages the
+   abandoned tunnel, **EGFX stays frozen even after loss stops** — there is no
+   server-side recovery path on a reliable stream. This is inherent to reliable-only
+   multitransport, not fixable in the transport; the answer is Phase 2 (lossy
+   `UdpFecL` + FEC). (Unrelated bug fixed the same day: a lock-order inversion in the
+   H.264 ship pipeline that froze EGFX on a *clean* link — see PR #78 / the
+   `ship_frames` `ctx`↔`server_handle` ordering. That one was a real deadlock; this
+   item is the expected lossy-link behavior.)
+
 ### P2.2 lossy-delivery soak (runbook)
 
 The first soak (above) shaped the **reliable** EGFX-over-UDP path. This one targets the

--- a/src/h264.rs
+++ b/src/h264.rs
@@ -494,18 +494,35 @@ impl Gfx {
 
     fn ship_frames(&self, frames: &[EncodedFrame]) -> Result<()> {
         let (dvc_messages, egfx_channel_id) = {
-            let mut guard = self.ctx.lock().unwrap();
-            let ctx = guard
-                .as_mut()
-                .ok_or_else(|| anyhow!("EGFX: ctx vanished mid-submit"))?;
-            let surface_id = ctx
-                .surface_id
-                .ok_or_else(|| anyhow!("EGFX: no surface_id"))?;
-            let (width, height) = ctx.dims;
-            let epoch = ctx.epoch;
-            // Liveness for ack-driven IDR recovery: we're actively shipping.
-            ctx.last_ship_at = Instant::now();
-            let mut server = ctx.server_handle.lock().unwrap();
+            // Phase 1: read what we need out of `ctx`, then DROP the ctx lock
+            // before touching `server_handle`. The inbound EGFX frame-ack path
+            // (`GfxDvcBridge::process` → `GraphicsPipelineServer::process` →
+            // `GfxHandler::on_frame_ack`) locks `server_handle` FIRST and then
+            // `ctx`. Holding `ctx` here while taking `server_handle` is the
+            // opposite order — a classic lock-order inversion that deadlocks the
+            // ship thread against an inbound ack. Over a long session the exact
+            // interleaving eventually hits and the whole pipeline freezes (idle
+            // CPU, no error, no reset — the "renders fine then freezes after a
+            // few seconds" stall, far more likely once acks ride the UDP tunnel).
+            // Cloning the `server_handle` Arc and releasing `ctx` first keeps the
+            // lock order consistent (server_handle is never nested under ctx).
+            let (surface_id, width, height, epoch, server_handle) = {
+                let mut guard = self.ctx.lock().unwrap();
+                let ctx = guard
+                    .as_mut()
+                    .ok_or_else(|| anyhow!("EGFX: ctx vanished mid-submit"))?;
+                let surface_id = ctx
+                    .surface_id
+                    .ok_or_else(|| anyhow!("EGFX: no surface_id"))?;
+                let (width, height) = ctx.dims;
+                let epoch = ctx.epoch;
+                // Liveness for ack-driven IDR recovery: we're actively shipping.
+                ctx.last_ship_at = Instant::now();
+                (surface_id, width, height, epoch, ctx.server_handle.clone())
+            };
+
+            // Phase 2: lock `server_handle` ALONE (ctx already released).
+            let mut server = server_handle.lock().unwrap();
             let egfx_channel_id = server
                 .channel_id()
                 .ok_or_else(|| anyhow!("EGFX: channel_id not assigned"))?;


### PR DESCRIPTION
## Problem

EGFX video (`--enable-h264`) would render cleanly, then **freeze after a few seconds** — idle CPU, no error, no client reset. Caught while testing EGFX over the reliable UDP multitransport tunnel (`MACRDP_UDP_MIGRATE_EGFX=1`), where it reproduced reliably ~18 s / ~1000 frames in, but the underlying bug could freeze EGFX-over-anything on a clean link too.

## Root cause — lock-order inversion

Two threads take the same two locks in opposite order:

- **ship thread** (`ship_frames`, every frame): `ctx` → `server_handle`
- **inbound frame-ack** (`GfxDvcBridge::process` → `GraphicsPipelineServer::process` → `GfxHandler::on_frame_ack`): `server_handle` → `ctx`

When a frame ship and an inbound ack interleave at the wrong moment, both threads block forever. Per-frame the odds are low, but over a long session it eventually hits; UDP-tunneled frame-acks (different timing/bursting than TCP) make it far more likely, which is why it surfaced there first.

## Fix

In `ship_frames`, read the needed values out of `ctx` and clone the `server_handle` `Arc`, then **drop the `ctx` guard before locking `server_handle`**. Both paths now take the locks in a consistent order (`server_handle` is never nested under `ctx`).

`setup_locked` keeps its `ctx`→`server_handle` nesting but is provably safe: it runs once per connection during surface/encoder init and only spawns the ship thread at its very end, so no concurrent `server_handle` holder exists and no frame-acks can arrive before the first frame ships.

## Verification

- Live on real mstsc over the reliable UDP tunnel: previously froze ~18 s / ~1000 frames in; now renders clean past a minute of continuous interaction (mouse/keyboard/window drag).
- `cargo fmt --all`, `cargo clippy --release` clean; release build + ad-hoc sign.

Note: this is unrelated to the *under-loss* video freeze on the reliable tunnel (HOL-blocking / window saturation) — that is the documented structural limit of reliable-only multitransport (needs Phase 2 lossy + FEC), not a bug.