### PR TITLE
fix(udp): restore full bitrate when EGFX de-migrates to TCP

### DIFF
--- a/src/h264.rs
+++ b/src/h264.rs
@@ -836,17 +836,29 @@ impl Gfx {
             return actions;
         }
         if !self.egfx_on_udp.load(Ordering::Relaxed) {
-            // EGFX is on TCP (never migrated, or the watchdog de-migrated). If we'd
-            // stretched the keyframe interval on the UDP tunnel, restore the normal
-            // periodic IDR for the TCP path (one-shot) — otherwise the encoder keeps
-            // the ~10 min stretched interval and the TCP session has no periodic
-            // keyframe to heal a decode glitch. The watchdog already forced one IDR
-            // at de-migration, so no extra recovery IDR is needed here.
+            // EGFX is on TCP (never migrated, or the watchdog de-migrated). TCP is
+            // paced by socket backpressure and never HOL-freezes on loss (it just
+            // slows), so the UDP-side backoff doesn't apply here — restore the FULL
+            // configured bitrate and the normal keyframe interval (one-shot). Without
+            // this the TCP session is stuck at whatever reduced bitrate the UDP
+            // controller had ramped down to (e.g. the floor) with nothing to climb it
+            // back, since the adaptive controller only runs while EGFX is on the UDP
+            // tunnel. (Dynamic rate control ON the TCP path — read backpressure /
+            // TCP_CONNECTION_INFO — is P3.) The watchdog already forced one IDR at
+            // de-migration, so no extra recovery IDR is needed here.
+            let ceiling = self.bitrate_bps.max(1);
+            if ctx.adaptive_target_bps < ceiling {
+                ctx.adaptive_target_bps = ceiling;
+                actions.bitrate_bps = Some(ceiling);
+            }
             if ctx.idr_backed_off {
                 ctx.idr_backed_off = false;
                 actions.keyframe_frames = Some(self.normal_keyframe_frames);
+            }
+            if actions.bitrate_bps.is_some() || actions.keyframe_frames.is_some() {
                 info!(
-                    "EGFX IDR backoff: EGFX left the UDP tunnel — restoring normal periodic keyframe"
+                    ceiling_bps = ceiling,
+                    "EGFX left the UDP tunnel — restoring full bitrate + normal keyframe for the TCP path"
                 );
             }
             return actions;


### PR DESCRIPTION
## Problem (reported by user)

After the EGFX-over-UDP watchdog de-migrates video to TCP, the session keeps running at the *reduced* bitrate the UDP adaptive controller had ramped down to (down to the 500k floor) — even on a TCP link that handles 6–8 Mbps fine. The bitrate never climbs back because the adaptive controller only runs while EGFX is on the UDP tunnel; the de-migrate handler restored the keyframe interval but **not** the bitrate.

## Fix

On de-migrate to TCP (`egfx_on_udp` false while `adaptive_target_bps < ceiling`), restore the full configured `--bitrate` + normal keyframe interval, one-shot. TCP is paced by socket backpressure and never HOL-freezes on loss (it just slows), so the UDP-side backoff doesn't apply there.

New `info` line on de-migrate: `EGFX left the UDP tunnel — restoring full bitrate + normal keyframe for the TCP path`.

Dynamic rate control *on* the TCP path (read write-backpressure / `TCP_CONNECTION_INFO`) is the separate P3 roadmap item.

## Tests

100 unit tests pass, clippy + fmt clean. Opt-in (`--adaptive-bitrate`), no-op when adaptive is off or EGFX never left the ceiling.