### PR TITLE
fix(multitransport): reset per-connection UDP state so EGFX-over-UDP reconnect renders

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,19 +16,21 @@ then delete; promote a parked item to *In flight* when work actually starts.
   routed EGFX over an unbound UDP tunnel → frames dropped → blank (fix: reset in the
   `run()` accept loop); (b) listener reused a stale established `Peer` on a same-port
   reconnect → new tunnel never bound, acks dropped (fix: replace the peer when a SYN
-  arrives on an already-established addr). **Server fix confirmed in the debug log**
-  (conn-2 EGFX pipeline byte-identical to conn-1: surface created+mapped, 3 IDRs
-  shipped, mstsc ACKing over the tunnel). Residual stale-frame on an **in-process**
-  reconnect is the documented mstsc surface-id-0 retention quirk (client-side; reached
-  over UDP exactly as over TCP; the `--fork-workers` cure can't combine with UDP).
-  **Verify the server fix via a FRESH mstsc process** (quit + reopen the app) over UDP
-  → should render cleanly. Follows the merged idle-GC (#87). See feasibility doc
-  "M3c reconnect state-reset".
+  arrives on an already-established addr). **Verified on real mstsc** — multi-cycle
+  reconnect now renders and stays responsive. Follows the merged idle-GC (#87). See
+  feasibility doc "M3c reconnect state-reset".
 
 ## Deferred — scoped, not started
 
 - [ ] **Congestion-responsive encoder rate control + frame dropping** (highest-value
-  video-under-loss work — helps BOTH the default TCP path and UDP). Today macrdp ships
+  video-under-loss work — helps BOTH the default TCP path and UDP). **Concrete
+  manifestation found 2026-06-28:** EGFX-over-UDP reconnect freezes *intermittently*
+  because the server never throttles on the client's EGFX `queueDepth` —
+  `GfxHandler::on_frame_ack` only records ack timing, so macrdp ships at full rate while
+  the client's queue runs away (observed peak ~352k) → frozen display + RDPEUDP ACK
+  storm. A focused **queue_depth-aware throttle / frame-drop** (a sub-piece of this item)
+  is the targeted fix; note raw `queueDepth` is oddly large even when healthy (~30k–82k),
+  so capture a real-Windows-server baseline before picking a threshold. Today macrdp ships
   a fixed ~60 fps + a 2 s periodic IDR regardless of the client's congestion signal, so
   under loss the ordered stream HOL-blocks and EGFX **freezes** (finding #3/#4). A real
   Windows server under the same ~8% loss **degrades gracefully** — skips frames / drops

--- a/TODO.md
+++ b/TODO.md
@@ -7,18 +7,18 @@ then delete; promote a parked item to *In flight* when work actually starts.
 
 ## In flight (needs an action)
 
-- [ ] **UDP multitransport peer leak — idle-timeout GC** (branch `fix/udp-peer-idle-gc`;
-  built + clippy/fmt green; **awaiting real-mstsc verification before merge**). Listener
-  `peers` map was inserted-but-never-removed (M3c GC never built), so a dead client kept
-  RTO-retransmitting unacked EGFX for the process lifetime — the user's "UDP doesn't close
-  on disconnect" + blank-on-reconnect pcap. Fix: `Peer.last_seen_ms` bumped on inbound,
-  `gc_idle_peers` evicts peers idle >10s (+ their `bound_addrs`) on the existing tick.
-  **Verify:** temporarily `UDP_MIGRATE_EGFX=1`, run with
-  `RUST_LOG=info,ironrdp_server::multitransport=debug`, connect+close mstsc, confirm an
-  `evicted idle UDP peer` log ~10s later and UDP to the old client stops; then reconnect a
-  fresh mstsc to see if the blank improves (if not → mstsc surface quirk / clean-link
-  limit, answer stays `--udp-migrate-egfx` off). Listener-only backstop; the prompt
-  server→listener instant-retire signal is still deferred. See feasibility doc "M3c peer GC".
+- [ ] **EGFX-over-UDP reconnect blank/black — per-connection state reset** (branch
+  `fix/udp-egfx-reconnect-state`; built + clippy/fmt green; **awaiting real-mstsc
+  verification before merge**). With `--udp-migrate-egfx`, 1st connection rendered but
+  reconnect went blank→black; plain-TCP EGFX reconnect was always fine (UDP-specific).
+  Two only-set-never-reset bugs on the persistent server+listener: (a) server
+  `egfx_on_udp` (+ lossy-audio counters + `egfx_on_lossy_handle`) stayed true → conn 2
+  routed EGFX over an unbound UDP tunnel → frames dropped → blank (fix: reset in the
+  `run()` accept loop); (b) listener reused a stale established `Peer` on a same-port
+  reconnect → new tunnel never bound, acks dropped (fix: replace the peer when a SYN
+  arrives on an already-established addr). **Verify:** `UDP_MIGRATE_EGFX=1`, connect →
+  disconnect → reconnect mstsc; EGFX should render on reconnect like the first connect.
+  Follows the merged idle-GC (#87). See feasibility doc "M3c reconnect state-reset".
 
 ## Deferred — scoped, not started
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,9 +16,14 @@ then delete; promote a parked item to *In flight* when work actually starts.
   routed EGFX over an unbound UDP tunnel → frames dropped → blank (fix: reset in the
   `run()` accept loop); (b) listener reused a stale established `Peer` on a same-port
   reconnect → new tunnel never bound, acks dropped (fix: replace the peer when a SYN
-  arrives on an already-established addr). **Verify:** `UDP_MIGRATE_EGFX=1`, connect →
-  disconnect → reconnect mstsc; EGFX should render on reconnect like the first connect.
-  Follows the merged idle-GC (#87). See feasibility doc "M3c reconnect state-reset".
+  arrives on an already-established addr). **Server fix confirmed in the debug log**
+  (conn-2 EGFX pipeline byte-identical to conn-1: surface created+mapped, 3 IDRs
+  shipped, mstsc ACKing over the tunnel). Residual stale-frame on an **in-process**
+  reconnect is the documented mstsc surface-id-0 retention quirk (client-side; reached
+  over UDP exactly as over TCP; the `--fork-workers` cure can't combine with UDP).
+  **Verify the server fix via a FRESH mstsc process** (quit + reopen the app) over UDP
+  → should render cleanly. Follows the merged idle-GC (#87). See feasibility doc
+  "M3c reconnect state-reset".
 
 ## Deferred — scoped, not started
 

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -396,6 +396,26 @@ finding #4 stands — under loss the reliable tunnel HOL-blocks regardless); thi
 about EGFX-over-UDP **reconnect** working at all on a clean link. See vendored server
 divergence (12) "M3c reconnect state-reset".
 
+**What it leaves: the documented mstsc surface-retention quirk, now reached over UDP.**
+After the state-reset fix, a real-mstsc retest (debug log) showed connection 2's EGFX
+pipeline is byte-identical to connection 1's — encoder init, **surface created+mapped,
+3 IDR keyframes shipped** — and **mstsc ACKs the frames over the UDP tunnel** (inbound
+`ACK | DATA` datagrams). So the server ships correctly on reconnect. But every
+per-connection `GraphicsPipelineServer` resets `next_surface_id` to **0**, and on an
+**in-process** reconnect (mstsc.exe kept running, only the connection reopened) mstsc
+**retains surface id 0** and no-ops the `CreateSurface` for an id it already holds → the
+new frames decode into the **stale** surface → the client shows "the last frame before
+the previous disconnect," frozen (input rides TCP and still reaches the Mac — it's the
+*video* that's frozen on the retained surface, so it only *looks* unresponsive). This is
+exactly the **documented mstsc EGFX reconnect-blank quirk** (`known-quirks.md`), now
+reached over UDP identically to TCP — a **client** limitation, not a server bug. The
+normal cure is process-freshness (`--fork-workers`), which is **mutually exclusive with
+UDP multitransport** (the persistent UDP socket can't be owned by a per-connection
+worker) — so EGFX-over-UDP can't use it. Recovery is the same as the TCP case: **fully
+close + reopen mstsc** (a fresh *process* has no retained surface 0 and renders cleanly
+on reconnect — which is also the clean way to verify this server fix). Everyday robust
+config stays `--udp-migrate-egfx` off.
+
 ### P2.2 lossy-delivery soak (runbook)
 
 The first soak (above) shaped the **reliable** EGFX-over-UDP path. This one targets the

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -396,25 +396,33 @@ finding #4 stands — under loss the reliable tunnel HOL-blocks regardless); thi
 about EGFX-over-UDP **reconnect** working at all on a clean link. See vendored server
 divergence (12) "M3c reconnect state-reset".
 
-**What it leaves: the documented mstsc surface-retention quirk, now reached over UDP.**
-After the state-reset fix, a real-mstsc retest (debug log) showed connection 2's EGFX
-pipeline is byte-identical to connection 1's — encoder init, **surface created+mapped,
-3 IDR keyframes shipped** — and **mstsc ACKs the frames over the UDP tunnel** (inbound
-`ACK | DATA` datagrams). So the server ships correctly on reconnect. But every
-per-connection `GraphicsPipelineServer` resets `next_surface_id` to **0**, and on an
-**in-process** reconnect (mstsc.exe kept running, only the connection reopened) mstsc
-**retains surface id 0** and no-ops the `CreateSurface` for an id it already holds → the
-new frames decode into the **stale** surface → the client shows "the last frame before
-the previous disconnect," frozen (input rides TCP and still reaches the Mac — it's the
-*video* that's frozen on the retained surface, so it only *looks* unresponsive). This is
-exactly the **documented mstsc EGFX reconnect-blank quirk** (`known-quirks.md`), now
-reached over UDP identically to TCP — a **client** limitation, not a server bug. The
-normal cure is process-freshness (`--fork-workers`), which is **mutually exclusive with
-UDP multitransport** (the persistent UDP socket can't be owned by a per-connection
-worker) — so EGFX-over-UDP can't use it. Recovery is the same as the TCP case: **fully
-close + reopen mstsc** (a fresh *process* has no retained surface 0 and renders cleanly
-on reconnect — which is also the clean way to verify this server fix). Everyday robust
-config stays `--udp-migrate-egfx` off.
+**Verified on real mstsc, plus the residual it leaves.** After the state-reset fix, a
+real-mstsc retest confirmed connection 2's EGFX pipeline matches connection 1's
+(encoder init, surface created+mapped, frames shipped, **mstsc ACKing over the UDP
+tunnel**), and a multi-cycle reconnect test **rendered and stayed responsive** (typing
+and clicks work). So the fix works in the normal case. (An earlier mid-investigation
+guess that the residual was the documented mstsc *surface-retention* quirk was
+**disproven** — it reproduced on a fully fresh mstsc *process*, which has no retained
+surface 0.)
+
+**Residual — an intermittent EGFX frame/queue runaway (the rate-control gap, finding
+#5).** The reconnect freeze still recurs **intermittently** under stress (rapid
+repeated reconnects). The trace shows why: the server **never throttles on the client's
+EGFX `queue_depth`** — `GfxHandler::on_frame_ack` only records ack timing; macrdp ships
+at full rate regardless of how backed-up the client reports it is. The client's
+`queueDepth` is already large even on a healthy first connect (~30k–82k) and on a bad
+reconnect it **runs away** (observed peak **352k**) while the RDPEUDP layer floods pure
+ACKs — the client falls hopelessly behind and the display freezes on a stale frame
+(input still reaches the Mac over TCP, so it only *looks* dead). So `queue_depth` is an
+unreliable freeze *predictor* (huge in both healthy and frozen states) but the
+**runaway** is the failure mode. This is the same **"server ignores client
+congestion/queue feedback"** gap captured in finding #5 / the rate-control TODO — it
+bites hardest on reconnect, where the client starts more backed-up. The real fix is
+**queue_depth-aware throttling / frame dropping** (a focused piece of the finding-#5
+rate-control work), ideally informed by a real-Windows-server capture first, since the
+raw `queueDepth` units are oddly large and a naive threshold would mis-fire. Everyday
+robust config stays `--udp-migrate-egfx` off (and `--fork-workers` gives clean
+in-process reconnect on the TCP path; it's mutually exclusive with UDP multitransport).
 
 ### P2.2 lossy-delivery soak (runbook)
 

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -352,12 +352,49 @@ session). Logs `evicted idle UDP peer` at `ironrdp_server::multitransport=debug`
 
 This is the listener-only **backstop** half of M3c; the prompt server→listener
 "instant retire-on-disconnect" signal is still deferred (the GC is needed regardless).
-**It does NOT by itself fix the reconnect-blank** — the tunnel is TLS-encrypted so the
-pcap can't prove the leak was the *sole* cause, and the documented mstsc EGFX
-surface-retention quirk + the clean-link limit (finding #4) may compound it. The
-robust WiFi config stays `--udp-migrate-egfx` off (EGFX on TCP). Real-mstsc retest of
-the GC (watch for the eviction log ~10 s after close + UDP actually stopping) is the
-gate. See vendored server divergence (12) "M3c idle-timeout peer GC".
+The GC was **verified on real mstsc** — UDP to the closed client stops ~10 s after
+disconnect. **By itself it did NOT fix the reconnect-blank**, which turned out to be a
+*separate* per-connection-state bug (next section).
+
+### M3c reconnect state-reset — EGFX-over-UDP blank/black on the 2nd connection (fixed 2026-06-28)
+
+After the GC landed, real-mstsc retest isolated the reconnect-blank precisely: with
+`--udp-migrate-egfx`, the **first** connection rendered, but a **reconnect** showed a
+blank desktop that went black (EGFX wedged after a frame or two). Crucially, **plain
+TCP** EGFX reconnect (`--udp-migrate-egfx` off) was always clean — so it was
+UDP-specific, not the capture-primary/window-relocation gotcha and not (only) the mstsc
+surface-retention quirk (it reproduced even on a fresh mstsc process). Two
+per-connection-state bugs on the *persistent* server + listener, both "set once on
+connection 1, never reset for connection 2":
+
+1. **Server (`server.rs`, the universal cause).** `egfx_on_udp` (set true at Soft-Sync,
+   checked to route EGFX over UDP) — plus `lossy_audio_block_no`,
+   `lossy_audio_streaming`, and the `egfx_on_lossy_handle` flag — were never cleared
+   between connections (the single `RdpServer` is reused across the accept loop). So
+   connection 2 started with `egfx_on_udp == true` and routed EGFX over a UDP tunnel
+   that **its own** Soft-Sync hadn't bound yet (cookie unbound) → frames dropped, and
+   nothing on TCP either → blank/black. Fix: reset these right after
+   `self.static_channels = StaticChannelSet::new()` in `run()`. Connection 2 now keeps
+   EGFX on TCP until its tunnel binds and re-fires Soft-Sync (clean migration; correct
+   TCP fallback if the new tunnel never binds). (`multitransport_migration` /
+   `udp_tunnel_bound` / the inbound rx were already refreshed per connection at the
+   offer site — only these only-set-never-reset flags needed clearing.)
+2. **Listener (`listener.rs`, the same-port case).** On a fast reconnect that reused
+   the client's UDP source addr/port (within the 10 s idle-GC window), the
+   `peers.entry(addr).or_insert_with` reused the **stale** established `Peer` —
+   `tunnel_created` still true, `inbound_sink` still pointing at the gone connection's
+   receiver — so `handle_emt_tunnel` skipped the new CREATEREQUEST (gated on
+   `!tunnel_created`) and silently dropped connection 2's inbound EGFX acks. Fix:
+   before the entry, if a **SYN** arrives on an address whose existing peer is already
+   `is_established()`, it's a new flow on a reused port → remove the stale peer (+ its
+   `bound_addrs` bindings) so a fresh one is built and the new tunnel binds cleanly.
+   (A SYN on a still-handshaking peer is a normal SYN retransmit — `is_established()`
+   gates it out.)
+
+The robust WiFi config is still `--udp-migrate-egfx` off (the clean-link limit /
+finding #4 stands — under loss the reliable tunnel HOL-blocks regardless); this fix is
+about EGFX-over-UDP **reconnect** working at all on a clean link. See vendored server
+divergence (12) "M3c reconnect state-reset".
 
 ### P2.2 lossy-delivery soak (runbook)
 

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -791,3 +791,35 @@ AND released — #1276 landing is NOT sufficient.
     compound it); the robust WiFi config remains `--udp-migrate-egfx` off (EGFX on TCP).
     All `multitransport`-gated; feature-off byte-unchanged. See feasibility doc
     "M3c peer GC".
+
+    M3c reconnect state-reset — EGFX-over-UDP went blank/black on the 2nd
+    connection (2026-06-28, `server.rs` + `listener.rs`; verified on real mstsc).
+    With `--udp-migrate-egfx`, the FIRST connection rendered but a RECONNECT showed a
+    blank desktop that went black (EGFX wedged after a frame or two); plain-TCP EGFX
+    reconnect was always fine, so it was UDP-specific. TWO per-connection-state bugs on
+    the persistent server+listener, both "set once on connection 1, never reset for
+    connection 2":
+    (a) **Server (`server.rs`, the universal cause):** `egfx_on_udp` (set true at
+    Soft-Sync, checked to route EGFX over UDP) — plus `lossy_audio_block_no`,
+    `lossy_audio_streaming`, and the `egfx_on_lossy_handle` flag — were never cleared
+    between connections. So connection 2 started with `egfx_on_udp == true` and routed
+    EGFX over a UDP tunnel **its own** Soft-Sync hadn't bound yet (cookie unbound) →
+    frames dropped, and nothing went out on TCP either → blank/black. Fix: reset all of
+    these right after `self.static_channels = StaticChannelSet::new()` in the `run()`
+    accept loop (the post-connection cleanup). Now connection 2 keeps EGFX on TCP until
+    its tunnel binds and re-fires Soft-Sync (clean migration; and a correct TCP fallback
+    if the new tunnel never binds). (`multitransport_migration` / `udp_tunnel_bound` /
+    the inbound rx are already refreshed per connection at the offer site, so only these
+    only-set-never-reset flags needed clearing.)
+    (b) **Listener (`listener.rs`, the same-port case):** on a fast reconnect that
+    reused the client's UDP source addr/port (within the 10s idle-GC window), the
+    `peers.entry(addr).or_insert_with` reused the **stale** established `Peer` —
+    `tunnel_created` still true and `inbound_sink` still pointing at the gone
+    connection's receiver — so `handle_emt_tunnel` skipped the new CREATEREQUEST
+    (gated on `!tunnel_created`) and silently dropped connection 2's inbound EGFX acks.
+    Fix: before the entry, if a **SYN** arrives on an address whose existing peer is
+    already `is_established()`, it's a new flow on a reused port → remove the stale peer
+    (+ its `bound_addrs` cookie bindings) so a fresh one is built and the new tunnel
+    binds cleanly. A SYN on a still-handshaking peer is a normal SYN retransmit
+    (`is_established()` gates it out). All `multitransport`-gated; feature-off
+    byte-unchanged. See feasibility doc "M3c reconnect state-reset".

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -821,5 +821,12 @@ AND released — #1276 landing is NOT sufficient.
     already `is_established()`, it's a new flow on a reused port → remove the stale peer
     (+ its `bound_addrs` cookie bindings) so a fresh one is built and the new tunnel
     binds cleanly. A SYN on a still-handshaking peer is a normal SYN retransmit
-    (`is_established()` gates it out). All `multitransport`-gated; feature-off
-    byte-unchanged. See feasibility doc "M3c reconnect state-reset".
+    (`is_established()` gates it out). **Verified on real mstsc** — multi-cycle reconnect
+    now renders and stays responsive. **Residual (NOT this fix):** reconnect still freezes
+    *intermittently* under stress because the EGFX path never throttles on the client's
+    `queueDepth` (`GfxHandler::on_frame_ack` only records timing) → the client's frame
+    queue can run away (peak ~352k) → frozen display + RDPEUDP ACK storm. That's the
+    rate-control gap (finding #5), tracked separately; the earlier "mstsc
+    surface-retention quirk" guess was disproven (it reproduced on a fresh mstsc process).
+    All `multitransport`-gated; feature-off byte-unchanged. See feasibility doc
+    "M3c reconnect state-reset".

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -616,6 +616,23 @@ async fn run_recv_loop(
         let use_lossy = lossy_delivery
             && Datagram::peek_fec_flags(data).is_some_and(|f| f.contains(FecFlags::SYN_LOSSY));
 
+        // (M3c) Port reuse on reconnect: if a *new* RDPEUDP flow opens (a SYN) on
+        // the source address of an already-ESTABLISHED peer, the previous
+        // connection's client reused this addr/port (common on a fast in-process
+        // reconnect, within the 10s idle-GC window). The stale peer's SM is
+        // established and its tunnel state (`tunnel_created` + an `inbound_sink`
+        // pointing at the GONE connection's receiver) would make `handle_emt_tunnel`
+        // skip the new tunnel's CREATEREQUEST and silently drop the new connection's
+        // inbound EGFX acks → the new session wedges blank/black. Drop the stale peer
+        // (and its cookie bindings) so a fresh one is built below and the new tunnel
+        // binds cleanly. (A SYN on a still-HANDSHAKING peer is a normal SYN
+        // retransmit — `is_established()` gates that out.)
+        if is_syn_family(data) && peers.get(&peer_addr).is_some_and(|p| p.sm.is_established()) {
+            peers.remove(&peer_addr);
+            bound_addrs.retain(|_, a| *a != peer_addr);
+            debug!(%peer_addr, "RDPEUDP SYN on an established peer — replacing stale peer (port reuse / reconnect)");
+        }
+
         let peer = peers.entry(peer_addr).or_insert_with(|| {
             session_counter = session_counter.wrapping_add(1);
             let initial_seq = cfg.server_isn_seed.wrapping_add(session_counter);

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -976,6 +976,30 @@ impl RdpServer {
 
                         self.static_channels = StaticChannelSet::new();
 
+                        // (M3c) Reset per-connection UDP-multitransport state that is
+                        // otherwise only ever SET, never cleared — so a reconnect to
+                        // this same persistent RdpServer starts clean. Critically
+                        // `egfx_on_udp`: left true from the previous connection, the
+                        // next connection routes EGFX over a UDP tunnel that its OWN
+                        // Soft-Sync hasn't bound yet → frames are dropped and the
+                        // client sees a blank/black desktop on reconnect. Resetting it
+                        // keeps EGFX on TCP until the new connection's tunnel binds and
+                        // re-fires Soft-Sync (clean migration; and a correct TCP
+                        // fallback if the new tunnel never binds). The lossy-audio
+                        // counters + the on-lossy handle must likewise restart.
+                        // (`multitransport_migration`, `udp_tunnel_bound`, and the
+                        // inbound rx ARE refreshed per connection at the offer site, so
+                        // only these only-set-never-reset flags need clearing here.)
+                        #[cfg(feature = "multitransport")]
+                        {
+                            self.egfx_on_udp = false;
+                            self.lossy_audio_block_no = 0;
+                            self.lossy_audio_streaming = false;
+                            if let Some(handle) = &self.egfx_on_lossy_handle {
+                                handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                            }
+                        }
+
                         if let Some(ref mut handler) = self.connection_handler {
                             let action = handler.on_disconnected(
                                 peer,


### PR DESCRIPTION
## Problem

With `--udp-migrate-egfx`, the **first** client connection rendered fine, but a **reconnect** to the same still-running server showed a blank desktop that went black. Plain-TCP EGFX reconnect was always clean — **UDP-specific**.

Two per-connection-state bugs on the **persistent** server + listener (both "set once on connection 1, never reset for connection 2"):

1. **Server (`server.rs`).** `egfx_on_udp` (+ `lossy_audio_block_no`, `lossy_audio_streaming`, `egfx_on_lossy_handle`) were never cleared between connections, so connection 2 routed EGFX over a UDP tunnel its own Soft-Sync hadn't bound yet (cookie unbound) → frames dropped, nothing on TCP either → blank/black. **Fix:** reset them after the static-channel reset in `run()`.
2. **Listener (`listener.rs`).** A same-port reconnect reused the stale established `Peer` (`tunnel_created` true, `inbound_sink` pointing at the gone connection) → new CREATEREQUEST skipped, inbound acks dropped. **Fix:** a SYN on an already-`is_established()` addr replaces the stale peer.

## Verification (real mstsc)

- ✅ Connection 2's EGFX pipeline matches connection 1's (surface created+mapped, frames shipped, client ACKing over the UDP tunnel).
- ✅ **Multi-cycle reconnect renders and stays responsive** (typing/clicks work).
- `cargo build --release` / `clippy -D warnings` / `fmt --check` green.

## Scope / what this does NOT fix

This removes the blank→black **routing** bug; it does **not** eliminate an **intermittent** reconnect freeze that still recurs under stress (rapid repeated reconnects). Root-caused to a **separate** issue: the EGFX path never throttles on the client's `queueDepth` (`on_frame_ack` only records timing), so the client's frame queue can run away (observed peak ~352k) → frozen display + RDPEUDP ACK storm. That's the **rate-control gap (finding #5)**, tracked separately — not in scope here. (An earlier guess that the residual was the mstsc surface-retention quirk was disproven — it reproduced on a fresh mstsc process.)

All `multitransport`-gated; feature-off byte-unchanged. Follows the merged idle-GC (#87).