### PR TITLE
feat(udp): congestion-responsive adaptive bitrate for EGFX-over-UDP (rate control P1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,13 +7,31 @@ then delete; promote a parked item to *In flight* when work actually starts.
 
 ## In flight (needs an action)
 
-- (nothing in flight — EGFX-over-UDP → TCP watchdog shipped as #93, verified on real
-  mstsc under clumsy UDP-only loss)
+- [ ] **Congestion-responsive rate control — P1: adaptive bitrate** (`--adaptive-bitrate`).
+  Built + verified on real mstsc under clumsy UDP-only loss: at 8% the bitrate dropped
+  (AIMD on the reliable-tunnel retransmit signal) and video **stayed alive with no wedge**;
+  at sustained 12% it still wedged → watchdog → TCP (the backstop). Branch
+  `feat/udp-adaptive-bitrate`. **Awaiting CI + merge.** P2/P3 (IDR-backoff, frame-drop
+  integration, TCP adapter, real-server capture tuning) remain in the item below.
+
+- [ ] **Watchdog follow-up: keep the de-migrated UDP tunnel from timing out.** Found
+  2026-06-29 during P1 testing: under *sustained* heavy loss the watchdog de-migrates EGFX
+  to TCP (video keeps running), but ~60s later **mstsc resets the whole session**
+  (`Connection reset by peer`) — its multitransport dead-tunnel timeout, since the UDP
+  tunnel it Soft-Synced EGFX onto goes silent after de-migration. Fix: after de-migration,
+  either send RDPEUDP **keepalives** on the abandoned tunnel so mstsc doesn't time out, or
+  cleanly **close** the multitransport tunnel so mstsc stops expecting it. Must distinguish
+  "de-migrated, client still here" from "client gone" (interacts with the 60s idle-GC).
+  Still strictly better than the pre-watchdog permanent freeze; only bites under sustained
+  loss. See the `feat/udp-adaptive-bitrate` test log (wedge 23:44:49 → reset 23:45:50).
 
 ## Deferred — scoped, not started
 
 - [ ] **Congestion-responsive encoder rate control + frame dropping** (highest-value
-  video-under-loss work — helps BOTH the default TCP path and UDP). **Concrete
+  video-under-loss work — helps BOTH the default TCP path and UDP). **P1 (adaptive bitrate)
+  SHIPPING — see In-flight above;** the remaining P2/P3 sub-pieces (IDR-backoff under the
+  controller, frame-drop integration, the TCP-path adapter, and tuning the control law
+  against a real-Windows-server capture) are below. **Concrete
   manifestation found 2026-06-28:** EGFX-over-UDP reconnect freezes *intermittently*
   because the server never throttles on the client's EGFX `queueDepth` —
   `GfxHandler::on_frame_ack` only records ack timing, so macrdp ships at full rate while

--- a/docs/rdp-udp-multitransport-feasibility.md
+++ b/docs/rdp-udp-multitransport-feasibility.md
@@ -332,6 +332,24 @@ reliable-only multitransport.
    the watchdog *escapes* a dead tunnel; rate control *prevents* the wedge and also
    helps the TCP path.
 
+   **SHIPPED 2026-06-29 — rate control P1: adaptive bitrate (`--adaptive-bitrate`).**
+   The first piece of the congestion-responsive controller. Loss signal: the UDP
+   listener accumulates reliable-tunnel **retransmits** into a shared counter
+   (`Arc<AtomicU64>`, threaded through `bind`/`run_recv_loop`); the H.264 controller
+   (`src/h264.rs::adaptive_bitrate_step`, pure `aimd_bitrate`, unit-tested) samples
+   the per-interval delta and runs **AIMD**: multiplicative-decrease the VideoToolbox
+   target toward a floor on any loss, additive-increase toward the `--bitrate` ceiling
+   when clean. Lever: `Encoder::set_bitrate` live-sets `AverageBitRate` on the running
+   VT session (no rebuild → reference chain intact). Opt-in, EGFX-over-UDP only (no-op
+   on TCP). **Verified on real mstsc under clumsy UDP-only loss: at 8% the bitrate
+   dropped and video stayed alive with NO wedge** (the controller kept the tunnel under
+   its window — the win); at sustained 12% it still wedged → watchdog → TCP. Uses the
+   retransmit signal only; CN/RTT/window and the levers below are P2/P3. **Follow-up
+   found in the same test:** under *sustained* heavy loss, ~60s after a watchdog
+   de-migration mstsc resets the session (its multitransport dead-tunnel timeout on the
+   now-silent UDP tunnel) — fix is to keepalive or cleanly close the abandoned tunnel
+   on de-migrate (TODO).
+
    **What "URCP" actually is, and the concrete signals macrdp already ignores.**
    URCP = **Universal Rate Control Protocol** (Microsoft Research, ~2013) — the
    congestion-/rate-control *algorithm* under RDP Shortpath + MS-RDPEUDP2. It's not a

