### PR TITLE
fix(multitransport): idle-timeout GC for leaked UDP peers (M3c backstop)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,18 @@ then delete; promote a parked item to *In flight* when work actually starts.
 
 ## In flight (needs an action)
 
-_(nothing in flight — see Deferred/Parked below)_
+- [ ] **UDP multitransport peer leak — idle-timeout GC** (branch `fix/udp-peer-idle-gc`;
+  built + clippy/fmt green; **awaiting real-mstsc verification before merge**). Listener
+  `peers` map was inserted-but-never-removed (M3c GC never built), so a dead client kept
+  RTO-retransmitting unacked EGFX for the process lifetime — the user's "UDP doesn't close
+  on disconnect" + blank-on-reconnect pcap. Fix: `Peer.last_seen_ms` bumped on inbound,
+  `gc_idle_peers` evicts peers idle >10s (+ their `bound_addrs`) on the existing tick.
+  **Verify:** temporarily `UDP_MIGRATE_EGFX=1`, run with
+  `RUST_LOG=info,ironrdp_server::multitransport=debug`, connect+close mstsc, confirm an
+  `evicted idle UDP peer` log ~10s later and UDP to the old client stops; then reconnect a
+  fresh mstsc to see if the blank improves (if not → mstsc surface quirk / clean-link
+  limit, answer stays `--udp-migrate-egfx` off). Listener-only backstop; the prompt
+  server→listener instant-retire signal is still deferred. See feasibility doc "M3c peer GC".
 
 ## Deferred — scoped, not started
 

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -325,6 +325,40 @@ reliable-only multitransport.
    Research "URCP: Universal Rate Control Protocol for Real-Time Communication";
    RDP Shortpath docs.)
 
