### PR TITLE
fix(multitransport): raise UDP idle-GC timeout 10s→60s (was reaping live idle peers)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -64,6 +64,18 @@ then delete; promote a parked item to *In flight* when work actually starts.
   risk: in-session fallback would be *frozen→recover* (NOT the reconnect-blank quirk —
   that needs a new connection), but only if mstsc accepts the channel's data back on TCP
   after Soft-Sync (no standard reverse Soft-Sync; untested). Spike against real mstsc first.
+- [ ] **UDP multitransport — explicit TCP-close → listener peer-evict signal** (the
+  deferred half of M3c; the *correct* fix for dead-peer reclaim). Today the listener only
+  reclaims a peer via the activity-based idle-GC, whose timeout had to be raised to 60s
+  (2026-06-29) because mstsc goes near-silent on the UDP flow when idle (~15s keepalive)
+  and a shorter timeout reaped *live* idle peers → permanent EGFX freeze. With a real
+  TCP-session-close signal (server marks the connection's cookie retired in the shared
+  `CookieRegistry` → listener drops that peer), a dead peer is reclaimed *immediately* on
+  disconnect and the idle-GC can be a long pure backstop (no risk of reaping a live idle
+  client regardless of its keepalive interval). Shared-state signal mirrors the existing
+  per-cookie tunnel-bound flag. See vendor `listener.rs` `PEER_IDLE_TIMEOUT_MS` + the
+  feasibility doc "M3c peer GC".
+
 - [ ] **UDP multitransport Phase 2 — lossy `UdpFecL` + DTLS + 1+1 redundancy** (FEC dropped).
   Phase 1 (reliable EGFX-over-UDP) shipped (v0.8.15, clean-link only). Phase 2 wants
   loss resilience. Status: lossy delivery mode + 1+1 duplicate-send (repetition code)

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -344,11 +344,29 @@ Fix (`vendor/ironrdp-server/src/multitransport/listener.rs`, idle-timeout GC):
 `Peer` gained `last_seen_ms`, bumped on **every inbound datagram** (only inbound — a
 dead peer still *sends* outbound retransmits but receives nothing, so its clock
 stops); `gc_idle_peers` runs on the existing `retransmit_tick` (right after
-`pump_peers_on_timer`) and evicts any peer idle > 10 s (`PEER_IDLE_TIMEOUT_MS`),
+`pump_peers_on_timer`) and evicts any peer idle > `PEER_IDLE_TIMEOUT_MS`,
 dropping its `bound_addrs` cookie→addr mapping too. Activity-based, so it covers