--- a/src/h264.rs
+++ b/src/h264.rs
@@ -182,6 +182,15 @@ struct ConnectionContext {
     /// never re-migrate to UDP in-session (no flapping); UDP is retried only on the
     /// next connection. Reset with the fresh context on reconnect.
     demigrated: bool,
+    /// Adaptive-bitrate (congestion-responsive rate control) per-connection state.
+    /// `adaptive_target_bps` is the controller's current target (starts at the
+    /// configured `--bitrate` ceiling); `adaptive_last_control` rate-limits the AIMD
+    /// step to one per `Gfx::adaptive_interval`; `adaptive_last_retransmits` is the
+    /// last sampled value of the shared cumulative-retransmit loss counter, so the
+    /// controller works on per-interval deltas. See [`Gfx::adaptive_bitrate_step`].
+    adaptive_target_bps: u32,
+    adaptive_last_control: Instant,
+    adaptive_last_retransmits: u64,
 }
 
 /// Tunables for ack-driven IDR recovery (EGFX-on-lossy). See
@@ -267,6 +276,27 @@ fn should_demigrate_to_tcp(
         && !acks_suspended
         && since_ship <= active_window
         && since_ack >= wedge_timeout
+}
+
+/// Pure AIMD step for congestion-responsive bitrate (P1). Given the current target,
+/// the reliable-tunnel loss delta observed this control interval, and the bounds/
+/// params, return the new target bitrate. **Multiplicative-decrease** on any loss
+/// (back off fast, clamp to `floor_bps`); **additive-increase** when clean (climb
+/// slowly, clamp to `ceiling_bps`). Pure (no clock/state) so it's unit-testable.
+/// See [`Gfx::adaptive_bitrate_step`].
+fn aimd_bitrate(
+    current: u32,
+    loss_delta: u64,
+    floor_bps: u32,
+    ceiling_bps: u32,
+    increase_bps: u32,
+    decrease: f32,
+) -> u32 {
+    if loss_delta > 0 {
+        (((current as f32) * decrease) as u32).max(floor_bps)
+    } else {
+        current.saturating_add(increase_bps).min(ceiling_bps)
+    }
 }
 
 /// Read the ack-recovery config from the environment once. Returns
