### PR TITLE
release: v0.8.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macrdp"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrdp"
-version = "0.8.17"
+version = "0.8.18"
 edition = "2021"
 description = "Native RDP server for macOS"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release. Single user-facing change since v0.8.17:

- **fix(multitransport):** raise the UDP idle-GC timeout 10 s → 60 s (#91) — fixes the EGFX-over-UDP **idle freeze**. When the screen goes quiet, mstsc drops to a ~15 s UDP keepalive cadence; the old 10 s idle-GC reaped the peer *between* keepalives, tearing down the tunnel of a fully live session → permanent freeze until reconnect. 60 s (4× the keepalive) keeps idle-but-live peers alive while still reclaiming genuinely dead ones. **Verified on real mstsc.** Pairs with the v0.8.17 load-freeze fix (#89) — both EGFX-over-UDP freezes (load + idle) are now fixed.