### PR TITLE
fix(h264/multitransport): EGFX-over-UDP frame-ack-lag backpressure with a trickle floor

### DIFF
--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -417,12 +417,40 @@ ACKs — the client falls hopelessly behind and the display freezes on a stale f
 unreliable freeze *predictor* (huge in both healthy and frozen states) but the
 **runaway** is the failure mode. This is the same **"server ignores client
 congestion/queue feedback"** gap captured in finding #5 / the rate-control TODO — it
-bites hardest on reconnect, where the client starts more backed-up. The real fix is
-**queue_depth-aware throttling / frame dropping** (a focused piece of the finding-#5
-rate-control work), ideally informed by a real-Windows-server capture first, since the
-raw `queueDepth` units are oddly large and a naive threshold would mis-fire. Everyday
-robust config stays `--udp-migrate-egfx` off (and `--fork-workers` gives clean
-in-process reconnect on the TCP path; it's mutually exclusive with UDP multitransport).
+bites hardest on reconnect, where the client starts more backed-up.
+
+**FIXED 2026-06-28 — frame-ack-lag backpressure with a TRICKLE FLOOR (the first
+focused piece of the finding-#5 rate-control work; verified on real mstsc under the
+exact repro that froze: headless `--virtual-display --capture-primary`, YouTube +
+rapidly held Cmd+Tab).** `src/h264.rs`'s `submit_bgra` now, on the UDP tunnel only,
+tracks per-frame lag = `last_shipped_frame_id − last_acked_frame_id` (the EGFX
+FrameAcknowledge id, recorded in `on_frame_ack`) and, when it exceeds
+`MACRDP_UDP_EGFX_MAX_FRAME_LAG` (default 16), **drops most captures so the client
+catches up** — capping the queue runaway. The load-bearing subtlety (and the bug in
+the first cut): it must **NOT drop to zero**. mstsc only *presents* — and therefore
+*frame-acks* — an H.264 frame once a couple more arrive behind it (the same
+presentation-buffer behaviour the `--flush-frames` burst feeds). With zero trailing
+frames the client never acks the in-flight ones, `lag` stays pinned one over the
+threshold, every capture is dropped, and the video **freezes permanently** (recovers
+only on reconnect — exactly the reported symptom). The fix keeps a low-rate **trickle**
+(`UDP_THROTTLE_FLOOR`, ~10 fps) flowing while lag is high, so the client keeps
+presenting + acking and the window reopens; dropping *before* encode keeps the H.264
+reference chain valid (the next encoded frame is a P-frame from the client's last
+reference). Net: under load the video degrades to **choppy-but-live** instead of
+freezing.
+
+*(Diagnostic dead-end, recorded so it isn't re-chased: a `sample` of the frozen
+process shows the `egfx-ship` thread parked in `_dispatch_semaphore_wait_slow` — this
+is NOT a stall. Rust's `std::sync::mpsc` implements its blocking `recv()` via a
+libdispatch semaphore on macOS, so an idle ship thread waiting for the next encoded
+frame looks exactly like that. The freeze was upstream of it — the capture-side gate
+dropping every frame so nothing was ever encoded.)*
+
+A fuller rate controller (continuous queue_depth-aware pacing, ideally informed by a
+real-Windows-server capture since the raw `queueDepth` units are oddly large) remains
+finding-#5 future work. Everyday robust config stays `--udp-migrate-egfx` off (and
+`--fork-workers` gives clean in-process reconnect on the TCP path; it's mutually
+exclusive with UDP multitransport).
 
 ### P2.2 lossy-delivery soak (runbook)
 

--- a/src/h264.rs
+++ b/src/h264.rs
@@ -71,6 +71,14 @@ use tracing::{debug, info, trace, warn};
 
 use crate::videotoolbox::{EncodedFrame, Encoder};
 
+/// Minimum spacing between "trickle" frames let through the EGFX-on-UDP
+/// backpressure gate while the client's frame-ack lag is over the threshold.
+/// ~10 fps: enough trailing frames for mstsc to keep presenting + acking (so
+/// the window reopens and lag recovers) while still throttling well below the
+/// full 60 fps so the client's decode queue drains net. See the gate in
+/// `submit_bgra` and `ConnectionContext::last_throttle_ship`.
+const UDP_THROTTLE_FLOOR: Duration = Duration::from_millis(100);
+
 /// How the H.264 NAL units are framed inside the AVC420 wire payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WireFormat {