@@ -355,6 +385,22 @@ pub struct Gfx {
     /// Shared with the vendored server: set true here on a wedge, read there to
     /// flip `egfx_on_udp` → TCP routing; reset there on reconnect.
     demigrate_request: Arc<AtomicBool>,
+    /// Adaptive bitrate (congestion-responsive rate control, P1). On by
+    /// `--adaptive-bitrate` (or `MACRDP_UDP_ADAPTIVE_BITRATE`); only acts while EGFX
+    /// is on a UDP tunnel, so it's a no-op on TCP. The controller (AIMD) reads the
+    /// shared `congestion_retransmits` loss counter the UDP listener bumps and live-
+    /// adjusts the VideoToolbox bitrate within `[adaptive_floor_bps, bitrate_bps]`:
+    /// multiplicative-decrease `adaptive_decrease` per interval with loss, additive-
+    /// increase `adaptive_increase_bps` per interval when clean. `bitrate_bps` (the
+    /// `--bitrate` value) is the ceiling. See [`Gfx::adaptive_bitrate_step`].
+    adaptive_enabled: bool,
+    adaptive_floor_bps: u32,
+    adaptive_increase_bps: u32,
+    adaptive_decrease: f32,
+    adaptive_interval: Duration,
+    /// Cumulative reliable-tunnel retransmit count, bumped by the UDP listener and
+    /// sampled (as deltas) by the controller. Shared `Arc` like the egfx flags.
+    congestion_retransmits: Arc<AtomicU64>,
 }
 
 impl Gfx {
@@ -368,6 +414,8 @@ impl Gfx {
         egfx_on_lossy: Arc<AtomicBool>,
         egfx_on_udp: Arc<AtomicBool>,
         demigrate_request: Arc<AtomicBool>,
+        adaptive_bitrate: bool,
+        congestion_retransmits: Arc<AtomicU64>,
     ) -> Self {
         let wire_format = WireFormat::from_env();
         let (recovery_enabled, recovery_params) = recovery_config_from_env();
@@ -391,6 +439,36 @@ impl Gfx {
         };
         let watchdog_wedge_timeout = watchdog_ms("MACRDP_UDP_EGFX_WATCHDOG_MS", 3000);
         let watchdog_active_window = watchdog_ms("MACRDP_UDP_EGFX_WATCHDOG_ACTIVE_MS", 1000);
+        // Adaptive bitrate (P1). Enabled by the --adaptive-bitrate flag OR the env
+        // fallback; the controller still only acts while EGFX is on a UDP tunnel.
+        let adaptive_enabled =
+            adaptive_bitrate || crate::multitransport::env_truthy("MACRDP_UDP_ADAPTIVE_BITRATE");
+        let env_u32 = |name: &str, default: u32| -> u32 {
+            std::env::var(name)
+                .ok()
+                .and_then(|s| s.trim().parse::<u32>().ok())
+                .filter(|&n| n > 0)
+                .unwrap_or(default)
+        };
+        // Floor: don't drop below this (degrade to "choppy but alive", not dead).
+        // Default = 1/8 of the ceiling, clamped to ≥500 kbps and ≤ the ceiling.
+        let adaptive_floor_bps = env_u32(
+            "MACRDP_UDP_ADAPTIVE_FLOOR_BPS",
+            (bitrate_bps / 8).max(500_000),
+        )
+        .min(bitrate_bps.max(1));
+        // Additive-increase step per interval: ~1/16 of the ceiling (≈16 clean
+        // intervals to climb the full range). Multiplicative-decrease factor on loss.
+        let adaptive_increase_bps = env_u32(
+            "MACRDP_UDP_ADAPTIVE_INCREASE_BPS",
+            (bitrate_bps / 16).max(250_000),
+        );
+        let adaptive_decrease = std::env::var("MACRDP_UDP_ADAPTIVE_DECREASE")
+            .ok()
+            .and_then(|s| s.trim().parse::<f32>().ok())
+            .filter(|&f| f > 0.0 && f < 1.0)
+            .unwrap_or(0.7);
+        let adaptive_interval = watchdog_ms("MACRDP_UDP_ADAPTIVE_INTERVAL_MS", 300);
         let (width, height) = desktop_size.get();
         info!(
             ?wire_format,
@@ -401,6 +479,17 @@ impl Gfx {
                 ?recovery_params,
                 "EGFX ack-driven IDR recovery ENABLED (MACRDP_UDP_EGFX_ACK_RECOVERY) — \
                  active only while EGFX is on the lossy UDP tunnel"
+            );
+        }
+        if adaptive_enabled {
+            info!(
+                ceiling_bps = bitrate_bps,
+                floor_bps = adaptive_floor_bps,
+                increase_bps = adaptive_increase_bps,
+                decrease = adaptive_decrease,
+                interval_ms = adaptive_interval.as_millis() as u64,
+                "EGFX adaptive bitrate ENABLED (--adaptive-bitrate) — congestion-responsive \
+                 rate control, active only while EGFX is on a UDP tunnel"
             );
         }
         Self {
@@ -421,6 +510,12 @@ impl Gfx {
             watchdog_wedge_timeout,
             watchdog_active_window,
             demigrate_request,
+            adaptive_enabled,
+            adaptive_floor_bps,
+            adaptive_increase_bps,
+            adaptive_decrease,
+            adaptive_interval,
+            congestion_retransmits,
         }
     }
 
@@ -600,13 +695,65 @@ impl Gfx {
             let Some(ctx) = guard.as_mut() else {
                 return Ok(true);
             };
+            // Congestion-responsive bitrate (P1): compute the new target (mutates
+            // ctx adaptive state) BEFORE borrowing the encoder, then apply it live.
+            // No-op unless adaptive is enabled AND EGFX is on a UDP tunnel.
+            let new_bitrate = self.adaptive_bitrate_step(ctx);
             let Some(encoder) = ctx.encoder.as_mut() else {
                 return Ok(true);
             };
+            if let Some(bps) = new_bitrate {
+                if let Err(e) = encoder.set_bitrate(bps) {
+                    trace!(error = ?e, bps, "adaptive set_bitrate failed");
+                }
+            }
             encoder.encode_bgra(bgra, stride, force_keyframe)?;
             ctx.submitted.fetch_add(1, Ordering::Relaxed);
         }
         Ok(true)
+    }
+
+    /// Congestion-responsive bitrate controller (P1, AIMD). Called once per capture
+    /// from `submit_bgra` while holding the ctx lock; rate-limited to one step per
+    /// `adaptive_interval`. Reads the shared cumulative-retransmit loss counter the
+    /// UDP listener bumps and, per interval: **multiplicative-decrease** the target
+    /// toward `adaptive_floor_bps` if any loss occurred, else **additive-increase**
+    /// toward the `bitrate_bps` ceiling. Returns `Some(bps)` when the target changed
+    /// (the caller live-sets it on the VT session). No-op (returns `None`) unless
+    /// the feature is enabled and EGFX is on a UDP tunnel — so TCP stays byte-identical.
+    fn adaptive_bitrate_step(&self, ctx: &mut ConnectionContext) -> Option<u32> {
+        if !self.adaptive_enabled || !self.egfx_on_udp.load(Ordering::Relaxed) {
+            return None;
+        }
+        let now = Instant::now();
+        if now.duration_since(ctx.adaptive_last_control) < self.adaptive_interval {
+            return None;
+        }
+        ctx.adaptive_last_control = now;
+        let cur = self.congestion_retransmits.load(Ordering::Relaxed);
+        let delta = cur.saturating_sub(ctx.adaptive_last_retransmits);
+        ctx.adaptive_last_retransmits = cur;
+        let new_target = aimd_bitrate(
+            ctx.adaptive_target_bps,
+            delta,
+            self.adaptive_floor_bps,
+            self.bitrate_bps.max(1),
+            self.adaptive_increase_bps,
+            self.adaptive_decrease,
+        );
+        if new_target != ctx.adaptive_target_bps {
+            let prev = ctx.adaptive_target_bps;
+            ctx.adaptive_target_bps = new_target;
+            debug!(
+                loss_delta = delta,
+                prev_bps = prev,
+                new_bps = new_target,
+                "EGFX adaptive bitrate adjusted"
+            );
+            Some(new_target)
+        } else {
+            None
+        }
     }
 
     /// Ship loop for the push pipeline: owns VideoToolbox's output receiver and
@@ -921,6 +1068,9 @@ impl GfxServerFactory for Gfx {
             egfx_acks_seen: false,
             last_throttle_ship: Instant::now(),
             demigrated: false,
+            adaptive_target_bps: self.bitrate_bps,
+            adaptive_last_control: Instant::now(),
+            adaptive_last_retransmits: self.congestion_retransmits.load(Ordering::Relaxed),
         });
         Some((GfxDvcBridge::new(handle.clone()), handle))
     }