+### M3c peer GC — the listener leaked dead peers (fixed 2026-06-28)
+
+A separate, transport-level correctness bug surfaced from a real mstsc pcap
+(EGFX-over-UDP, `--udp-migrate-egfx`, WiFi): on **reconnect the video went blank**,
+and the user noticed **"the UDP connection continues even after I close the client"**
+(recovery needed a server restart). The pcap confirmed it: after the client's TCP
+session RST'd, the server kept shipping UDP (EGFX retransmits) to the gone client for
+the rest of the capture (~10 s / 32 packets and still going).
+
+Root cause: the listener's `peers: HashMap<SocketAddr, Peer>` was inserted-but-never
+removed — the module doc literally said *"never garbage-collected … GC + idle timeout
+come with M3c"*, and M3c's GC half was never built. So a client whose RDP/TCP session
+went away kept its peer entry forever, and `pump_peers_on_timer` kept RTO-retransmitting
+unacked EGFX to it; over a long-running server dead peers also accumulate unbounded.
+
+Fix (`vendor/ironrdp-server/src/multitransport/listener.rs`, idle-timeout GC):
+`Peer` gained `last_seen_ms`, bumped on **every inbound datagram** (only inbound — a
+dead peer still *sends* outbound retransmits but receives nothing, so its clock
+stops); `gc_idle_peers` runs on the existing `retransmit_tick` (right after
+`pump_peers_on_timer`) and evicts any peer idle > 10 s (`PEER_IDLE_TIMEOUT_MS`),
+dropping its `bound_addrs` cookie→addr mapping too. Activity-based, so it covers
+graceful / abrupt / crashed disconnects uniformly; 10 s is safe because a live client
+— even idle — sends RDPEUDP keepalive/delayed-ACKs continuously (~200/s in a real
+session). Logs `evicted idle UDP peer` at `ironrdp_server::multitransport=debug`.
+
+This is the listener-only **backstop** half of M3c; the prompt server→listener
+"instant retire-on-disconnect" signal is still deferred (the GC is needed regardless).
+**It does NOT by itself fix the reconnect-blank** — the tunnel is TLS-encrypted so the
+pcap can't prove the leak was the *sole* cause, and the documented mstsc EGFX
+surface-retention quirk + the clean-link limit (finding #4) may compound it. The
+robust WiFi config stays `--udp-migrate-egfx` off (EGFX on TCP). Real-mstsc retest of
+the GC (watch for the eviction log ~10 s after close + UDP actually stopping) is the
+gate. See vendored server divergence (12) "M3c idle-timeout peer GC".
+
 ### P2.2 lossy-delivery soak (runbook)
 
 The first soak (above) shaped the **reliable** EGFX-over-UDP path. This one targets the

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -766,3 +766,28 @@ AND released — #1276 landing is NOT sufficient.
     stays a clean-link feature (reliable ordered stream HOL-blocks under loss — the
     under-loss freeze is the documented structural limit, soak finding #4). All
     `multitransport`-gated; feature-off byte-unchanged.
+
+    M3c idle-timeout peer GC (2026-06-28, `listener.rs`). The listener's
+    `peers: HashMap<SocketAddr, Peer>` was inserted-but-never-removed ("GC + idle
+    timeout come with M3c" — never built), so a client whose RDP/TCP session went away
+    kept its peer entry forever and `pump_peers_on_timer` kept RTO-retransmitting
+    unacked EGFX to it. Reproduced from a real mstsc pcap (EGFX-over-UDP reconnect):
+    after the client's TCP RST the server shipped UDP retransmits to the gone client
+    for the rest of the capture (~10s/32 pkts and still going), and recovery needed a
+    server restart — the user's "the UDP connection doesn't close on disconnect"
+    report. Fix: `Peer` gained `last_seen_ms`, bumped on **every inbound datagram**
+    (only inbound — a dead peer still *sends* outbound retransmits but receives
+    nothing, so its clock stops); a new `gc_idle_peers(peers, bound_addrs, now_ms)`
+    runs on the existing `retransmit_tick` (right after `pump_peers_on_timer`) and
+    evicts any peer idle > `PEER_IDLE_TIMEOUT_MS` (10s), also dropping its
+    `bound_addrs` cookie→addr mapping (`retain(|_, a| *a != gone)`). Activity-based, so
+    it covers graceful / abrupt / crashed disconnects uniformly; 10s is safe because a
+    live client — even idle — sends RDPEUDP keepalive/delayed-ACKs continuously
+    (~200/s in a real session). This is the listener-only backstop half of M3c; the
+    prompt server→listener "instant retire-on-disconnect" signal is still deferred (the
+    GC is needed regardless). Logs `evicted idle UDP peer` at `debug`
+    (`ironrdp_server::multitransport=debug`). Does NOT by itself fix the mstsc EGFX
+    reconnect-blank (a client-side surface-retention quirk + the clean-link limit may
+    compound it); the robust WiFi config remains `--udp-migrate-egfx` off (EGFX on TCP).
+    All `multitransport`-gated; feature-off byte-unchanged. See feasibility doc
+    "M3c peer GC".

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -19,8 +19,13 @@
 //!   first macrdp↔client capture (our own cookie + the client's resulting hash),
 //!   which is what's needed to derive/verify the exact hash formula; strict
 //!   binding to a specific TCP session lands in M3c.
-//! - Peers are demuxed by source address and never garbage-collected (one client
-//!   in the M3b path); GC + idle timeout come with M3c.
+//! - Peers are demuxed by source address and **idle-timeout garbage-collected**
+//!   (M3c): a peer with no *inbound* datagram for `PEER_IDLE_TIMEOUT_MS` is evicted
+//!   by `gc_idle_peers` (its `peers` entry + any `bound_addrs` cookie→addr mapping),
+//!   so a dead RDP session's reliability SM stops RTO-retransmitting to a gone client
+//!   and the maps don't leak for the process lifetime. The prompt server→listener
+//!   "instant retire-on-disconnect" signal is the still-deferred other half of M3c
+//!   (the idle GC is the needed backstop regardless).
 //!
 //! Cross-platform (pure tokio/std networking), so Linux CI exercises it too — see
 //! the loopback integration test in the macrdp crate (the vendored server is
@@ -116,6 +121,12 @@ struct Peer {
     dtls: Option<DtlsConn>,
     /// Whether we've logged DTLS-handshake completion (avoid log spam).
     dtls_done_logged: bool,
+    /// (M3c) Wall-clock ms (listener `start.elapsed()`) of the last *inbound*
+    /// datagram from this peer. Drives `gc_idle_peers`: a dead client (its RDP/TCP
+    /// session gone) stops acking, so this stops advancing while the reliability SM
+    /// would otherwise RTO-retransmit unacked data to it forever and the
+    /// `peers`/`bound_addrs` entries would leak for the process lifetime.
+    last_seen_ms: u64,
 }
 
 /// (P2.0 spike) Scan a raw RDPEUDP datagram for a **DTLS handshake** record — the
@@ -244,6 +255,47 @@ async fn pump_peers_on_timer(
         if retransmits > 0 || syn_retransmit {
             debug!(peer_addr = %addr, retransmits, syn_retransmit, "RDPEUDP RTO retransmit (timer)");
         }
+    }
+}
+
+/// (M3c) Evict a peer after this many ms with no *inbound* datagram. A live client —
+/// even an idle/quiet one — sends RDPEUDP keepalive/delayed ACKs continuously (a real
+/// session ran ~200 inbound pkts/s), so 10s is a very safe "the client is gone"
+/// threshold; a dead client sends nothing and ages out cleanly.
+const PEER_IDLE_TIMEOUT_MS: u64 = 10_000;
+
+/// (M3c) Idle-timeout garbage collection. Drop every peer whose last *inbound*
+/// datagram is older than `PEER_IDLE_TIMEOUT_MS`, along with any `bound_addrs`
+/// cookie→addr mapping pointing at it. Without this, peers inserted by
+/// `run_recv_loop` are never removed: a client whose RDP/TCP session has gone away
+/// stops acking but the reliability SM keeps RTO-retransmitting unacked EGFX to it
+/// forever (`pump_peers_on_timer`), and over a long-running server dead peers
+/// accumulate unbounded. Activity-based, so it covers graceful, abrupt, and crashed
+/// disconnects uniformly. O(peers) on each `retransmit_tick`; peers is a handful.
+fn gc_idle_peers(
+    peers: &mut HashMap<SocketAddr, Peer>,
+    bound_addrs: &mut HashMap<[u8; 16], SocketAddr>,
+    now_ms: u64,
+) {
+    let gone: Vec<SocketAddr> = peers
+        .iter()
+        .filter(|(_, p)| now_ms.saturating_sub(p.last_seen_ms) > PEER_IDLE_TIMEOUT_MS)
+        .map(|(addr, _)| *addr)
+        .collect();
+    for addr in gone {
+        let idle_ms = peers
+            .remove(&addr)
+            .map(|p| now_ms.saturating_sub(p.last_seen_ms))
+            .unwrap_or(0);
+        // Drop any cookie→addr bindings for the evicted peer so a stale cookie can't
+        // route server tunnel data to it (or to a later peer that reuses the addr).
+        bound_addrs.retain(|_, a| *a != addr);
+        debug!(
+            peer_addr = %addr,
+            idle_ms,
+            timeout_ms = PEER_IDLE_TIMEOUT_MS,
+            "evicted idle UDP peer (no inbound; reliability retransmits stop, state reclaimed)"
+        );
     }
 }
 
@@ -501,6 +553,10 @@ async fn run_recv_loop(
             _ = retransmit_tick.tick() => {
                 let now_ms = start.elapsed().as_millis() as u64;
                 pump_peers_on_timer(&socket, &mut peers, now_ms, cfg.mtu).await;
+                // (M3c) Reap peers whose client has gone away (no inbound for
+                // PEER_IDLE_TIMEOUT_MS) so the dead-peer retransmits above stop and
+                // peers/bound_addrs don't leak. Same tick — cheap, peers is small.
+                gc_idle_peers(&mut peers, &mut bound_addrs, now_ms);
                 continue;
             }
             out = outbound => {
@@ -597,8 +653,13 @@ async fn run_recv_loop(
                 dtls_observed: false,
                 dtls: None,
                 dtls_done_logged: false,
+                last_seen_ms: now_ms,
             }
         });
+        // (M3c) Any inbound datagram is liveness for the idle-GC clock. A dead client
+        // still emits outbound retransmits but receives nothing, so only *inbound*
+        // bumps this — its `last_seen_ms` then stops advancing and it ages out.
+        peer.last_seen_ms = now_ms;
 
         // (P2.0 spike) Before anything else, sniff the raw datagram for a DTLS
         // ClientHello. This fires on a *lossy* flow regardless of whether the


### PR DESCRIPTION
## Problem

The UDP multitransport listener's `peers: HashMap<SocketAddr, Peer>` was inserted-but-never-removed — the M3c GC half was never built (the module doc literally said *"never garbage-collected … GC + idle timeout come with M3c"*). So a client whose RDP/TCP session went away kept its peer entry forever, and `pump_peers_on_timer` kept RTO-retransmitting unacked EGFX to the gone client.

Reproduced from a real mstsc pcap (EGFX-over-UDP, `--udp-migrate-egfx`, WiFi): on reconnect the **video went blank**, and **UDP kept flowing to the client after it closed** — the pcap shows the server shipping UDP retransmits to the dead client for the rest of the capture (~10 s / 32 packets and still going) after its TCP session RST'd. Recovery needed a full server restart. This is the user's "the UDP connection doesn't close on disconnect" report.

## Fix (listener-only, `vendor/ironrdp-server/src/multitransport/listener.rs`)

- `Peer` gains `last_seen_ms`, bumped on **every inbound datagram** (only inbound — a dead peer still *sends* outbound retransmits but receives nothing, so its clock stops advancing and it ages out).
- `gc_idle_peers` runs on the existing `retransmit_tick` (right after `pump_peers_on_timer`) and evicts any peer idle > `PEER_IDLE_TIMEOUT_MS` (10 s), also dropping its `bound_addrs` cookie→addr mapping.
- Activity-based, so it covers graceful / abrupt / crashed disconnects uniformly. 10 s is safe: a live client — even idle — sends RDPEUDP keepalive/delayed-ACKs continuously (~200/s in a real session).

This is the **backstop** half of M3c; the prompt server→listener "instant retire-on-disconnect" signal stays deferred (the idle GC is needed regardless).

## Scope / caveat

Does **not** by itself fix the mstsc EGFX reconnect-blank — the tunnel is TLS-encrypted so the pcap can't prove the leak was the *sole* cause, and the documented mstsc EGFX surface-retention quirk + the clean-link limit (soak finding #4) may compound it. The robust WiFi config stays `--udp-migrate-egfx` off (EGFX on TCP).

All `multitransport`-gated; feature-off byte-unchanged.

## Verification

- [x] `cargo build --release`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check` — green.
- [ ] **Real mstsc (gate):** temporarily `UDP_MIGRATE_EGFX=1`, run with `RUST_LOG=info,ironrdp_server::multitransport=debug`, connect + close mstsc, confirm an `evicted idle UDP peer` log ~10 s later and that UDP to the old client stops; then reconnect a fresh mstsc to see whether the blank improves.