@@ -143,6 +151,31 @@ struct ConnectionContext {
     acks_suspended: bool,
     last_ship_at: Instant,
     last_recovery_at: Instant,
+    /// EGFX-on-UDP frame-ack backpressure. `last_shipped_frame_id` is the id of
+    /// the most recent frame handed to `send_avc420_frame` (bumped by the ship
+    /// thread); `last_acked_frame_id` is the most recent frame the client
+    /// reported *decoded* via RDPGFX_FRAME_ACKNOWLEDGE (bumped in `on_frame_ack`).
+    /// Their difference is the client's decode backlog. On TCP the socket's own
+    /// backpressure paces the server to the client; on the UDP tunnel nothing
+    /// does, so without this the server floods frames and the client's decode
+    /// queue runs away → frozen video. `submit_bgra` drops captures (to latest)
+    /// when the lag exceeds the threshold — but only once `egfx_acks_seen` (avoid
+    /// a cold-start false drop before the first ack) and only while EGFX is on the
+    /// UDP tunnel (`Gfx::egfx_on_udp`) and acks aren't suspended. `Arc` so the
+    /// ship thread can bump `last_shipped_frame_id` without taking the ctx lock
+    /// (the ship-path lock-order invariant: never hold ctx under server_handle).
+    last_shipped_frame_id: Arc<AtomicU64>,
+    last_acked_frame_id: Arc<AtomicU64>,
+    egfx_acks_seen: bool,
+    /// When the EGFX-on-UDP backpressure gate last let a "trickle" frame
+    /// through while lag was over the threshold. The gate drops MOST captures
+    /// when the client is behind, but NOT all of them: mstsc only *presents*
+    /// (and thus frame-acks) an H.264 frame once a couple more arrive behind
+    /// it, so dropping to zero starves that — the acks never advance, lag never
+    /// recovers, and video freezes permanently. This timestamp paces a low-rate
+    /// floor (`UDP_THROTTLE_FLOOR`) so the client always has trailing frames to
+    /// drain its presentation buffer and the window reopens.
+    last_throttle_ship: Instant,
 }
 
 /// Tunables for ack-driven IDR recovery (EGFX-on-lossy). See
