### PR TITLE
fix(input): de-nest CYCLE_SESSION from LAST_FOCUS_BUNDLE (lock-order hardening)

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1744,31 +1744,43 @@ mod macos {
     /// released, and lazily from cycle_apps when the grace timeout
     /// has elapsed.
     fn commit_cycle_session() {
-        let cursor_pid = {
+        // Take the session out under the CYCLE_SESSION lock, then DROP the lock
+        // (it's confined to this block) before any HUD / AX / mru /
+        // LAST_FOCUS_BUNDLE work below — those acquire OTHER mutexes, and holding
+        // CYCLE_SESSION across them would nest locks (the same lock-order hazard
+        // removed from h264 `ship_frames`: LAST_FOCUS_BUNDLE is written cross-
+        // thread by the focus observer / click hit-test). Nothing below needs the
+        // session map locked, only the taken session's data. The session is
+        // already `take()`n, so a racing cycle_apps just starts a fresh one — the
+        // correct outcome after a commit.
+        let session = {
             let mut guard = CYCLE_SESSION.lock().expect("cycle session mutex poisoned");
-            let Some(session) = guard.take() else { return };
-            // A session existed → tear down the on-screen HUD (best-effort).
-            if super::APP_SWITCHER_HUD.load(std::sync::atomic::Ordering::Relaxed) {
-                crate::switcher_hud::hide();
+            match guard.take() {
+                Some(s) => s,
+                None => return,
             }
-            if let Some((bundle, _, _)) = session
-                .snapshot
-                .iter()
-                .find(|(_, _, p)| *p == session.cursor_pid)
-            {
-                promote_bundle_to_front(bundle);
-                // Record the landed app as the current focus for the Ctrl→Cmd
-                // remap. Its `frontmost_is_excluded` reads LAST_FOCUS_BUNDLE
-                // first, and our own Cmd+Tab/Option+Tab AX activation doesn't
-                // reliably post an NSWorkspace activation — so without this,
-                // cycling from an excluded app (terminal/VSCode) to a normal one
-                // left the remap suppressed until the user clicked the new app.
-                if let Ok(mut g) = LAST_FOCUS_BUNDLE.lock() {
-                    *g = Some(bundle.clone());
-                }
-            }
-            session.cursor_pid
         };
+        // A session existed → tear down the on-screen HUD (best-effort).
+        if super::APP_SWITCHER_HUD.load(std::sync::atomic::Ordering::Relaxed) {
+            crate::switcher_hud::hide();
+        }
+        if let Some((bundle, _, _)) = session
+            .snapshot
+            .iter()
+            .find(|(_, _, p)| *p == session.cursor_pid)
+        {
+            promote_bundle_to_front(bundle);
+            // Record the landed app as the current focus for the Ctrl→Cmd
+            // remap. Its `frontmost_is_excluded` reads LAST_FOCUS_BUNDLE
+            // first, and our own Cmd+Tab/Option+Tab AX activation doesn't
+            // reliably post an NSWorkspace activation — so without this,
+            // cycling from an excluded app (terminal/VSCode) to a normal one
+            // left the remap suppressed until the user clicked the new app.
+            if let Ok(mut g) = LAST_FOCUS_BUNDLE.lock() {
+                *g = Some(bundle.clone());
+            }
+        }
+        let cursor_pid = session.cursor_pid;
         // On commit (Cmd release), re-assert the landed app and, if it has no
         // window (e.g. Notes/Calendar/Mail with their window closed), reopen it so
         // it surfaces — both gated to commit so apps merely cycled *through* aren't


### PR DESCRIPTION
Follow-up to the h264 deadlock fix (#78): applies the same **structural** de-nesting to the one other place that held two cross-thread mutexes nested.

## What
`commit_cycle_session` held `CYCLE_SESSION` while taking `LAST_FOCUS_BUNDLE` (and `mru` via `promote_bundle_to_front`). `LAST_FOCUS_BUNDLE` is written **cross-thread** (the NSWorkspace focus observer on the runloop thread + the mouse-down AX hit-test), so that nesting is a latent lock-order inversion of the same shape as the h264 bug — safe today only by the unwritten "CYCLE_SESSION is always outermost" convention.

## Fix
Confine the `CYCLE_SESSION` guard to a small block that `take()`s the session, then **drop the lock** before any HUD / AX / mru / `LAST_FOCUS_BUNDLE` work. The two locks are never held at once → the inversion is impossible **by construction, not by convention** (this is real code, not a comment). Behavior is identical (same ops, same order; session already taken so a racing `cycle_apps` correctly starts fresh).

## Scope note
`cycle_apps` still holds `CYCLE_SESSION` across `mru_bundles` by design (it interleaves session + MRU state in place). That path never takes `LAST_FOCUS_BUNDLE` under `CYCLE_SESSION` and keeps the consistent `CYCLE_SESSION→mru` order, so it stays safe; fully de-nesting it would be a large rewrite of working code (deferred).

## Verification
- `cargo build` / `clippy` / `fmt --check` clean; **77 tests pass**.
- ⚠️ **Needs real-client Cmd+Tab verification before merge** — the AX app-switch cycle can't be exercised in headless CI (the "needs a TCC Mac runner" gap). Please confirm Cmd+Tab / Cmd+Shift+Tab still land on the right app (and the Ctrl→Cmd remap still applies after a switch) on a real client, then merge.

Do **not** auto-merge.