### PR TITLE
release: v0.8.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macrdp"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrdp"
-version = "0.8.14"
+version = "0.8.15"
 edition = "2021"
 description = "Native RDP server for macOS"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version bump 0.8.14 → 0.8.15 (`Cargo.toml` + `Cargo.lock`).

First release to carry the **RDP UDP multitransport** work (#15–#81) and the **H.264 ship-path deadlock fix** (#78). Highlights:

- **fix(h264):** break a lock-order inversion in `ship_frames` that could freeze the EGFX pipeline (rare on TCP, frequent on the UDP path) — verified live.
- **feat(multitransport):** EGFX H.264 over a reliable UDP tunnel (MS-RDPEMT/RDPEUDP), opt-in via `--enable-udp-multitransport` + `--udp-migrate-egfx` — **experimental, default OFF, clean-link only**. First known OSS RDP *server* with a working UDP data path. Phase-2 lossy-audio groundwork is env-gated/default-OFF.
- **feat(gui):** UDP toggles in the menu-bar controller.
- Docs: `config.env.example` UDP keys; extensive feasibility/divergence notes.

Default (TCP) behavior is unchanged from v0.8.14 apart from benefiting from the deadlock fix.