### PR TITLE
fix(udp): de-migrate EGFX to TCP on minimize/restore so the surface unfreezes

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1035,6 +1035,12 @@ mod macos {
                     let resume_keyframe = if self.was_suppressed {
                         self.was_suppressed = false;
                         tracing::debug!("client un-suppress edge — forcing IDR on next encode");
+                        // If EGFX is on the reliable UDP tunnel, mstsc's surface
+                        // won't survive the minimize/restore — switch back to TCP
+                        // BEFORE shipping the restore frame into the now-stale
+                        // tunnel (no-op on TCP/lossy/default; see
+                        // `Gfx::demigrate_on_resume`).
+                        gfx.demigrate_on_resume();
                         true
                     } else {
                         false

--- a/src/h264.rs
+++ b/src/h264.rs
@@ -722,6 +722,47 @@ impl Gfx {
         }
     }
 
+    /// Proactively de-migrate EGFX off the reliable UDP tunnel back onto TCP when
+    /// the client comes out of a minimize (SuppressOutput → restore).
+    ///
+    /// Once the EGFX channel has been Soft-Sync-migrated onto the reliable UDP
+    /// tunnel, mstsc's surface does NOT survive a minimize/restore: on restore the
+    /// picture freezes and the watchdog's *reactive* de-migrate (3–6 s later, after
+    /// we've already shipped frames into the now-stale tunnel) is too late to heal
+    /// it — recovery needs a fresh mstsc. The fix is to switch the transport back to
+    /// TCP on the un-suppress edge, BEFORE shipping a single frame back into the
+    /// post-minimize tunnel, so the forced restore-IDR lands over TCP (which mstsc
+    /// renders cleanly across minimize, exactly like an EGFX-on-TCP-from-start
+    /// session). One-way per connection (the `demigrated` latch), and a no-op unless
+    /// EGFX is currently on the reliable UDP tunnel → the TCP/default path and the
+    /// lossy path are byte-unchanged.
+    pub fn demigrate_on_resume(&self) {
+        let on_reliable_udp =
+            self.egfx_on_udp.load(Ordering::Relaxed) && !self.egfx_on_lossy.load(Ordering::Relaxed);
+        if !on_reliable_udp {
+            return; // not on the reliable UDP tunnel → nothing to switch
+        }
+        let mut guard = self.ctx.lock().unwrap();
+        let Some(ctx) = guard.as_mut() else {
+            return;
+        };
+        if ctx.demigrated {
+            return; // already on TCP for this session
+        }
+        ctx.need_keyframe = true;
+        ctx.last_acked_frame_id.store(
+            ctx.last_shipped_frame_id.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+        ctx.demigrated = true;
+        self.demigrate_request.store(true, Ordering::Relaxed);
+        warn!(
+            "client resumed from minimize while EGFX was on the reliable UDP tunnel — \
+             proactively de-migrating to TCP (one-way for this session) so the restore \
+             IDR lands over TCP instead of a stale tunnel"
+        );
+    }
+
     /// Feed one full-frame BGRA buffer. Never blocks on the encoder.
     ///
     /// `request_keyframe` asks for the next encoded frame to be a forced IDR —


### PR DESCRIPTION
## Problem

With `--udp-migrate-egfx`, **minimizing the mstsc window then restoring it leaves the video frozen** until a full disconnect + reconnect to a fresh mstsc (audio, on TCP, resumes fine). An EGFX-on-TCP-from-start session handles minimize/restore cleanly, so the freeze is specific to the Soft-Sync-migrated UDP path.

## Root cause

The watchdog already de-migrates a wedged tunnel back to TCP, but only **reactively** — 3–6 s after restore (confirmed in the log: `since_ack_ms=6641`), *after* we've already shipped the restore frames into the now-stale post-minimize UDP tunnel. By then mstsc's surface is wedged and switching the transport is too late to heal it.

## Fix

On the un-suppress (restore) edge, if EGFX is currently on the reliable UDP tunnel, **proactively de-migrate to TCP before shipping a single frame back into the tunnel**, so the forced restore-IDR lands over TCP — which mstsc renders across minimize exactly like an EGFX-on-TCP-from-start session.

- New `Gfx::demigrate_on_resume()` mirrors the watchdog's de-migrate steps (force IDR + reset lag baseline + set the demigrate latch/request), gated to `egfx_on_udp && !egfx_on_lossy` and the one-way `demigrated` latch.
- `capture.rs` calls it from the existing `was_suppressed` resume edge.
- No-op on the TCP/default and lossy paths (byte-unchanged). One-way per session (a reconnect starts fresh on UDP).

## Verification

Verified live on real mstsc (Win11/WiFi, `--udp-migrate-egfx`, `--bitrate 6`, `--adaptive-bitrate`): connect → video over UDP → minimize → restore → **video comes back** (previously frozen-until-reconnect). Log shows the proactive de-migrate firing exactly on the restore edge:

```
client resumed from minimize while EGFX was on the reliable UDP tunnel — proactively de-migrating to TCP (one-way for this session) so the restore IDR lands over TCP instead of a stale tunnel
```

`cargo build --release` / `clippy --all-targets` / `fmt --check` clean.