-graceful / abrupt / crashed disconnects uniformly; 10 s is safe because a live client
-— even idle — sends RDPEUDP keepalive/delayed-ACKs continuously (~200/s in a real
-session). Logs `evicted idle UDP peer` at `ironrdp_server::multitransport=debug`.
+graceful / abrupt / crashed disconnects uniformly. Logs `evicted idle UDP peer` at
+`ironrdp_server::multitransport=debug`.
+
+**Timeout corrected 2026-06-29: 10 s → 60 s (it was reaping live idle peers).** The
+10 s rested on a wrong assumption — that a live client *always* sends frequent RDPEUDP
+keepalive/delayed-ACKs (~200/s). That's only true while the picture is **active**. When
+the screen goes idle, **mstsc drops to a ~15 s UDP keepalive cadence** (verified live:
+inbound datagrams exactly 15 s apart once frame-acks stop). The 10 s GC then reaped the
+peer **between** two keepalives — tearing down the UDP tunnel of a *fully live* TCP
+session (audio kept flowing), so EGFX froze **permanently until reconnect** (the
+client's next keepalive isn't a SYN, so the peer is never recreated). This is a distinct
+bug from the load-freeze (#89): triggered by simply going idle for ~15–60 s, and it
+happens on mirror-primary too. The trace was unambiguous — inbound floods at 100–450/s
+during activity, then exactly one datagram every 15 s once idle, then `evicted idle UDP
+peer idle_ms=10049`. Fix: raise to 60 s (4× the observed 15 s keepalive), so an
+idle-but-live peer is never reaped while a genuinely dead one still ages out (the leak
+becomes ≤60 s, not indefinite). **Verified on real mstsc**: a live peer idle ~45 s
+recovered on activity with no eviction; only the *abandoned* peer from a prior reconnect
+was reaped (idle_ms≈60042). The fully robust fix is an explicit TCP-session-close →
+evict signal (the deferred half of M3c, below); until that lands the activity-based
+backstop must stay generous enough not to reap an idle client.
 
 This is the listener-only **backstop** half of M3c; the prompt server→listener
 "instant retire-on-disconnect" signal is still deferred (the GC is needed regardless).

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -779,13 +779,27 @@ AND released — #1276 landing is NOT sufficient.
     (only inbound — a dead peer still *sends* outbound retransmits but receives
     nothing, so its clock stops); a new `gc_idle_peers(peers, bound_addrs, now_ms)`
     runs on the existing `retransmit_tick` (right after `pump_peers_on_timer`) and
-    evicts any peer idle > `PEER_IDLE_TIMEOUT_MS` (10s), also dropping its
+    evicts any peer idle > `PEER_IDLE_TIMEOUT_MS`, also dropping its
     `bound_addrs` cookie→addr mapping (`retain(|_, a| *a != gone)`). Activity-based, so
-    it covers graceful / abrupt / crashed disconnects uniformly; 10s is safe because a
-    live client — even idle — sends RDPEUDP keepalive/delayed-ACKs continuously
-    (~200/s in a real session). This is the listener-only backstop half of M3c; the
-    prompt server→listener "instant retire-on-disconnect" signal is still deferred (the
-    GC is needed regardless). Logs `evicted idle UDP peer` at `debug`
+    it covers graceful / abrupt / crashed disconnects uniformly.
+    **TIMEOUT CORRECTED 2026-06-29: 10s → 60s.** The original 10s rested on a wrong
+    assumption — that a live client *always* sends frequent RDPEUDP keepalive/delayed
+    ACKs (~200/s). That holds only while the picture is **active**. When the screen goes
+    idle, **mstsc drops to a ~15s UDP keepalive cadence** (verified live: inbound
+    datagrams exactly 15s apart once frame-acks stop). The 10s GC then reaped the peer
+    **between** two keepalives — killing the UDP tunnel of a fully live TCP session
+    (audio still flowing), so EGFX froze **permanently** (the client's next keepalive
+    isn't a SYN, so the peer is never recreated → needs reconnect). This was a distinct
+    bug from the load-freeze (#89): triggered by going idle ~15–60s, on mirror-primary
+    too. Fix: 60s = 4× the observed 15s keepalive, so an idle-but-live peer is never
+    reaped; a genuinely dead peer still ages out (the "UDP retransmits after disconnect"
+    leak becomes ≤60s instead of indefinite). **Verified on real mstsc**: a live peer
+    idle ~45s recovered on activity with no eviction, while the *abandoned* peer from a
+    prior reconnect was correctly reaped at idle_ms≈60042. The fully robust fix is an
+    explicit TCP-session-close → evict signal (deferred half of M3c); until then the
+    activity-based backstop must stay generous. This is the listener-only backstop half
+    of M3c; the prompt server→listener "instant retire-on-disconnect" signal is still
+    deferred (the GC is needed regardless). Logs `evicted idle UDP peer` at `debug`
     (`ironrdp_server::multitransport=debug`). Does NOT by itself fix the mstsc EGFX
     reconnect-blank (a client-side surface-retention quirk + the clean-link limit may
     compound it); the robust WiFi config remains `--udp-migrate-egfx` off (EGFX on TCP).

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -258,11 +258,22 @@ async fn pump_peers_on_timer(
     }
 }
 
-/// (M3c) Evict a peer after this many ms with no *inbound* datagram. A live client —
-/// even an idle/quiet one — sends RDPEUDP keepalive/delayed ACKs continuously (a real
-/// session ran ~200 inbound pkts/s), so 10s is a very safe "the client is gone"
-/// threshold; a dead client sends nothing and ages out cleanly.
-const PEER_IDLE_TIMEOUT_MS: u64 = 10_000;
+/// (M3c) Evict a peer after this many ms with no *inbound* datagram.
+///
+/// CORRECTED 2026-06-29 (was 10_000): the original 10s rested on the assumption that
+/// a live client always sends frequent RDPEUDP keepalive/delayed ACKs (~200/s). That
+/// holds only while the picture is *active* — when the screen goes idle, **mstsc drops
+/// to a ~15s UDP keepalive cadence** (verified: inbound datagrams exactly 15s apart
+/// once frame-acks stop). The 10s timeout then reaped the peer *between* two keepalives
+/// — killing the UDP tunnel of a fully live TCP session (audio still flowing), so EGFX
+/// froze permanently until reconnect (the client's next keepalive isn't a SYN, so the
+/// peer is never recreated). The threshold must comfortably exceed the client's idle
+/// keepalive interval. 60s = 4× the observed 15s — still reclaims a genuinely dead peer
+/// promptly enough (the original "UDP keeps retransmitting after disconnect" leak
+/// becomes ≤60s instead of indefinite). The fully robust fix is an explicit
+/// TCP-session-close → evict signal (the deferred half of M3c); until then this
+/// activity-based backstop must be generous enough not to reap an idle-but-live client.
+const PEER_IDLE_TIMEOUT_MS: u64 = 60_000;
 
 /// (M3c) Idle-timeout garbage collection. Drop every peer whose last *inbound*
 /// datagram is older than `PEER_IDLE_TIMEOUT_MS`, along with any `bound_addrs`


### PR DESCRIPTION
## Problem

EGFX-over-UDP (`--udp-migrate-egfx`) froze **permanently (needs reconnect)** when the screen was left **idle** for ~15–60 s — a distinct bug from the load-freeze (#89), and it happens on mirror-primary too (not capture-primary-specific).

## Root cause (verified live on real mstsc)

The idle-GC (#87) evicted the UDP peer of a **fully live** session. Its 10 s timeout assumed a live client always sends frequent RDPEUDP keepalives (~200/s) — true only while the picture is **active**. When the screen goes idle, **mstsc drops to a ~15 s UDP keepalive cadence** (verified: inbound datagrams exactly 15 s apart once frame-acks stop). The 10 s GC reaped the peer **between** two keepalives, killing the tunnel of a live TCP session (audio still flowing). The client's next keepalive isn't a SYN, so the peer is never recreated → frozen until reconnect.

The listener trace was unambiguous: inbound floods at 100–450/s during activity → exactly 1 datagram every 15 s once idle → `evicted idle UDP peer idle_ms=10049`.

## Fix

`PEER_IDLE_TIMEOUT_MS` 10 s → **60 s** (4× the observed 15 s keepalive). An idle-but-live peer is never reaped; a genuinely dead peer still ages out (the original "UDP retransmits after disconnect" leak becomes ≤60 s instead of indefinite).

## Verification

Real mstsc: a live peer idle ~45 s **recovered on activity with no eviction**; only the *abandoned* peer from a prior reconnect was reaped (`idle_ms≈60042`). User-confirmed: "it recovered when I moved, no freeze."

## Follow-up

The fully robust fix is an explicit TCP-session-close → listener evict signal (the deferred half of M3c) so the backstop timeout needn't be tuned to the client's keepalive interval. Added to TODO.