### PR TITLE
docs(packaging): add UDP multitransport keys to config.env.example

### DIFF
--- a/packaging/config.env.example
+++ b/packaging/config.env.example
@@ -89,6 +89,22 @@ PRIMARY_MODE=none
 VD_WIDTH=1920
 VD_HEIGHT=1080
 
+# EXPERIMENTAL — RDP UDP multitransport (MS-RDPEMT over reliable RDPEUDP). Offer
+# an auxiliary UDP transport to clients that advertise it and bind a UDP listener
+# on the same address/port as TCP. On its own this keeps EGFX on TCP (a proven
+# safe spike) — set UDP_MIGRATE_EGFX=1 too to actually move the H.264 video onto
+# the reliable UDP tunnel. Input/audio/clipboard always ride TCP. Mutually
+# exclusive with FORK_WORKERS (the UDP socket must outlive reconnects, which a
+# per-connection worker can't own — with both set, the client falls back to TCP).
+ENABLE_UDP_MULTITRANSPORT=0
+# Migrate EGFX (H.264) onto the reliable UDP tunnel via MS-RDPEDYC Soft-Sync
+# (needs ENABLE_UDP_MULTITRANSPORT=1 and ENABLE_H264=1). CLEAN-LINK FEATURE ONLY:
+# the reliable tunnel is an ordered stream, so under packet loss it head-of-line-
+# blocks like TCP and, once the client abandons the tunnel, the picture freezes
+# with no recovery until reconnect (audio keeps playing on TCP). Use only on a
+# low-loss link; leave 0 otherwise.
+UDP_MIGRATE_EGFX=0
+
 # EXPERIMENTAL — fork-per-connection workers (xrdp's model). A thin supervisor
 # owns the virtual display + headless blanking and spawns a FRESH worker process
 # per RDP connection. This makes mstsc reconnect to a still-running server render


### PR DESCRIPTION
Adds `ENABLE_UDP_MULTITRANSPORT` and `UDP_MIGRATE_EGFX` to `packaging/config.env.example` (the template had no UDP-multitransport keys at all), matching the `args_from_config` keys from #79.

- Both default `0`.
- `UDP_MIGRATE_EGFX` carries the clean-link-only caveat (reliable tunnel HOL-blocks under loss → freeze with no recovery until reconnect).
- Notes the `FORK_WORKERS` mutual exclusion.

Packaging/docs only — no code change.