### PR TITLE
release: v0.8.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macrdp"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrdp"
-version = "0.8.15"
+version = "0.8.16"
 edition = "2021"
 description = "Native RDP server for macOS"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release. Bumps `0.8.15 → 0.8.16` (Cargo.toml + Cargo.lock).

## Changes since v0.8.15
- **fix(input)** — de-nest `CYCLE_SESSION` from `LAST_FOCUS_BUNDLE` in `commit_cycle_session`: lock-order hardening of the Cmd+Tab / app-cycle path. **Verified on live mstsc** (smooth cycling, no hang). The one user-facing change. (#84)
- **test(rdpeudp)** — proptest property suite for the reliability state machine: randomized loss/reorder/dup + in-order-prefix, send-window-bound, and sequence-wraparound invariants. Test-only; no binary change. (#85)
- **docs** — `TODO.md` work-queue index; FEC NO-GO "industry status" note; UDP multitransport README + landscape clarifications.

## Pre-tag gates (local)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean

Merge, then tag `v0.8.16` on main to trigger the release workflow (draft).