### PR TITLE
feat(udp): EGFX-over-UDP → TCP watchdog (auto-recover from a wedged reliable tunnel)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,10 @@ then delete; promote a parked item to *In flight* when work actually starts.
 
 ## In flight (needs an action)
 
-- (nothing in flight — EGFX-over-UDP reconnect state reset shipped as #88, and the
-  freeze-under-load fix as #89/v0.8.17)
+- [ ] **EGFX-over-UDP → TCP watchdog** (auto-recover a wedged reliable tunnel) — built
+  + verified on real mstsc (deterministic ack-drop injection AND genuine clumsy UDP-only
+  loss; recovered, no permanent freeze), branch `feat/udp-egfx-watchdog-tcp-fallback`.
+  **Awaiting CI green + squash-merge.** Was the "auto-fallback" deferred item below.
 
 ## Deferred — scoped, not started
 
@@ -58,12 +60,12 @@ then delete; promote a parked item to *In flight* when work actually starts.
     same VT-bitrate/frame-drop/IDR-backoff levers; only the input source differs per transport.
   Bigger than FEC (dead) or auto-fallback (band-aid). Worth a real-server↔mstsc capture
   first to read the URCP signaling. See finding #5 in `docs/rdp-udp-multitransport-feasibility.md`.
-- [ ] **EGFX-over-UDP auto-fallback to TCP on tunnel abandonment** (secondary safety net,
-  below rate control). When the reliable tunnel is abandoned (window pegged / client
-  stopped acking), re-route EGFX to TCP + force an IDR instead of staying frozen. Open
-  risk: in-session fallback would be *frozen→recover* (NOT the reconnect-blank quirk —
-  that needs a new connection), but only if mstsc accepts the channel's data back on TCP
-  after Soft-Sync (no standard reverse Soft-Sync; untested). Spike against real mstsc first.
+- [ ] **EGFX-over-UDP watchdog — ack-lag-pegged secondary trigger** (refinement of the
+  shipped watchdog above). The watchdog fires on ~3s of *fully silent* acks; a real wedge
+  dribbles a few stray acks before going silent, so it latched at `since_ack_ms≈7.7s` in
+  the clumsy soak (vs. 3s ideal). Add a second trigger that fires when the frame-ack *lag*
+  (shipped−acked) stays pinned above threshold for N s even if odd acks trickle in, to
+  shorten the real-wedge recovery window. Low priority — the freeze already recovers.
 - [ ] **UDP multitransport — explicit TCP-close → listener peer-evict signal** (the
   deferred half of M3c; the *correct* fix for dead-peer reclaim). Today the listener only
   reclaims a peer via the activity-based idle-GC, whose timeout had to be raised to 60s

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -304,6 +304,34 @@ reliable-only multitransport.
    (A proper *capture* of real-server↔mstsc — to read the exact URCP rate-control
    signaling on the wire — is still worth doing before implementing.)
 
+   **SHIPPED 2026-06-29 — EGFX-over-UDP → TCP watchdog (the "auto-fallback band-aid",
+   built anyway because it's cheap and removes the *permanent* freeze).** While
+   rate control (above) is the real fix, it doesn't help a tunnel that has *already*
+   wedged/abandoned — that stays frozen until reconnect. The watchdog catches exactly
+   that: when EGFX is on the **reliable** UDP tunnel and frame acks go silent for
+   ~3s (`MACRDP_UDP_EGFX_WATCHDOG_MS`) while the server is still actively shipping
+   (the #89 trickle floor guarantees it ships even when ack-lag is high), it declares
+   the tunnel wedged and routes EGFX back onto **TCP** + forces an IDR (the last UDP
+   frames never arrived, so the client's reference is stale). mstsc renders EGFX on
+   TCP after a Soft-Sync — established first by a throwaway *timed* de-migration
+   ("Spike A", flip `egfx_on_udp` false → TCP, no reverse Soft-Sync needed, verified
+   live), then the full ack-stall-driven watchdog. Pure predicate
+   `should_demigrate_to_tcp` in `src/h264.rs` (8 unit tests); the server route arm
+   reads a shared `demigrate_request` flag and flips routing (one-way per connection;
+   reset on reconnect). Default-on but a strict no-op off the reliable UDP tunnel.
+   **Verified two ways on real mstsc:** (1) a deterministic clean-link injection
+   (drop acks after N s) fired at exactly `since_ack_ms=3004` and recovered; (2) a
+   genuine **clumsy UDP-only loss** wedge (UDP dropped, TCP left healthy as the
+   fallback) fired at `since_ack_ms≈7736` — *real* wedges dribble a few stray acks
+   before going fully silent, so the pure-silence trigger latches later than the
+   injection's instant silence — and EGFX recovered on the healthy TCP channel, no
+   permanent freeze. Follow-up (deferred): an **ack-lag-pegged secondary trigger**
+   (fire when shipped−acked stays pinned for N s even if odd acks trickle in) would
+   shorten the ~7–8s real-wedge recovery window toward the 3s ideal. NOTE this is
+   complementary to — not a substitute for — congestion-responsive rate control:
+   the watchdog *escapes* a dead tunnel; rate control *prevents* the wedge and also
+   helps the TCP path.
+
    **What "URCP" actually is, and the concrete signals macrdp already ignores.**
    URCP = **Universal Rate Control Protocol** (Microsoft Research, ~2013) — the
    congestion-/rate-control *algorithm* under RDP Shortpath + MS-RDPEUDP2. It's not a

--- a/src/h264.rs
+++ b/src/h264.rs
@@ -176,6 +176,12 @@ struct ConnectionContext {
     /// floor (`UDP_THROTTLE_FLOOR`) so the client always has trailing frames to
     /// drain its presentation buffer and the window reopens.
     last_throttle_ship: Instant,
+    /// EGFX-over-UDP → TCP watchdog latch. Set true once the watchdog has
+    /// de-migrated EGFX off a wedged RELIABLE UDP tunnel back onto TCP (see
+    /// [`should_demigrate_to_tcp`]). One-way per connection — once de-migrated we
+    /// never re-migrate to UDP in-session (no flapping); UDP is retried only on the
+    /// next connection. Reset with the fresh context on reconnect.
+    demigrated: bool,
 }
 
 /// Tunables for ack-driven IDR recovery (EGFX-on-lossy). See
@@ -219,6 +225,48 @@ fn should_force_recovery_idr(
         && since_ship <= p.active_window
         && since_ack >= p.ack_stall
         && since_recovery >= p.min_recovery_interval
+}
+
+/// Decide whether to de-migrate EGFX from the RELIABLE UDP tunnel back onto TCP.
+/// Pure (Durations, not a clock) so it's unit-testable without timing.
+///
+/// The reliable (UdpFecR) tunnel is ordered, so it head-of-line-blocks under loss
+/// exactly like TCP (feasibility finding #4): once the client stops acking while
+/// we're *actively* shipping (the #89 trickle floor guarantees we keep shipping
+/// even when the ack-lag is high), the tunnel is wedged and queued frames will
+/// never arrive — the video freezes with no recovery until reconnect. The fix is
+/// to route EGFX back over TCP, which mstsc accepts post-Soft-Sync (Spike A,
+/// verified live 2026-06-29) — the caller pairs this with a forced IDR, since the
+/// last UDP frames never arrived so the client's decode reference is stale.
+///
+/// Each clause guards a distinct failure mode:
+/// - `egfx_on_udp && !egfx_on_lossy`: only on the RELIABLE UDP tunnel. The lossy
+///   tunnel uses ack-driven IDR recovery instead ([`should_force_recovery_idr`]);
+///   TCP needs nothing (socket backpressure paces it).
+/// - `!already_demigrated`: fire once per connection (one-way latch, no flapping).
+/// - `!acks_suspended`: with acks off (`queueDepth==0xFFFFFFFF`) a wedge can't be
+///   inferred from ack-staleness.
+/// - `since_ship <= active_window`: only while actively shipping (else: static
+///   screen, where silent acks are normal and the periodic IDR backstops).
+/// - `since_ack >= wedge_timeout`: the wedge signal — acks have gone fully silent
+///   long enough to rule out a transient congestion blip.
+#[allow(clippy::too_many_arguments)]
+fn should_demigrate_to_tcp(
+    since_ship: Duration,
+    since_ack: Duration,
+    acks_suspended: bool,
+    egfx_on_udp: bool,
+    egfx_on_lossy: bool,
+    already_demigrated: bool,
+    active_window: Duration,
+    wedge_timeout: Duration,
+) -> bool {
+    egfx_on_udp
+        && !egfx_on_lossy
+        && !already_demigrated
+        && !acks_suspended
+        && since_ship <= active_window
+        && since_ack >= wedge_timeout
 }
 
 /// Read the ack-recovery config from the environment once. Returns
@@ -288,9 +336,29 @@ pub struct Gfx {
     /// that a healthy high-RTT link never trips it; low enough to cap the decode
     /// backlog so video degrades to choppy-but-live instead of freezing.
     max_frame_lag: u64,
+    /// EGFX-over-UDP → TCP watchdog. On by default (disable with
+    /// `MACRDP_UDP_EGFX_WATCHDOG=0`); only ever acts while EGFX is on the RELIABLE
+    /// UDP tunnel (`egfx_on_udp && !egfx_on_lossy`), so it's a no-op unless
+    /// `--udp-migrate-egfx` is in use. On a detected wedge `submit_bgra` forces an
+    /// IDR, resets the lag baseline, and sets `demigrate_request` — the cue the
+    /// vendored server reads to flip EGFX routing back to the TCP DRDYNVC channel.
+    watchdog_enabled: bool,
+    /// How long EGFX frame acks must stay fully silent (while actively shipping)
+    /// before the reliable UDP tunnel is declared wedged.
+    /// `MACRDP_UDP_EGFX_WATCHDOG_MS` (default 3000). The freeze the user sees
+    /// before auto-recovery is ~this long; long enough to rule out a transient blip.
+    watchdog_wedge_timeout: Duration,
+    /// Companion to `watchdog_wedge_timeout`: the last ship must be within this
+    /// window for the ack silence to read as a wedge (vs. a static screen).
+    /// `MACRDP_UDP_EGFX_WATCHDOG_ACTIVE_MS` (default 1000).
+    watchdog_active_window: Duration,
+    /// Shared with the vendored server: set true here on a wedge, read there to
+    /// flip `egfx_on_udp` → TCP routing; reset there on reconnect.
+    demigrate_request: Arc<AtomicBool>,
 }
 
 impl Gfx {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         desktop_size: crate::capture::SharedDesktopSize,
         fps: u32,
@@ -299,6 +367,7 @@ impl Gfx {
         max_in_flight: u32,
         egfx_on_lossy: Arc<AtomicBool>,
         egfx_on_udp: Arc<AtomicBool>,
+        demigrate_request: Arc<AtomicBool>,
     ) -> Self {
         let wire_format = WireFormat::from_env();
         let (recovery_enabled, recovery_params) = recovery_config_from_env();
@@ -307,6 +376,21 @@ impl Gfx {
             .and_then(|s| s.trim().parse::<u64>().ok())
             .filter(|&n| n > 0)
             .unwrap_or(16);
+        let watchdog_enabled = match std::env::var("MACRDP_UDP_EGFX_WATCHDOG") {
+            Ok(v) => !(v == "0" || v.eq_ignore_ascii_case("false")),
+            Err(_) => true, // default on (no-op unless EGFX is on the reliable UDP tunnel)
+        };
+        let watchdog_ms = |name: &str, default: u64| -> Duration {
+            Duration::from_millis(
+                std::env::var(name)
+                    .ok()
+                    .and_then(|s| s.trim().parse::<u64>().ok())
+                    .filter(|&n| n > 0)
+                    .unwrap_or(default),
+            )
+        };
+        let watchdog_wedge_timeout = watchdog_ms("MACRDP_UDP_EGFX_WATCHDOG_MS", 3000);
+        let watchdog_active_window = watchdog_ms("MACRDP_UDP_EGFX_WATCHDOG_ACTIVE_MS", 1000);
         let (width, height) = desktop_size.get();
         info!(
             ?wire_format,
@@ -333,6 +417,10 @@ impl Gfx {
             egfx_on_lossy,
             egfx_on_udp,
             max_frame_lag,
+            watchdog_enabled,
+            watchdog_wedge_timeout,
+            watchdog_active_window,
+            demigrate_request,
         }
     }
 
@@ -393,6 +481,44 @@ impl Gfx {
                     info!(
                         since_ack_ms = since_ack.as_millis() as u64,
                         "EGFX ack-stall on lossy tunnel — forcing recovery IDR"
+                    );
+                }
+            }
+            // EGFX-over-UDP → TCP watchdog (default on): the RELIABLE tunnel is
+            // ordered, so it head-of-line-blocks under loss (finding #4). If acks go
+            // fully silent while we're still actively shipping (the #89 trickle keeps
+            // frames flowing even when lag is high), the tunnel is wedged and queued
+            // frames will never arrive → the video freezes with no recovery until
+            // reconnect. Route EGFX back to TCP (mstsc renders it post-Soft-Sync —
+            // Spike A) + force an IDR (the last UDP frames never arrived, so the
+            // client's reference is stale) + reset the lag baseline so the trickle
+            // gate below doesn't drop the recovery IDR before the server flips
+            // routing. One-way per connection (the `demigrated` latch). No-op unless
+            // EGFX is on the reliable UDP tunnel → default path unchanged.
+            if self.watchdog_enabled {
+                let now = Instant::now();
+                let since_ack = now.saturating_duration_since(ctx.last_ack_at);
+                if should_demigrate_to_tcp(
+                    now.saturating_duration_since(ctx.last_ship_at),
+                    since_ack,
+                    ctx.acks_suspended,
+                    self.egfx_on_udp.load(Ordering::Relaxed),
+                    self.egfx_on_lossy.load(Ordering::Relaxed),
+                    ctx.demigrated,
+                    self.watchdog_active_window,
+                    self.watchdog_wedge_timeout,
+                ) {
+                    ctx.need_keyframe = true;
+                    ctx.last_acked_frame_id.store(
+                        ctx.last_shipped_frame_id.load(Ordering::Relaxed),
+                        Ordering::Relaxed,
+                    );
+                    ctx.demigrated = true;
+                    self.demigrate_request.store(true, Ordering::Relaxed);
+                    warn!(
+                        since_ack_ms = since_ack.as_millis() as u64,
+                        "EGFX-over-UDP reliable tunnel wedged (acks silent while shipping) — \
+                         de-migrating to TCP + forcing IDR (one-way for this session)"
                     );
                 }
             }
@@ -794,6 +920,7 @@ impl GfxServerFactory for Gfx {
             last_acked_frame_id: Arc::new(AtomicU64::new(0)),
             egfx_acks_seen: false,
             last_throttle_ship: Instant::now(),
+            demigrated: false,
         });
         Some((GfxDvcBridge::new(handle.clone()), handle))
     }
@@ -1132,6 +1259,135 @@ mod tests {
             false,
             true,
             &p
+        ));
+    }
+
+    // ---- EGFX-over-UDP → TCP watchdog (`should_demigrate_to_tcp`) ----
+    // Arg order: since_ship, since_ack, acks_suspended, egfx_on_udp, egfx_on_lossy,
+    // already_demigrated, active_window, wedge_timeout.
+    const WD_ACTIVE: Duration = Duration::from_millis(1000);
+    const WD_WEDGE: Duration = Duration::from_millis(3000);
+
+    #[test]
+    fn watchdog_fires_on_reliable_udp_wedge_while_shipping() {
+        // Reliable UDP (on_udp && !on_lossy), actively shipping (30ms), acks silent
+        // past the wedge timeout (4s > 3s), not suspended, not yet de-migrated → fire.
+        assert!(should_demigrate_to_tcp(
+            ms(30),
+            ms(4000),
+            false,
+            true,
+            false,
+            false,
+            WD_ACTIVE,
+            WD_WEDGE
+        ));
+    }
+
+    #[test]
+    fn watchdog_never_on_tcp() {
+        // egfx_on_udp=false (plain TCP): socket backpressure paces us; nothing to do.
+        assert!(!should_demigrate_to_tcp(
+            ms(30),
+            ms(4000),
+            false,
+            false,
+            false,
+            false,
+            WD_ACTIVE,
+            WD_WEDGE
+        ));
+    }
+
+    #[test]
+    fn watchdog_never_on_lossy_tunnel() {
+        // egfx_on_lossy=true: the lossy tunnel uses ack-driven IDR recovery, not
+        // de-migration (a dropped frame there is real loss, not a wedge).
+        assert!(!should_demigrate_to_tcp(
+            ms(30),
+            ms(4000),
+            false,
+            true,
+            true,
+            false,
+            WD_ACTIVE,
+            WD_WEDGE
+        ));
+    }
+
+    #[test]
+    fn watchdog_suppressed_when_acks_suspended() {
+        // queueDepth==0xFFFFFFFF → a wedge can't be inferred from ack-staleness.
+        assert!(!should_demigrate_to_tcp(
+            ms(30),
+            ms(4000),
+            true,
+            true,
+            false,
+            false,
+            WD_ACTIVE,
+            WD_WEDGE
+        ));
+    }
+
+    #[test]
+    fn watchdog_latches_one_way() {
+        // already_demigrated=true: fire once per connection, never flap back.
+        assert!(!should_demigrate_to_tcp(
+            ms(30),
+            ms(4000),
+            false,
+            true,
+            false,
+            true,
+            WD_ACTIVE,
+            WD_WEDGE
+        ));
+    }
+
+    #[test]
+    fn watchdog_not_when_acks_fresh() {
+        // since_ack (500ms) below the wedge timeout (3s): acks still flowing.
+        assert!(!should_demigrate_to_tcp(
+            ms(30),
+            ms(500),
+            false,
+            true,
+            false,
+            false,
+            WD_ACTIVE,
+            WD_WEDGE
+        ));
+    }
+
+    #[test]
+    fn watchdog_not_when_static_screen() {
+        // since_ship (2s) above active_window (1s): the screen went static, so silent
+        // acks are normal — not a wedge. Heals on the next activity if still wedged.
+        assert!(!should_demigrate_to_tcp(
+            ms(2000),
+            ms(4000),
+            false,
+            true,
+            false,
+            false,
+            WD_ACTIVE,
+            WD_WEDGE
+        ));
+    }
+
+    #[test]
+    fn watchdog_thresholds_are_inclusive() {
+        // since_ship == active_window (<=), since_ack == wedge_timeout (>=) → fires.
+        assert!(should_demigrate_to_tcp(
+            ms(1000),
+            ms(3000),
+            false,
+            true,
+            false,
+            false,
+            WD_ACTIVE,
+            WD_WEDGE
         ));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2010,6 +2010,10 @@ async fn async_main() -> Result<()> {
     // H.264 pipeline reads it to enable frame-ack-lag backpressure (the UDP tunnel
     // has no socket pacing); the server flips it at the same migration site.
     let egfx_on_udp_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    // EGFX-over-UDP → TCP watchdog request: the H.264 pipeline sets it true when the
+    // reliable UDP tunnel wedges (acks silent while shipping); the server reads it to
+    // flip EGFX routing back to TCP. Reset on reconnect (server side).
+    let egfx_demigrate_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     // EGFX/H.264 video pipeline (macOS-only; opt-in via --enable-h264). One
     // clone drives the builder's GfxServerFactory (protocol side); another
@@ -2024,6 +2028,7 @@ async fn async_main() -> Result<()> {
             args.h264_frames_in_flight.max(1),
             egfx_on_lossy_flag.clone(),
             egfx_on_udp_flag.clone(),
+            egfx_demigrate_flag.clone(),
         )
     });
 
@@ -2239,6 +2244,10 @@ async fn async_main() -> Result<()> {
                 // migrates EGFX onto a UDP tunnel (reliable or lossy), and the H.264
                 // pipeline drops captures when the client's decode backlog runs away.
                 server.set_egfx_on_udp_handle(Some(egfx_on_udp_flag.clone()));
+                // EGFX-over-UDP → TCP watchdog: the H.264 pipeline sets this true when
+                // the reliable UDP tunnel wedges; the server reads it to de-migrate
+                // EGFX back to TCP (mstsc renders it post-Soft-Sync). Reset on reconnect.
+                server.set_demigrate_request_handle(Some(egfx_demigrate_flag.clone()));
                 // (P2.4b, EXPERIMENTAL) Register the lossy-UDP audio DVC
                 // (AUDIO_PLAYBACK_LOSSY_DVC). Behind its OWN dedicated env gate
                 // (`MACRDP_UDP_LOSSY_AUDIO=1`) — NOT the lossy-offer flag — so the

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -852,3 +852,25 @@ AND released — #1276 landing is NOT sufficient.
     rate controller remains finding-#5 future work. All `multitransport`-gated; feature-off
     byte-unchanged. See feasibility doc "M3c reconnect state-reset" + the "Residual …
     rate-control gap" / trickle-floor note.
+    **EGFX-over-UDP → TCP watchdog (added 2026-06-29):** the reliable (UdpFecR)
+    tunnel is ordered, so under loss it head-of-line-blocks like TCP (finding #4) —
+    once the client stops acking while the server is still shipping, the tunnel is
+    wedged and queued frames never arrive → permanent freeze until reconnect. The
+    H.264 pipeline (`src/h264.rs::should_demigrate_to_tcp` / `submit_bgra`) detects
+    that wedge (reliable UDP only, `egfx_on_udp && !egfx_on_lossy`, acks silent
+    `MACRDP_UDP_EGFX_WATCHDOG_MS`≈3s while actively shipping, not suspended) and sets
+    a shared `demigrate_request: Arc<AtomicBool>` (setter
+    `set_demigrate_request_handle`, wired in `main.rs` alongside the egfx_on_udp
+    handle). The `ServerEvent::Egfx` route arm reads it: on true it flips
+    `egfx_on_udp` false (+ mirrors the egfx_on_udp handle so the H.264 #89 gate
+    releases), logs, and falls through to the TCP DRDYNVC path — the existing
+    `soft_sync_sent` guard stops any re-migration. mstsc renders EGFX on TCP after a
+    Soft-Sync (proven by the throwaway timed "Spike A", verified live 2026-06-29).
+    One-way per connection (h264 `demigrated` latch + the server resets
+    `demigrate_request` false on reconnect alongside `egfx_on_udp`). Default-on but a
+    strict no-op unless EGFX is on the reliable UDP tunnel; even a false positive only
+    routes EGFX to TCP (the proven everyday path). **Verified on real mstsc under
+    clumsy UDP-only loss** (UDP-only so TCP stays a healthy fallback): the wedge fired
+    at `since_ack_ms≈7.7s` (real wedges dribble acks before going fully silent, vs.
+    the deterministic injection's clean ~3s) and EGFX recovered on TCP — no permanent
+    freeze. A future ack-lag-pegged secondary trigger could shorten recovery.

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -420,6 +420,14 @@ pub struct RdpServer {
     /// stay byte-identical). `None` = not wired (default).
     #[cfg(feature = "multitransport")]
     egfx_on_udp_handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// EGFX-over-UDP → TCP watchdog request. The macrdp H.264 pipeline sets this
+    /// true when it detects the reliable UDP tunnel has wedged (acks silent while
+    /// shipping); the EGFX route block reads it and flips `egfx_on_udp` back to
+    /// false so subsequent frames route over the TCP DRDYNVC channel (mstsc renders
+    /// EGFX on TCP post-Soft-Sync — Spike A). One-way per connection; reset to false
+    /// on reconnect so a fresh connection retries UDP. `None` = not wired (default).
+    #[cfg(feature = "multitransport")]
+    demigrate_request: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     /// (M5c step 3b) Receiver for inbound migrated-channel data the UDP listener
     /// forwards (each item is a bare DRDYNVC PDU — HigherLayerData of an inbound
     /// `RDP_TUNNEL_DATA`, e.g. an EGFX frame ack). Created + registered (with the
@@ -558,6 +566,8 @@ impl RdpServer {
             egfx_on_lossy_handle: None,
             egfx_on_udp_handle: None,
             #[cfg(feature = "multitransport")]
+            demigrate_request: None,
+            #[cfg(feature = "multitransport")]
             multitransport_tunnel_sender: None,
             #[cfg(feature = "multitransport")]
             egfx_on_udp: false,
@@ -679,6 +689,18 @@ impl RdpServer {
     #[cfg(feature = "multitransport")]
     pub fn set_egfx_on_udp_handle(&mut self, handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>) {
         self.egfx_on_udp_handle = handle;
+    }
+
+    /// Wire the EGFX-over-UDP → TCP watchdog request flag. The macrdp H.264 pipeline
+    /// sets it true when the reliable UDP tunnel wedges; the EGFX route block reads
+    /// it and de-migrates EGFX back to the TCP DRDYNVC channel for the rest of the
+    /// session. Reset to false on reconnect so a fresh connection retries UDP.
+    #[cfg(feature = "multitransport")]
+    pub fn set_demigrate_request_handle(
+        &mut self,
+        handle: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    ) {
+        self.demigrate_request = handle;
     }
 
     /// Enable migrating the EGFX DVC onto the reliable UDP tunnel (the
@@ -1018,6 +1040,12 @@ impl RdpServer {
                             if let Some(handle) = &self.egfx_on_udp_handle {
                                 handle.store(false, std::sync::atomic::Ordering::Relaxed);
                             }
+                            // Clear the watchdog's de-migrate request so a fresh
+                            // connection retries UDP instead of instantly routing the
+                            // newly-migrated EGFX straight back to TCP.
+                            if let Some(handle) = &self.demigrate_request {
+                                handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                            }
                         }
 
                         if let Some(ref mut handler) = self.connection_handler {
@@ -1345,8 +1373,32 @@ impl RdpServer {
                         // channel. Default path is unchanged TCP.
                         #[cfg(feature = "multitransport")]
                         if self.egfx_on_udp {
-                            self.route_dvc_over_udp(messages)?;
-                            continue;
+                            // EGFX-over-UDP → TCP watchdog: the H.264 pipeline sets
+                            // `demigrate_request` when it detects the reliable UDP
+                            // tunnel has wedged (acks silent while shipping). Flip
+                            // routing back to the TCP DRDYNVC channel for the rest of
+                            // this session and fall through to the TCP path — mstsc
+                            // renders EGFX on TCP after a Soft-Sync (Spike A). The flip
+                            // also clears the H.264 #89 backpressure gate via the
+                            // shared egfx_on_udp handle. One-way; reset on reconnect.
+                            if self
+                                .demigrate_request
+                                .as_ref()
+                                .is_some_and(|h| h.load(std::sync::atomic::Ordering::Relaxed))
+                            {
+                                self.egfx_on_udp = false;
+                                if let Some(handle) = &self.egfx_on_udp_handle {
+                                    handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                                }
+                                warn!(
+                                    "EGFX-over-UDP reliable tunnel wedged — watchdog de-migrating EGFX to \
+                                     TCP DRDYNVC for the rest of this session"
+                                );
+                                // fall through to the TCP DRDYNVC path below
+                            } else {
+                                self.route_dvc_over_udp(messages)?;
+                                continue;
+                            }
                         }
                         let drdynvc_channel_id = self
                             .get_channel_id_by_type::<dvc::DrdynvcServer>()


### PR DESCRIPTION
## What

Adds a watchdog that auto-recovers EGFX video when the reliable UDP multitransport
tunnel **wedges** — instead of staying frozen until the user reconnects.

The reliable (UdpFecR) tunnel is ordered, so under loss it head-of-line-blocks like
TCP (feasibility finding #4): once the client stops acking while the server is still
shipping, queued EGFX frames never arrive and the picture freezes permanently. The
watchdog detects that and routes EGFX back onto **TCP** (which mstsc renders cleanly
after a Soft-Sync) + forces an IDR.

## How

- **Detect** (`src/h264.rs`, pure `should_demigrate_to_tcp`, 8 unit tests): reliable
  UDP only (`egfx_on_udp && !egfx_on_lossy`); frame acks silent for
  `MACRDP_UDP_EGFX_WATCHDOG_MS` (default 3000) while actively shipping (the #89
  trickle floor keeps frames flowing even when ack-lag is high); not suspended; not
  yet de-migrated.
- **Recover**: force an IDR (last UDP frames never arrived → stale reference), reset
  the #89 lag baseline (so the trickle gate doesn't drop the recovery IDR before
  routing flips), and set a shared `demigrate_request` flag. The vendored server's
  EGFX route arm reads it, flips `egfx_on_udp` false (+ mirrors the egfx_on_udp
  handle so the #89 gate releases), logs, and falls through to the TCP DRDYNVC path.
  The existing `soft_sync_sent` guard stops re-migration.
- **One-way** per connection (`demigrated` latch; server resets `demigrate_request`
  on reconnect so a fresh connection retries UDP). Default-on but a strict no-op
  unless EGFX is on the reliable UDP tunnel (`--udp-migrate-egfx`), so the default
  TCP path is byte-identical. Disable with `MACRDP_UDP_EGFX_WATCHDOG=0`.

## Verification

Established first by a throwaway *timed* de-migration spike (flip `egfx_on_udp`
false → TCP, no reverse Soft-Sync needed — mstsc keeps rendering, verified live).
Then the full ack-stall watchdog, verified two ways on **real mstsc**:

1. **Deterministic clean-link injection** (drop acks after N s) → fired at
   `since_ack_ms=3004`, video recovered.
2. **Genuine clumsy UDP-only loss** (UDP dropped, TCP left healthy as the fallback)
   → fired at `since_ack_ms≈7736` (real wedges dribble a few stray acks before going
   fully silent, so the pure-silence trigger latches later than the injection) → EGFX
   recovered on the healthy TCP channel, **no permanent freeze**.

Follow-up (deferred, TODO): an ack-lag-pegged secondary trigger to shorten the
~7–8s real-wedge recovery window toward the 3s ideal.

## Tests / checks

- 8 new unit tests for the predicate; `cargo test` 85 pass.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.

Docs: feasibility doc + vendored `ironrdp-server` divergence (12) + TODO updated.