### PR TITLE
docs(multitransport): clarify the landscape (rename 'Client UDP support')

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -96,11 +96,19 @@ things**, often conflated:
 2. **Server UDP *data path*** — the server actually binds a UDP socket, runs the
    RDPEUDP reliability handshake, secures it (TLS/DTLS), establishes the MS-RDPEMT
    tunnel, and **carries channel data over it**. This is the hard part.
-3. **Client UDP support** — a *client* that connects out over UDP. A different
-   (and easier-to-reach) codebase than the server. Notably, even FreeRDP — the
+3. **Client-side UDP data path** — the *client* counterpart of (2): it accepts
+   the server's offer, opens the UDP association, secures it, joins the EMT
+   tunnel, and carries channel data over it. A separate (and somewhat
+   easier-to-reach) codebase than the server's. Notably, even FreeRDP — the
    most complete OSS stack — has never merged this either: its client declines
    UDP with `E_ABORT`, and the RDPEUDP/RDPEUDP2 work stayed an out-of-tree
    prototype (re-verified against full git history 2026-06-26).
+
+macrdp implements (1) and (2); it is a server, not a client, so (3) is listed
+only to keep the "supports UDP" claim unambiguous and to flag the interop
+dependency — macrdp's server data path is exercised only when a client with its
+own client-side UDP data path (today, only mstsc) connects to it. See "Which
+clients actually take macrdp's UDP offer" below.
 
 | RDP **server** | Base / lang | (1) Negotiation | (2) **UDP data path** | Notes |
 |---|---|---|---|---|


### PR DESCRIPTION
Wording/clarity fix in the Landscape section of `docs/rdp-udp-multitransport-feasibility.md`. No factual claims change.

- **Rename item (3)** "Client UDP support" → **"Client-side UDP data path"** — the old label was vague where (1)/(2) are precise and broke the parallel with (2) "Server UDP data path". The new label makes it the clear client counterpart of (2), which also sharpens the FreeRDP point (its client has negotiation but no data path either).
- **Add a clarifying sentence**: macrdp is a *server* — it implements (1)+(2); (3) is listed only to keep the "supports UDP" claim unambiguous and to flag the interop dependency (macrdp's server data path is exercised only when a client with its own client-side UDP data path — today only mstsc — connects).

Docs-only.