### PR TITLE
release: v0.8.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macrdp"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrdp"
-version = "0.8.16"
+version = "0.8.17"
 edition = "2021"
 description = "Native RDP server for macOS"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release. Single user-facing change since v0.8.16:

- **fix(h264/multitransport):** EGFX-over-UDP frame-ack-lag backpressure with a **trickle floor** (#89) — fixes the video freeze under load on the reliable UDP tunnel (`--udp-migrate-egfx`). When the client's frame-ack lag is high, drop most captures but never to zero (mstsc needs trailing frames to present/ack, or it freezes permanently). **Verified on real mstsc** under the headless `--virtual-display --capture-primary` + held-Cmd+Tab repro; degrades to choppy-but-live instead of freezing. TCP push path byte-identical. EGFX-over-UDP remains clean-link-only under packet loss.