@@ -243,6 +276,18 @@ pub struct Gfx {
     recovery_enabled: bool,
     recovery_params: RecoveryParams,
     egfx_on_lossy: Arc<AtomicBool>,
+    /// Runtime gate the vendored server flips true when EGFX is migrated onto the
+    /// UDP multitransport tunnel (reliable OR lossy). Enables the frame-ack-lag
+    /// backpressure in `submit_bgra` — only on the UDP tunnel, since the TCP path
+    /// is paced by socket backpressure and must stay byte-identical (never-drop
+    /// push model). Stays false on TCP → the gate is a no-op there.
+    egfx_on_udp: Arc<AtomicBool>,
+    /// Max EGFX frame-ack lag (shipped − decoded, in frames) tolerated on the UDP
+    /// tunnel before `submit_bgra` drops captures to let the client catch up.
+    /// `MACRDP_UDP_EGFX_MAX_FRAME_LAG` (default 16 ≈ 266 ms at 60 fps). High enough
+    /// that a healthy high-RTT link never trips it; low enough to cap the decode
+    /// backlog so video degrades to choppy-but-live instead of freezing.
+    max_frame_lag: u64,
 }
 
 impl Gfx {
@@ -253,9 +298,15 @@ impl Gfx {
         keyframe_secs: f32,
         max_in_flight: u32,
         egfx_on_lossy: Arc<AtomicBool>,
+        egfx_on_udp: Arc<AtomicBool>,
     ) -> Self {
         let wire_format = WireFormat::from_env();
         let (recovery_enabled, recovery_params) = recovery_config_from_env();
+        let max_frame_lag = std::env::var("MACRDP_UDP_EGFX_MAX_FRAME_LAG")
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(16);
         let (width, height) = desktop_size.get();
         info!(
             ?wire_format,
@@ -280,6 +331,8 @@ impl Gfx {
             recovery_enabled,
             recovery_params,
             egfx_on_lossy,
+            egfx_on_udp,
+            max_frame_lag,
         }
     }
 
@@ -365,6 +418,51 @@ impl Gfx {
                     "EGFX pipeline full; dropping capture to latest"
                 );
                 return Ok(true); // still the active path; just dropped this frame
+            }
+            // EGFX-on-UDP frame-ack backpressure: on the UDP tunnel there's no
+            // socket backpressure to pace us to the client (unlike TCP), so without
+            // this the server floods frames and the client's DECODE queue runs away
+            // → frozen video while audio (on TCP) keeps playing. When the client's
+            // decode backlog (shipped − decoded, from FrameAcknowledge) exceeds the
+            // threshold, drop this capture so the client catches up — video degrades
+            // to choppy-but-live instead of freezing. Gated to the UDP tunnel
+            // (TCP push path stays byte-identical), to acks actually flowing (a
+            // suspended-ack client falls back to the submitted−shipped throttle
+            // above), and to having seen ≥1 ack (no cold-start false drop). Dropping
+            // before encode keeps the H.264 reference chain valid.
+            if self.egfx_on_udp.load(Ordering::Relaxed) && ctx.egfx_acks_seen && !ctx.acks_suspended
+            {
+                let lag = ctx
+                    .last_shipped_frame_id
+                    .load(Ordering::Relaxed)
+                    .saturating_sub(ctx.last_acked_frame_id.load(Ordering::Relaxed));
+                if lag > self.max_frame_lag {
+                    // Client is behind. Drop MOST captures so it catches up — but
+                    // keep a low-rate trickle, never zero: mstsc only presents (and
+                    // thus frame-acks) an H.264 frame once a couple more arrive
+                    // behind it, so dropping to zero means it never acks the
+                    // in-flight frames, `lag` never falls back under the threshold,
+                    // and the video freezes PERMANENTLY (recovers only on
+                    // reconnect). The trickle keeps trailing frames flowing so the
+                    // presentation buffer drains and the window reopens. Dropping
+                    // before encode keeps the H.264 reference chain valid (the
+                    // encoder never sees the dropped frames, so the next encoded
+                    // frame is a valid P-frame from the client's last reference).
+                    let now = Instant::now();
+                    if now.duration_since(ctx.last_throttle_ship) < UDP_THROTTLE_FLOOR {
+                        trace!(
+                            lag,
+                            "EGFX-on-UDP lag high; dropping capture (trickle floor)"
+                        );
+                        return Ok(true);
+                    }
+                    ctx.last_throttle_ship = now;
+                    trace!(
+                        lag,
+                        "EGFX-on-UDP lag high; letting a trickle frame through to drain client buffer"
+                    );
+                    // fall through: ship this one to keep the client presenting/acking
+                }
             }
             std::mem::replace(&mut ctx.need_keyframe, false)
         };