@@ -1389,6 +1539,62 @@ mod tests {
             WD_ACTIVE,
             WD_WEDGE
         ));
+    }
+
+    // ---- adaptive bitrate AIMD (`aimd_bitrate`) ----
+    // (current, loss_delta, floor, ceiling, increase, decrease)
+    #[test]
+    fn aimd_decreases_multiplicatively_on_loss() {
+        // 10 Mbps, loss this interval, 0.7 factor → 7 Mbps (above the 1 Mbps floor).
+        assert_eq!(
+            aimd_bitrate(10_000_000, 3, 1_000_000, 10_000_000, 500_000, 0.7),
+            7_000_000
+        );
+    }
+
+    #[test]
+    fn aimd_decrease_clamps_to_floor() {
+        // Already near the floor; a further cut can't go below it.
+        assert_eq!(
+            aimd_bitrate(1_200_000, 5, 1_000_000, 10_000_000, 500_000, 0.7),
+            1_000_000
+        );
+    }
+
+    #[test]
+    fn aimd_increases_additively_when_clean() {
+        // No loss → climb by the step.
+        assert_eq!(
+            aimd_bitrate(5_000_000, 0, 1_000_000, 10_000_000, 500_000, 0.7),
+            5_500_000
+        );
+    }
+
+    #[test]
+    fn aimd_increase_clamps_to_ceiling() {
+        // Near the ceiling; the additive step can't exceed it.
+        assert_eq!(
+            aimd_bitrate(9_800_000, 0, 1_000_000, 10_000_000, 500_000, 0.7),
+            10_000_000
+        );
+    }
+
+    #[test]
+    fn aimd_at_ceiling_clean_is_stable() {
+        // At the ceiling on a clean interval → unchanged (caller treats == as no-op).
+        assert_eq!(
+            aimd_bitrate(10_000_000, 0, 1_000_000, 10_000_000, 500_000, 0.7),
+            10_000_000
+        );
+    }
+
+    #[test]
+    fn aimd_at_floor_with_loss_is_stable() {
+        // At the floor under continued loss → stays at the floor (choppy-but-alive).
+        assert_eq!(
+            aimd_bitrate(1_000_000, 9, 1_000_000, 10_000_000, 500_000, 0.7),
+            1_000_000
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,6 +471,16 @@ struct Args {
     #[arg(long)]
     udp_migrate_egfx: bool,
 
+    /// EXPERIMENTAL, opt-in (default OFF). Congestion-responsive H.264 bitrate for
+    /// EGFX-over-UDP: when the reliable UDP tunnel shows packet loss (retransmits),
+    /// lower the VideoToolbox bitrate toward a floor (AIMD multiplicative-decrease),
+    /// and climb back toward the --bitrate ceiling when the link clears — so video
+    /// degrades to "choppy but alive" under loss instead of wedging. Only acts while
+    /// EGFX is on a UDP tunnel (no-op on TCP). Tunables: MACRDP_UDP_ADAPTIVE_FLOOR_BPS,
+    /// _INCREASE_BPS, _DECREASE, _INTERVAL_MS. macOS-only build.
+    #[arg(long)]
+    adaptive_bitrate: bool,
+
     /// Don't adopt the client's requested desktop resolution. By default —
     /// when mirroring the primary display without --width/--height/--hidpi —
     /// macrdp reads the resolution the client asked for while connecting
@@ -1397,6 +1407,9 @@ fn args_from_config(path: &Path) -> Result<Args> {
     if on("UDP_MIGRATE_EGFX", false) {
         argv.push("--udp-migrate-egfx".into());
     }
+    if on("ADAPTIVE_BITRATE", false) {
+        argv.push("--adaptive-bitrate".into());
+    }
     if on("FORK_WORKERS", false) {
         argv.push("--fork-workers".into());
     }
@@ -2014,6 +2027,11 @@ async fn async_main() -> Result<()> {
     // reliable UDP tunnel wedges (acks silent while shipping); the server reads it to
     // flip EGFX routing back to TCP. Reset on reconnect (server side).
     let egfx_demigrate_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    // Adaptive-bitrate loss signal: cumulative reliable-tunnel retransmit count the
+    // UDP listener bumps and the H.264 controller samples (deltas) to drive
+    // congestion-responsive bitrate. Cross-platform so the listener wiring compiles
+    // on CI; only read on the macOS H.264 path.
+    let congestion_retransmits = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
 
     // EGFX/H.264 video pipeline (macOS-only; opt-in via --enable-h264). One
     // clone drives the builder's GfxServerFactory (protocol side); another
@@ -2029,6 +2047,8 @@ async fn async_main() -> Result<()> {
             egfx_on_lossy_flag.clone(),
             egfx_on_udp_flag.clone(),
             egfx_demigrate_flag.clone(),
+            args.adaptive_bitrate,
+            congestion_retransmits.clone(),
         )
     });
 
@@ -2215,6 +2235,7 @@ async fn async_main() -> Result<()> {
             Some(cookie_registry.clone()),
             Some(tunnel_rx),
             udp_dtls_config,
+            Some(congestion_retransmits.clone()),
         )
         .await
         {

--- a/src/multitransport.rs
+++ b/src/multitransport.rs
@@ -283,6 +283,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("bind listener");

--- a/src/videotoolbox.rs
+++ b/src/videotoolbox.rs
@@ -118,6 +118,14 @@ impl Encoder {
         self.rx.take()
     }
 
+    /// Live-update the target average bitrate (bps) on the running session, for
+    /// congestion-responsive rate control (`h264.rs`'s adaptive-bitrate
+    /// controller). No encoder rebuild, so the H.264 reference chain is preserved.
+    pub fn set_bitrate(&self, bitrate_bps: u32) -> Result<()> {
+        // SAFETY: `self.inner.session` is valid for the lifetime of the Encoder.
+        unsafe { ffi::set_average_bitrate(self.inner.session, bitrate_bps) }
+    }
+
     /// Submit a BGRA frame for encoding. `stride` is in bytes per row
     /// of the source buffer — VideoToolbox is told the source pixel
     /// format is `kCVPixelFormatType_32BGRA`, so each pixel is 4 bytes
@@ -536,6 +544,22 @@ mod ffi {
             bail!("VTCompressionSessionPrepareToEncodeFrames failed: OSStatus {prepared}");
         }
         Ok(guard)
+    }
+
+    /// Live-update the target average bitrate on a running session — for
+    /// congestion-responsive rate control. `kVTCompressionPropertyKey_AverageBitRate`
+    /// is settable mid-session; VT's rate controller adapts within a frame or two,
+    /// so we can lower it under loss and climb back when the link clears without
+    /// rebuilding the encoder (which would force an IDR + lose the reference chain).
+    pub(super) unsafe fn set_average_bitrate(
+        session: VTCompressionSessionRef,
+        bitrate_bps: u32,
+    ) -> Result<()> {
+        set_i32(
+            session,
+            kVTCompressionPropertyKey_AverageBitRate,
+            bitrate_bps.max(1) as i32,
+        )
     }
 
     unsafe fn set_bool(

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -874,3 +874,14 @@ AND released — #1276 landing is NOT sufficient.
     at `since_ack_ms≈7.7s` (real wedges dribble acks before going fully silent, vs.
     the deterministic injection's clean ~3s) and EGFX recovered on TCP — no permanent
     freeze. A future ack-lag-pegged secondary trigger could shorten recovery.
+    **Adaptive-bitrate loss signal (added 2026-06-29):** the UDP listener
+    (`multitransport/listener.rs`) accumulates reliable-tunnel **retransmits** into a
+    shared `Arc<AtomicU64>` so macrdp's H.264 controller can do congestion-responsive
+    bitrate (AIMD). Threaded as a new last param through
+    `UdpMultitransportListener::bind` → `run_recv_loop` alongside the existing tls/dtls
+    Arcs (NOT in `ListenerConfig`, which stays `Copy`), bumped at all three `sm.step()`
+    retransmit sites via a `bump_loss` closure + `pump_peers_on_timer`'s return value.
+    `None` = not wired. See `src/h264.rs::adaptive_bitrate_step` + feasibility doc
+    "rate control P1". **Watchdog follow-up (TODO):** under sustained loss mstsc resets
+    ~60s after a de-migration (its multitransport dead-tunnel timeout on the now-silent
+    UDP tunnel) — keepalive or cleanly close the abandoned tunnel on de-migrate.

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -36,6 +36,7 @@ use std::io;
 use std::io::Read as _;
 use std::io::Write as _;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use ironrdp_rdpeudp::datagram::Datagram;
@@ -177,6 +178,7 @@ impl UdpMultitransportListener {
         cookie_registry: Option<CookieRegistry>,
         tunnel_rx: Option<UnboundedReceiver<TunnelOutbound>>,
         dtls_config: Option<DtlsServerContext>,
+        congestion_retransmits: Option<Arc<AtomicU64>>,
     ) -> io::Result<Self> {
         let socket = UdpSocket::bind(addr).await?;
         let local_addr = socket.local_addr()?;
@@ -196,6 +198,7 @@ impl UdpMultitransportListener {
             cookie_registry,
             tunnel_rx,
             dtls_config,
+            congestion_retransmits,
         ));
         Ok(Self { local_addr, task })
     }
@@ -242,13 +245,15 @@ async fn pump_peers_on_timer(
     peers: &mut HashMap<SocketAddr, Peer>,
     now_ms: u64,
     mtu: u16,
-) {
+) -> usize {
+    let mut total_retransmits = 0usize;
     for (addr, peer) in peers.iter_mut() {
         if !peer.sm.is_established() {
             continue;
         }
         let out = peer.sm.step(now_ms, None);
         let (retransmits, syn_retransmit) = (out.retransmits, out.syn_retransmit);
+        total_retransmits += retransmits;
         if !out.to_send.is_empty() {
             send_datagrams(socket, *addr, out.to_send, mtu).await;
         }
@@ -256,6 +261,7 @@ async fn pump_peers_on_timer(
             debug!(peer_addr = %addr, retransmits, syn_retransmit, "RDPEUDP RTO retransmit (timer)");
         }
     }
+    total_retransmits
 }
 
 /// (M3c) Evict a peer after this many ms with no *inbound* datagram.
@@ -491,7 +497,20 @@ async fn run_recv_loop(
     cookie_registry: Option<CookieRegistry>,
     mut tunnel_rx: Option<UnboundedReceiver<TunnelOutbound>>,
     dtls_config: Option<DtlsServerContext>,
+    // Adaptive-bitrate loss signal: cumulative reliable-tunnel retransmit count the
+    // macrdp H.264 controller samples (deltas) to drive congestion-responsive
+    // bitrate. `None` = not wired (the feature off / TCP-only build).
+    congestion_retransmits: Option<Arc<AtomicU64>>,
 ) {
+    // Accumulate reliable retransmits into the shared loss-signal counter (no-op
+    // when not wired). Closure over the Option so the 3 step sites stay one-liners.
+    let bump_loss = |n: usize| {
+        if n > 0 {
+            if let Some(c) = &congestion_retransmits {
+                c.fetch_add(n as u64, Ordering::Relaxed);
+            }
+        }
+    };
     let mut peers: HashMap<SocketAddr, Peer> = HashMap::new();
     // (M5c) cookie -> peer address, populated when a tunnel binds, so
     // server-originated `TunnelOutbound` (keyed by cookie) reaches the right peer.
@@ -563,7 +582,7 @@ async fn run_recv_loop(
             },
             _ = retransmit_tick.tick() => {
                 let now_ms = start.elapsed().as_millis() as u64;
-                pump_peers_on_timer(&socket, &mut peers, now_ms, cfg.mtu).await;
+                bump_loss(pump_peers_on_timer(&socket, &mut peers, now_ms, cfg.mtu).await);
                 // (M3c) Reap peers whose client has gone away (no inbound for
                 // PEER_IDLE_TIMEOUT_MS) so the dead-peer retransmits above stop and
                 // peers/bound_addrs don't leak. Same tick — cheap, peers is small.
@@ -714,6 +733,7 @@ async fn run_recv_loop(
         let had_data = Datagram::peek_fec_flags(data).is_some_and(|f| f.contains(FecFlags::DATA));
         let out = peer.sm.step(now_ms, Some(data));
         let (retransmits, syn_retransmit) = (out.retransmits, out.syn_retransmit);
+        bump_loss(retransmits);
         send_datagrams(&socket, peer_addr, out.to_send, cfg.mtu).await;
         if retransmits > 0 || syn_retransmit {
             // The reliable transport recovered lost packets — the signal a
@@ -957,6 +977,7 @@ async fn run_recv_loop(
                 if !tls_out.is_empty() {
                     let o = sm.enqueue(now_ms, &tls_out);
                     let (retransmits, syn_retransmit) = (o.retransmits, o.syn_retransmit);
+                    bump_loss(retransmits);
                     send_datagrams(&socket, peer_addr, o.to_send, cfg.mtu).await;
                     if retransmits > 0 || syn_retransmit {
                         debug!(%peer_addr, retransmits, syn_retransmit, "RDPEUDP RTO retransmit (outbound)");


### PR DESCRIPTION
## What

First piece of the congestion-responsive rate controller (the highest-value
video-under-loss work). The watchdog (#93) *escapes* a tunnel that has already
wedged; this *prevents* the wedge by lowering H.264 bitrate under loss, so
EGFX-over-UDP degrades to "choppy but alive" instead of pegging the reliable
window and freezing.

## How

- **Loss signal:** the UDP listener (`vendor/ironrdp-server/.../listener.rs`)
  accumulates reliable-tunnel retransmits into a shared `Arc<AtomicU64>`, threaded
  through `bind` → `run_recv_loop` alongside the existing tls/dtls Arcs (NOT in
  `ListenerConfig`, which stays `Copy`), bumped at all three `sm.step()` sites.
- **Controller** (`src/h264.rs::adaptive_bitrate_step`, pure `aimd_bitrate`, 6 unit
  tests): once per `MACRDP_UDP_ADAPTIVE_INTERVAL_MS` (300) while EGFX is on a UDP
  tunnel, sample the retransmit delta → AIMD: multiplicative-decrease toward a floor
  on loss, additive-increase toward the `--bitrate` ceiling when clean.
- **Lever:** `Encoder::set_bitrate` live-sets `kVTCompressionPropertyKey_AverageBitRate`
  on the running VT session (no rebuild → H.264 reference chain preserved).
- **Gating:** `--adaptive-bitrate` (or `MACRDP_UDP_ADAPTIVE_BITRATE`), config
  passthrough `ADAPTIVE_BITRATE`. Default OFF; strict no-op on TCP (only acts while
  `egfx_on_udp`) → default path byte-identical. Tunables:
  MACRDP_UDP_ADAPTIVE_{FLOOR_BPS,INCREASE_BPS,DECREASE,INTERVAL_MS}.

Composes with the watchdog: adaptive tries to avoid the wedge; if loss still wedges
the tunnel, the watchdog moves EGFX to TCP.

## Verification (real mstsc, clumsy UDP-only loss)

- **8% loss:** bitrate dropped (AIMD) and **video stayed alive with no wedge** — the
  controller kept the tunnel under its window. The win.
- **Sustained 12%:** still wedged even at the floor → watchdog → TCP (the backstop).
  No permanent freeze.

## Follow-up (logged, not in this PR)

Under *sustained* heavy loss, ~60s after a watchdog de-migration mstsc resets the
session (its multitransport dead-tunnel timeout on the now-silent UDP tunnel). Fix:
keepalive or cleanly close the abandoned tunnel on de-migrate. Tracked in TODO; still
strictly better than the pre-watchdog permanent freeze.

## Scope

P1 = bitrate only (retransmit signal). P2/P3 (IDR-backoff, frame-drop integration,
CN/RTT/window signals, TCP-path adapter, real-server capture tuning) remain.

## Tests / checks
- 6 new unit tests for `aimd_bitrate`; `cargo test` 91 pass.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.