@@ -506,7 +604,7 @@ impl Gfx {
             // few seconds" stall, far more likely once acks ride the UDP tunnel).
             // Cloning the `server_handle` Arc and releasing `ctx` first keeps the
             // lock order consistent (server_handle is never nested under ctx).
-            let (surface_id, width, height, epoch, server_handle) = {
+            let (surface_id, width, height, epoch, server_handle, last_shipped) = {
                 let mut guard = self.ctx.lock().unwrap();
                 let ctx = guard
                     .as_mut()
@@ -518,7 +616,17 @@ impl Gfx {
                 let epoch = ctx.epoch;
                 // Liveness for ack-driven IDR recovery: we're actively shipping.
                 ctx.last_ship_at = Instant::now();
-                (surface_id, width, height, epoch, ctx.server_handle.clone())
+                // Clone the shipped-frame-id gauge so we can bump it in Phase 2
+                // (under server_handle) WITHOUT re-taking the ctx lock — preserving
+                // the never-hold-ctx-under-server_handle invariant.
+                (
+                    surface_id,
+                    width,
+                    height,
+                    epoch,
+                    ctx.server_handle.clone(),
+                    ctx.last_shipped_frame_id.clone(),
+                )
             };
 
             // Phase 2: lock `server_handle` ALONE (ctx already released).
@@ -551,7 +659,13 @@ impl Gfx {
                 // the surface stays blank.
                 let ps_count = f.parameter_sets.len();
                 let ps_bytes: usize = f.parameter_sets.iter().map(Vec::len).sum();
-                match server.send_avc420_frame(surface_id, &payload, &[region], ts_ms) {
+                let sent = server.send_avc420_frame(surface_id, &payload, &[region], ts_ms);
+                // Record the newest shipped frame id for the UDP frame-ack-lag
+                // backpressure gate (`submit_bgra`). Monotonic per connection.
+                if let Some(frame_id) = sent {
+                    last_shipped.store(u64::from(frame_id), Ordering::Relaxed);
+                }
+                match sent {
                     Some(frame_id) if f.is_keyframe => debug!(
                         frame_id,
                         ?self.wire_format,
@@ -676,6 +790,10 @@ impl GfxServerFactory for Gfx {
             acks_suspended: false,
             last_ship_at: Instant::now(),
             last_recovery_at: Instant::now(),
+            last_shipped_frame_id: Arc::new(AtomicU64::new(0)),
+            last_acked_frame_id: Arc::new(AtomicU64::new(0)),
+            egfx_acks_seen: false,
+            last_throttle_ship: Instant::now(),
         });
         Some((GfxDvcBridge::new(handle.clone()), handle))
     }
@@ -779,6 +897,16 @@ impl GraphicsPipelineHandler for GfxHandler {
         if let Some(ctx) = self.ctx.lock().unwrap().as_mut() {
             ctx.last_ack_at = Instant::now();
             ctx.acks_suspended = queue_depth == 0xFFFF_FFFF;
+            // Record decode progress for the UDP frame-ack-lag backpressure gate.
+            // The client sends FrameAcknowledge after it DECODES a frame, so this
+            // is the floor of its decode backlog. Only advance on a real ack (not
+            // the suspend sentinel), and mark that we've seen at least one ack so
+            // `submit_bgra` doesn't false-drop during cold start.
+            if !ctx.acks_suspended {
+                ctx.last_acked_frame_id
+                    .store(u64::from(frame_id), Ordering::Relaxed);
+                ctx.egfx_acks_seen = true;
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2006,6 +2006,10 @@ async fn async_main() -> Result<()> {
     // server flips it at the migration site. Cross-platform so the UDP listener
     // wiring below (which hands the same clone to the server) compiles on CI.
     let egfx_on_lossy_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    // Companion flag: EGFX migrated onto ANY UDP tunnel (reliable or lossy). The
+    // H.264 pipeline reads it to enable frame-ack-lag backpressure (the UDP tunnel
+    // has no socket pacing); the server flips it at the same migration site.
+    let egfx_on_udp_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     // EGFX/H.264 video pipeline (macOS-only; opt-in via --enable-h264). One
     // clone drives the builder's GfxServerFactory (protocol side); another
@@ -2019,6 +2023,7 @@ async fn async_main() -> Result<()> {
             args.keyframe_interval,
             args.h264_frames_in_flight.max(1),
             egfx_on_lossy_flag.clone(),
+            egfx_on_udp_flag.clone(),
         )
     });
 
@@ -2230,6 +2235,10 @@ async fn async_main() -> Result<()> {
                 // flag the H.264 pipeline reads. The server flips it true only when
                 // it migrates EGFX onto the LOSSY tunnel.
                 server.set_egfx_on_lossy_handle(Some(egfx_on_lossy_flag.clone()));
+                // Frame-ack-lag backpressure: the server flips this true whenever it
+                // migrates EGFX onto a UDP tunnel (reliable or lossy), and the H.264
+                // pipeline drops captures when the client's decode backlog runs away.
+                server.set_egfx_on_udp_handle(Some(egfx_on_udp_flag.clone()));
                 // (P2.4b, EXPERIMENTAL) Register the lossy-UDP audio DVC
                 // (AUDIO_PLAYBACK_LOSSY_DVC). Behind its OWN dedicated env gate
                 // (`MACRDP_UDP_LOSSY_AUDIO=1`) — NOT the lossy-offer flag — so the

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -822,11 +822,19 @@ AND released — #1276 landing is NOT sufficient.
     (+ its `bound_addrs` cookie bindings) so a fresh one is built and the new tunnel
     binds cleanly. A SYN on a still-handshaking peer is a normal SYN retransmit
     (`is_established()` gates it out). **Verified on real mstsc** — multi-cycle reconnect
-    now renders and stays responsive. **Residual (NOT this fix):** reconnect still freezes
-    *intermittently* under stress because the EGFX path never throttles on the client's
-    `queueDepth` (`GfxHandler::on_frame_ack` only records timing) → the client's frame
-    queue can run away (peak ~352k) → frozen display + RDPEUDP ACK storm. That's the
-    rate-control gap (finding #5), tracked separately; the earlier "mstsc
-    surface-retention quirk" guess was disproven (it reproduced on a fresh mstsc process).
-    All `multitransport`-gated; feature-off byte-unchanged. See feasibility doc
-    "M3c reconnect state-reset".
+    now renders and stays responsive. **Residual (the EGFX-over-UDP freeze under load /
+    on reconnect) — FIXED 2026-06-28 in `macrdp` (`src/h264.rs`), not this crate:** the
+    EGFX path never throttled on the client's `queueDepth`, so under a high-volume stream
+    (or a backed-up reconnect) the client's frame queue ran away (peak ~352k) → frozen
+    display + RDPEUDP ACK storm (input still reached the Mac over TCP, so it only *looked*
+    dead). The fix is a frame-ack-lag backpressure gate in `submit_bgra` **with a trickle
+    floor** — dropping most captures when the client is behind but never to zero, because
+    mstsc only presents/acks an H.264 frame once trailing frames arrive (dropping to zero
+    latches the freeze permanently). Verified on real mstsc under the headless
+    `--capture-primary` + held-Cmd+Tab repro. The earlier "mstsc surface-retention quirk"
+    guess was disproven (it reproduced on a fresh mstsc process); and the `egfx-ship`
+    thread parked in `_dispatch_semaphore_wait_slow` during the freeze is a red herring —
+    that's just Rust's `std::sync::mpsc::recv` idling on macOS. A fuller continuous
+    rate controller remains finding-#5 future work. All `multitransport`-gated; feature-off
+    byte-unchanged. See feasibility doc "M3c reconnect state-reset" + the "Residual …
+    rate-control gap" / trickle-floor note.

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -413,6 +413,13 @@ pub struct RdpServer {
     /// (a missing ack there is congestion, not loss). `None` = not wired (default).
     #[cfg(feature = "multitransport")]
     egfx_on_lossy_handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Shared flag the macrdp-side EGFX/H.264 pipeline reads to enable frame-ack-lag
+    /// backpressure: set true once EGFX is migrated onto **any** UDP tunnel
+    /// (reliable or lossy), where there's no socket backpressure to pace the server
+    /// to the client. On TCP it stays false (the socket paces it; the push path must
+    /// stay byte-identical). `None` = not wired (default).
+    #[cfg(feature = "multitransport")]
+    egfx_on_udp_handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     /// (M5c step 3b) Receiver for inbound migrated-channel data the UDP listener
     /// forwards (each item is a bare DRDYNVC PDU — HigherLayerData of an inbound
     /// `RDP_TUNNEL_DATA`, e.g. an EGFX frame ack). Created + registered (with the
@@ -549,6 +556,7 @@ impl RdpServer {
             udp_tunnel_bound: None,
             #[cfg(feature = "multitransport")]
             egfx_on_lossy_handle: None,
+            egfx_on_udp_handle: None,
             #[cfg(feature = "multitransport")]
             multitransport_tunnel_sender: None,
             #[cfg(feature = "multitransport")]
@@ -662,6 +670,15 @@ impl RdpServer {
     #[cfg(feature = "multitransport")]
     pub fn set_egfx_on_lossy_handle(&mut self, handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>) {
         self.egfx_on_lossy_handle = handle;
+    }
+
+    /// Wire the EGFX-on-UDP flag (frame-ack-lag backpressure). The server flips it
+    /// `true` whenever it Soft-Syncs the EGFX DVC onto a UDP tunnel (reliable or
+    /// lossy) and back to `false` on connection teardown; the macrdp H.264 pipeline
+    /// reads it to enable capture-dropping when the client's decode backlog grows.
+    #[cfg(feature = "multitransport")]
+    pub fn set_egfx_on_udp_handle(&mut self, handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>) {
+        self.egfx_on_udp_handle = handle;
     }
 
     /// Enable migrating the EGFX DVC onto the reliable UDP tunnel (the
@@ -996,6 +1013,9 @@ impl RdpServer {
                             self.lossy_audio_block_no = 0;
                             self.lossy_audio_streaming = false;
                             if let Some(handle) = &self.egfx_on_lossy_handle {
+                                handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                            }
+                            if let Some(handle) = &self.egfx_on_udp_handle {
                                 handle.store(false, std::sync::atomic::Ordering::Relaxed);
                             }
                         }
@@ -1787,6 +1807,11 @@ impl RdpServer {
             {
                 Some(id) => {
                     self.egfx_on_udp = true;
+                    // Tell the H.264 pipeline EGFX is now on the UDP tunnel so it
+                    // enables frame-ack-lag backpressure (no socket pacing here).
+                    if let Some(handle) = &self.egfx_on_udp_handle {
+                        handle.store(true, Ordering::Relaxed);
+                    }
                     debug!(
                         gfx_channel_id = id,
                         "--udp-migrate-egfx: Soft-Sync will migrate the EGFX DVC onto the UDP tunnel"


### PR DESCRIPTION
## Problem

EGFX-over-UDP (`--udp-migrate-egfx`) video **froze under load** — most reliably with the headless `--virtual-display --capture-primary` config while a video played and Cmd+Tab was held to cycle rapidly. Audio (on TCP) kept playing; the picture recovered only on disconnect + reconnect.

## Root cause

On the UDP tunnel there's no socket backpressure to pace the server to the client, so the H.264 push pipeline floods frames and the client's EGFX decode queue runs away (observed `queueDepth` peak ~352k) → frozen video. This is the finding-#5 rate-control gap (`GfxHandler::on_frame_ack` only recorded ack timing; the server never throttled on client feedback).

## Fix

`src/h264.rs::submit_bgra` now tracks per-frame lag = `last_shipped_frame_id − last_acked_frame_id` (EGFX FrameAcknowledge id) on the UDP tunnel and, when it exceeds `MACRDP_UDP_EGFX_MAX_FRAME_LAG` (default 16), drops most captures so the client catches up — **with a trickle floor (`UDP_THROTTLE_FLOOR`, ~10 fps), never zero.**

The load-bearing subtlety (and the bug in the first cut of this branch, now folded in): mstsc only *presents* — and therefore frame-acks — an H.264 frame once a couple more arrive behind it. Dropping to **zero** trailing frames means the client never acks the in-flight ones, `lag` stays pinned one over the threshold, every capture is dropped, and the video **freezes permanently**. The trickle keeps the client presenting/acking so the window reopens. Dropping *before* encode keeps the H.264 reference chain valid. Under load the video degrades to **choppy-but-live** instead of freezing.

Gated to the UDP tunnel (TCP push path byte-identical), to acks actually flowing (suspended-ack clients use the existing `submitted − shipped` throttle), and to having seen ≥1 ack (no cold-start false drop).

## Verification

Verified on **real mstsc** under the exact repro that reliably froze before (headless `--virtual-display --capture-primary`, YouTube + rapidly held Cmd+Tab): video stayed live, no freeze, no noticeable stutter.

## Notes

- Diagnostic dead-end recorded in the docs: the `egfx-ship` thread parked in `_dispatch_semaphore_wait_slow` during the freeze is **not** a stall — Rust's `std::sync::mpsc` blocking `recv()` is a libdispatch semaphore on macOS, so an idle ship thread looks exactly like that.
- A fuller continuous queue_depth-aware rate controller remains finding-#5 future work. Everyday robust config stays `--udp-migrate-egfx` off (clean-link-only; reliable ordered tunnel HOL-blocks under loss).
- Docs updated: feasibility doc residual section + vendor server divergence (12) note.