### PR TITLE
feat(reliability): bounded log rotation + startup reaper

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,31 @@ src/multitransport.rs  macrdp-side RDP UDP multitransport provider
                   cookie-registry + Initiate-Request tests live here (the vendored
                   crates are test=false). See docs/rdp-udp-multitransport-
                   feasibility.md.
+src/logging.rs    Tracing sink + size-based log rotation. By default stdout
+                  (interactive). When headless (stdout not a TTY, e.g. under the
+                  LaunchAgent) or given --log-dir/LOG_DIR, writes a self-owned,
+                  size-bounded rotating file at ~/Library/Logs/macrdp.log — stable
+                  live name (the GUI reads it + scans for "panicked") rotating
+                  logrotate-style to macrdp.log.1..N (MACRDP_LOG_MAX_BYTES /
+                  MACRDP_LOG_MAX_FILES). Custom (not tracing-appender, which only
+                  does dated files; non_blocking was reverted) BLOCKING writer via
+                  a MakeWriter over Arc<Mutex<Rotator>>. On the file path it also
+                  installs a panic hook that routes panics through tracing into
+                  macrdp.log (observability only — cleanup is the reaper's job).
+                  The plist drops StandardOutPath (the binary owns the file) and
+                  points StandardErrorPath at a small macrdp.err.log.
+src/reaper.rs     Startup reaper — on launch, sweeps leftovers from a PRIOR macrdp
+                  that died uncleanly (SIGKILL/panic/power-loss skip Drop AND the
+                  signal handler): stale NFS mounts + $TMPDIR/macrdp-rdpdr-<pid>/
+                  and macrdp-{paste,lazy-paste}-<pid>-* dirs. Holds the shared,
+                  platform-independent primitives (process_is_alive via
+                  libc::kill(pid,0)→ESRCH; pid_from_tagged; for_each_stale);
+                  per-module reap_stale fns live next to each module's
+                  shutdown_cleanup (rdpdr/surface.rs, file_promise*.rs). Only
+                  DEAD-pid, non-self dirs are reaped, so it's safe with another
+                  instance live. Called once from async_main on a detached thread
+                  (a stale umount can't block startup); covers single-process,
+                  the fork supervisor, and each worker.
 build.rs          Bakes Xcode Swift-runtime rpath into the final binary
 
 vendor/ironrdp-server/    Local fork of ironrdp-server 0.10.0, pulled in via

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,6 +171,15 @@ Useful CLI flags (see `src/main.rs::Args` for the full set):
                           #   nicety, while --fork-workers fixes the real mstsc pain).
                           #   macOS-only. See the H.264 reconnect-blank quirk note.
 --cert-dir PATH           # default ~/Library/Application Support/macrdp
+--log-dir PATH            # Directory for the rotating log file (macrdp.log). If
+                          #   unset: a rotating file in ~/Library/Logs when running
+                          #   HEADLESS (stdout is not a TTY, e.g. under the
+                          #   LaunchAgent), or stdout when interactive (cargo run).
+                          #   The file is size-bounded — keeps macrdp.log + N
+                          #   logrotate-style archives (macrdp.log.1, .2, …),
+                          #   dropping the oldest. Tunables: MACRDP_LOG_MAX_BYTES
+                          #   (default 10 MiB), MACRDP_LOG_MAX_FILES (default 5).
+                          #   Config key: LOG_DIR.
 ```
 
 Testing against the server:

--- a/docs/production-readiness-roadmap.md
+++ b/docs/production-readiness-roadmap.md
@@ -41,11 +41,20 @@ are scope limits, not gaps to close.
    drift* item, and documented SCStream / NFS-mount leaks on hard kill (`SIGKILL` skips
    `Drop`). Run a 48–72 h soak (idle + active, with reconnect cycles) and fix what it
    surfaces.
-5. **Robust teardown + log rotation.** Ensure `SIGKILL`/panic never leaks a mount or
-   capture stream (audit the `shutdown_cleanup` / process-global handle paths); rotate
-   `~/Library/Logs/macrdp.log` so it can't grow unbounded. Add a lightweight
-   **health-check** that detects a hung-but-alive process and bounces it (LaunchAgent
-   `KeepAlive` already restarts on outright crash).
+5. **Robust teardown + log rotation.** *(log rotation + startup reaper SHIPPED 2026-06-30.)*
+   - **Log rotation — DONE.** `~/Library/Logs/macrdp.log` is now a self-owned, size-bounded
+     rotating file (`src/logging.rs`: `macrdp.log` + N logrotate-style archives, default
+     10 MiB × 5; tunable via `MACRDP_LOG_MAX_BYTES`/`MACRDP_LOG_MAX_FILES`). The plist no
+     longer redirects stdout there (panics → a small `macrdp.err.log`; a panic hook also
+     routes panics into `macrdp.log` so the GUI still detects crashes).
+   - **Startup reaper — DONE.** The graceful `SIGTERM`/`SIGINT` path already unmounts + cleans;
+     the remaining leak was `SIGKILL`/panic (uncatchable in-process). `src/reaper.rs` now sweeps
+     a *dead* prior process's leftovers on the next start (stale NFS mounts +
+     `$TMPDIR/macrdp-{rdpdr,paste,lazy-paste}-<pid>` dirs), dead-pid-gated so it's safe with
+     another instance live. (SCStreams / virtual display / blanking were already process-scoped
+     and auto-restore.)
+   - **Still TODO:** a lightweight **health-check** that detects a hung-but-alive process and
+     bounces it (LaunchAgent `KeepAlive` already restarts on outright crash, but not on a hang).
 6. **Make `--fork-workers` the production default.** It's what fixes the mstsc
    reconnect-blank that bites real users; recommend (or default) it for unattended
    deployments. Note it's mutually exclusive with `--enable-udp-multitransport`.

--- a/gui/Sources/macrdptray/main.swift
+++ b/gui/Sources/macrdptray/main.swift
@@ -31,6 +31,9 @@ final class AppController: NSObject, NSApplicationDelegate, NSMenuDelegate {
     var home: URL { FileManager.default.homeDirectoryForCurrentUser }
     var configURL: URL { home.appendingPathComponent("Library/Application Support/macrdp/config.env") }
     var logURL: URL { home.appendingPathComponent("Library/Logs/macrdp.log") }
+    // The server owns + rotates macrdp.log itself; stderr (panics, pre-logging
+    // startup errors) goes to a small separate file.
+    var errLogURL: URL { home.appendingPathComponent("Library/Logs/macrdp.err.log") }
     var plistURL: URL { home.appendingPathComponent("Library/LaunchAgents/\(label).plist") }
 
     var timer: Timer?
@@ -481,8 +484,10 @@ final class AppController: NSObject, NSApplicationDelegate, NSMenuDelegate {
             "ProgramArguments": [bin, "--config", configURL.path],
             "RunAtLoad": true,
             "KeepAlive": true,
-            "StandardOutPath": logURL.path,
-            "StandardErrorPath": logURL.path,
+            // No StandardOutPath: the server writes + rotates macrdp.log itself
+            // (a second writer would corrupt it / strand launchd on a rotated
+            // inode). StandardErrorPath keeps panics + pre-logging stderr.
+            "StandardErrorPath": errLogURL.path,
             "EnvironmentVariables": ["RUST_LOG": "info"],
         ]
         let fm = FileManager.default

--- a/packaging/launchagent.plist.template
+++ b/packaging/launchagent.plist.template
@@ -9,7 +9,11 @@
   Background Task Management identifies the agent by its stable Developer-ID
   identity (approve once, survives rebuilds) rather than re-flagging an unsigned
   wrapper script on every update. The binary reads config.env itself. Keeps the
-  job alive, and logs to ~/Library/Logs/macrdp.log.
+  job alive. The binary owns ~/Library/Logs/macrdp.log itself now (a self-rotating,
+  size-bounded file — see src/logging.rs), so there is NO StandardOutPath redirect:
+  having launchd ALSO write that path would corrupt the file and strand launchd on a
+  rotated-away inode. StandardErrorPath still captures panics + pre-logging stderr in
+  a small separate macrdp.err.log.
 -->
 <plist version="1.0">
 <dict>
@@ -31,10 +35,10 @@
     <key>KeepAlive</key>
     <true/>
 
-    <key>StandardOutPath</key>
-    <string>__HOME__/Library/Logs/macrdp.log</string>
+    <!-- No StandardOutPath: the binary writes (and rotates) macrdp.log itself.
+         StandardErrorPath keeps panics + pre-logging-init stderr in a small file. -->
     <key>StandardErrorPath</key>
-    <string>__HOME__/Library/Logs/macrdp.log</string>
+    <string>__HOME__/Library/Logs/macrdp.err.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>

--- a/src/file_promise.rs
+++ b/src/file_promise.rs
@@ -362,6 +362,24 @@ fn make_temp_dir() -> std::io::Result<PathBuf> {
     Ok(dir)
 }
 
+/// Reap eager-paste temp dirs (`$TMPDIR/macrdp-paste-<pid>-<nanos>`) left by a
+/// PRIOR macrdp process that died uncleanly (SIGKILL/panic skip the backend's
+/// Drop + the signal handler's cleanup). Dead-pid-gated, never our own, so it's
+/// safe with another instance live. Best-effort; called once at startup.
+pub fn reap_stale() {
+    crate::reaper::for_each_stale(
+        &std::env::temp_dir(),
+        "macrdp-paste-",
+        false,
+        std::process::id() as i32,
+        &crate::reaper::process_is_alive,
+        &mut |dir| {
+            let _ = std::fs::remove_dir_all(dir);
+            debug!(stale_dir = ?dir, "eager paste: reaped temp dir from a dead prior macrdp process");
+        },
+    );
+}
+
 fn publish_to_pasteboard(paths: &[PathBuf], self_change_count: &SelfChangeCount) {
     if paths.is_empty() {
         return;

--- a/src/file_promise_lazy.rs
+++ b/src/file_promise_lazy.rs
@@ -586,6 +586,24 @@ fn make_temp_dir() -> std::io::Result<PathBuf> {
     Ok(dir)
 }
 
+/// Reap lazy-paste temp dirs (`$TMPDIR/macrdp-lazy-paste-<pid>-<nanos>`) left by
+/// a PRIOR macrdp process that died uncleanly (SIGKILL/panic skip the backend's
+/// Drop + the signal handler's [`shutdown_cleanup`]). Dead-pid-gated, never our
+/// own, so it's safe with another instance live. Best-effort; called at startup.
+pub fn reap_stale() {
+    crate::reaper::for_each_stale(
+        &std::env::temp_dir(),
+        "macrdp-lazy-paste-",
+        false,
+        std::process::id() as i32,
+        &crate::reaper::process_is_alive,
+        &mut |dir| {
+            let _ = std::fs::remove_dir_all(dir);
+            debug!(stale_dir = ?dir, "lazy paste: reaped temp dir from a dead prior macrdp process");
+        },
+    );
+}
+
 fn publish_to_pasteboard(urls: &[SendRetained<NSURL>], self_change_count: &SelfChangeCount) {
     if urls.is_empty() {
         return;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,309 @@
+//! Tracing sink + size-based log rotation.
+//!
+//! By default macrdp writes tracing to **stdout** (great for `cargo run`). Under
+//! the LaunchAgent there is no terminal, so we instead write to a **self-owned,
+//! size-bounded rotating file** at `~/Library/Logs/macrdp.log` — without it the
+//! launchd-redirected log grew unbounded. The live file keeps the **stable name**
+//! `macrdp.log` (the GUI controller reads that exact path and detects crashes by
+//! the substring `"panicked"`), rotating logrotate-style to `macrdp.log.1`, `.2`,
+//! … up to `max_files`, dropping the oldest.
+//!
+//! Why a custom rotator and not `tracing-appender`: its `RollingFileAppender`
+//! only does **time/date-suffixed** files (`macrdp.log.2026-06-30`), which breaks
+//! the stable-name contract above, and its `non_blocking` writer was tried for
+//! macrdp before and reverted. This writer is **blocking** and **size-based**.
+//!
+//! Sink selection (see [`init`]): an explicit `--log-dir` always wins; otherwise
+//! we log to a file when stdout is **not** a TTY (the headless/launchd case) and
+//! to stdout when it is (interactive). On the file path we also install a panic
+//! hook so Rust's panic message lands in `macrdp.log` (preserving the GUI's crash
+//! detection now that stderr no longer goes to that file).
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::EnvFilter;
+
+/// The stable live-log filename. Archives are `macrdp.log.1`, `.2`, …
+const BASE: &str = "macrdp.log";
+
+const DEFAULT_MAX_BYTES: u64 = 10 * 1024 * 1024; // 10 MiB
+const DEFAULT_MAX_FILES: usize = 5;
+
+/// Initialize the global tracing subscriber.
+///
+/// `filter` is the already-resolved [`EnvFilter`]. `log_dir_override` is the
+/// `--log-dir` / `LOG_DIR` value, if any. Resolution:
+/// - `Some(dir)` → rotating file in `dir` (explicit override, even interactively).
+/// - else stdout-is-a-TTY → stdout (interactive / `cargo run`).
+/// - else → rotating file in `~/Library/Logs` (headless under launchd).
+///
+/// Any failure to set up the file sink falls back to stdout with an `eprintln!`
+/// note (which, under launchd, lands in `StandardErrorPath` = `macrdp.err.log`).
+pub fn init(filter: EnvFilter, log_dir_override: Option<&Path>) {
+    let dir = match log_dir_override {
+        Some(d) => Some(d.to_path_buf()),
+        None => {
+            if std::io::stdout().is_terminal() {
+                None
+            } else {
+                default_log_dir()
+            }
+        }
+    };
+
+    let Some(dir) = dir else {
+        // Interactive / no HOME: plain stdout, ANSI on. Unchanged dev behavior.
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+        return;
+    };
+
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("macrdp: cannot create log dir {dir:?}: {e}; logging to stdout");
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+        return;
+    }
+
+    let writer = match RotatingWriter::new(&dir) {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("macrdp: cannot open log file in {dir:?}: {e}; logging to stdout");
+            tracing_subscriber::fmt().with_env_filter(filter).init();
+            return;
+        }
+    };
+
+    tracing_subscriber::fmt()
+        .with_writer(writer)
+        .with_ansi(false)
+        .with_env_filter(filter)
+        .init();
+    install_panic_hook();
+    tracing::info!(dir = ?dir, "logging to rotating file ({BASE})");
+}
+
+/// `~/Library/Logs` (mirrors `main::default_cert_dir`'s HOME resolution).
+fn default_log_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join("Library/Logs"))
+}
+
+/// Route Rust panics through tracing so the message reaches `macrdp.log` (its
+/// `Display` contains `"panicked at"`, which the GUI scans for), then chain the
+/// previous hook. **Observability only** — does NOT run cleanup (a panicking
+/// tokio task unwinds without killing the process; teardown is the startup
+/// reaper's job, see `crate::reaper`).
+fn install_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        tracing::error!("{info}");
+        prev(info);
+    }));
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(default)
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    // 0 is a legal value here (no archives kept), so don't filter it out.
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+/// The rotating file behind a mutex. Tracking `written` in-memory avoids a
+/// `stat` per event. **The rotation/write code must never emit a tracing event**
+/// (`std::sync::Mutex` is non-reentrant) — errors are reported via `eprintln!`.
+struct Rotator {
+    dir: PathBuf,
+    file: File,
+    written: u64,
+    max_bytes: u64,
+    max_files: usize,
+}
+
+impl Rotator {
+    fn open(dir: PathBuf, max_bytes: u64, max_files: usize) -> io::Result<Self> {
+        let path = dir.join(BASE);
+        // Append + seed the counter from the existing length so a KeepAlive
+        // restart continues the same file instead of truncating it.
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let written = file.metadata().map(|m| m.len()).unwrap_or(0);
+        Ok(Self {
+            dir,
+            file,
+            written,
+            max_bytes,
+            max_files,
+        })
+    }
+
+    /// `macrdp.log → .1 → .2 → … → .max_files` (oldest dropped), then reopen a
+    /// fresh empty `macrdp.log`. `rename` replaces the destination atomically on
+    /// unix, so the cascade alone drops the oldest.
+    fn rotate(&mut self) -> io::Result<()> {
+        self.file.flush()?;
+        let base = self.dir.join(BASE);
+        for n in (1..self.max_files).rev() {
+            let from = self.dir.join(format!("{BASE}.{n}"));
+            if from.exists() {
+                std::fs::rename(&from, self.dir.join(format!("{BASE}.{}", n + 1)))?;
+            }
+        }
+        if self.max_files >= 1 {
+            std::fs::rename(&base, self.dir.join(format!("{BASE}.1")))?;
+        } else {
+            std::fs::remove_file(&base)?;
+        }
+        self.file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&base)?;
+        self.written = 0;
+        Ok(())
+    }
+}
+
+impl Write for Rotator {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Rotate before an event that would push us over the cap (but never on an
+        // empty file — an oversized single event then writes whole, one big file,
+        // rather than looping forever).
+        if self.written > 0 && self.written + buf.len() as u64 > self.max_bytes {
+            if let Err(e) = self.rotate() {
+                // Best-effort: keep writing to the current file rather than drop
+                // logs. eprintln lands in macrdp.err.log under launchd.
+                eprintln!("macrdp: log rotation failed: {e}");
+            }
+        }
+        let n = self.file.write(buf)?;
+        self.written += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()
+    }
+}
+
+/// `MakeWriter` handle. Cloneable + `'static` so the fmt subscriber can own it.
+#[derive(Clone)]
+pub struct RotatingWriter(Arc<Mutex<Rotator>>);
+
+impl RotatingWriter {
+    /// Open `dir/macrdp.log` (append), reading `MACRDP_LOG_MAX_BYTES`
+    /// (default 10 MiB) and `MACRDP_LOG_MAX_FILES` (default 5).
+    pub fn new(dir: &Path) -> io::Result<Self> {
+        let max_bytes = env_u64("MACRDP_LOG_MAX_BYTES", DEFAULT_MAX_BYTES);
+        let max_files = env_usize("MACRDP_LOG_MAX_FILES", DEFAULT_MAX_FILES);
+        let rot = Rotator::open(dir.to_path_buf(), max_bytes, max_files)?;
+        Ok(Self(Arc::new(Mutex::new(rot))))
+    }
+}
+
+/// Per-event guard: a bare `MutexGuard` doesn't impl `io::Write`, so wrap it.
+pub struct LockedRotator<'a>(MutexGuard<'a, Rotator>);
+
+impl Write for LockedRotator<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<'a> MakeWriter<'a> for RotatingWriter {
+    type Writer = LockedRotator<'a>;
+    fn make_writer(&'a self) -> Self::Writer {
+        // Recover from a poisoned lock (a panic while logging) rather than
+        // panicking again — keep logging alive.
+        LockedRotator(self.0.lock().unwrap_or_else(|e| e.into_inner()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_dir(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "macrdp-logtest-{tag}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn rotates_at_threshold() {
+        let dir = unique_dir("rotate");
+        let mut r = Rotator::open(dir.clone(), 100, 5).unwrap();
+        // Two ~80-byte writes: the first fits, the second crosses 100 → rotates.
+        r.write_all(&[b'a'; 80]).unwrap();
+        assert!(!dir.join("macrdp.log.1").exists());
+        r.write_all(&[b'b'; 80]).unwrap();
+        r.flush().unwrap();
+        assert!(dir.join("macrdp.log.1").exists(), "archive should exist");
+        // The live file now holds only the second write.
+        let live = std::fs::read(dir.join("macrdp.log")).unwrap();
+        assert_eq!(live.len(), 80);
+        assert_eq!(live[0], b'b');
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn respects_max_files_cap() {
+        let dir = unique_dir("cap");
+        let max_files = 2;
+        let mut r = Rotator::open(dir.clone(), 50, max_files).unwrap();
+        // Force several rotations.
+        for _ in 0..6 {
+            r.write_all(&[b'x'; 60]).unwrap();
+        }
+        r.flush().unwrap();
+        assert!(dir.join("macrdp.log").exists());
+        assert!(dir.join("macrdp.log.1").exists());
+        assert!(dir.join("macrdp.log.2").exists());
+        assert!(
+            !dir.join(format!("macrdp.log.{}", max_files + 1)).exists(),
+            "must not keep more than max_files archives"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn appends_and_seeds_counter_on_open() {
+        let dir = unique_dir("seed");
+        std::fs::write(dir.join("macrdp.log"), b"preexisting-content").unwrap();
+        let r = Rotator::open(dir.clone(), 1024, 5).unwrap();
+        assert_eq!(r.written, "preexisting-content".len() as u64);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn env_parsing_falls_back_to_defaults() {
+        // Absent / unset → defaults (these env vars are not set in the test env).
+        assert_eq!(
+            env_u64("MACRDP_LOG_MAX_BYTES_NOPE", DEFAULT_MAX_BYTES),
+            DEFAULT_MAX_BYTES
+        );
+        assert_eq!(
+            env_usize("MACRDP_LOG_MAX_FILES_NOPE", DEFAULT_MAX_FILES),
+            DEFAULT_MAX_FILES
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,10 @@ mod file_promise_lazy;
 mod h264;
 mod input;
 mod keyboard_layout;
+mod logging;
 mod multitransport;
 mod rdpdr;
+mod reaper;
 #[cfg(target_os = "macos")]
 mod runloop_thread;
 mod switcher_hud;
@@ -233,6 +235,13 @@ struct Args {
     /// Defaults to ~/Library/Application Support/macrdp.
     #[arg(long)]
     cert_dir: Option<PathBuf>,
+
+    /// Directory for the rotating log file (`macrdp.log`, size-bounded via
+    /// MACRDP_LOG_MAX_BYTES / MACRDP_LOG_MAX_FILES). If unset, logs go to a
+    /// rotating file in ~/Library/Logs when running headless (stdout is not a
+    /// TTY, e.g. under the LaunchAgent) and to stdout when interactive.
+    #[arg(long)]
+    log_dir: Option<PathBuf>,
 
     /// Show debug-level logs from macrdp and the underlying ironrdp / rustls
     /// crates. Without this, known-noisy lines (TLS SNI warnings, the
@@ -1454,6 +1463,12 @@ fn args_from_config(path: &Path) -> Result<Args> {
             argv.push(layout.clone());
         }
     }
+    if let Some(dir) = cfg.get("LOG_DIR") {
+        if !dir.is_empty() {
+            argv.push("--log-dir".into());
+            argv.push(dir.clone());
+        }
+    }
     // EXTRA_FLAGS: space-separated escape hatch, appended verbatim.
     if let Some(extra) = cfg.get("EXTRA_FLAGS") {
         for tok in extra.split_whitespace() {
@@ -1492,7 +1507,20 @@ async fn async_main() -> Result<()> {
             "info,rustls=error,ironrdp_server::encoder=error,ironrdp_server::server=error",
         )
     };
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    logging::init(filter, args.log_dir.as_deref());
+
+    // Sweep leftovers from a PRIOR macrdp that died uncleanly (SIGKILL / panic /
+    // power-loss skip Drop AND the signal handler, stranding NFS mounts + paste
+    // temp dirs). Dead-pid-gated so it's safe with another instance live; on a
+    // detached thread so a stale `umount` can never delay startup. Runs in every
+    // role (single-process, supervisor, each forked worker re-enters async_main —
+    // workers are serialized, so reaping a prior dead worker is safe too).
+    #[cfg(target_os = "macos")]
+    std::thread::spawn(|| {
+        rdpdr::reap_stale();
+        file_promise::reap_stale();
+        file_promise_lazy::reap_stale();
+    });
 
     // --fork-workers PoC. A process is a *worker* iff the supervisor set
     // MACRDP_WORKER_FD (the already-accepted client socket); that takes

--- a/src/rdpdr/mod.rs
+++ b/src/rdpdr/mod.rs
@@ -28,6 +28,16 @@ pub fn shutdown_cleanup() {
     surface::shutdown_cleanup();
 }
 
+/// Reap RDPDR NFS-mount leftovers from a PRIOR macrdp process that died
+/// uncleanly (SIGKILL/panic skip both `Surface::Drop` and [`shutdown_cleanup`],
+/// stranding a stale mount + its `$TMPDIR/macrdp-rdpdr-<pid>` mountpoint dir).
+/// Called once at startup; dead-pid-gated and best-effort. No-op off macOS / when
+/// nothing was left behind. See `surface::reap_stale` and `crate::reaper`.
+pub fn reap_stale() {
+    #[cfg(target_os = "macos")]
+    surface::reap_stale();
+}
+
 /// Map a client-returned [`NtStatus`] to the closest NFS status.
 ///
 /// Extracted as a pure fn (no platform deps) so it's unit-tested on every

--- a/src/rdpdr/surface.rs
+++ b/src/rdpdr/surface.rs
@@ -717,6 +717,38 @@ pub fn shutdown_cleanup() {
     }
 }
 
+/// Reap mount leftovers from a PRIOR macrdp process that died uncleanly. A
+/// SIGKILL/panic skips both `Surface::Drop` and [`shutdown_cleanup`], so its
+/// `$TMPDIR/macrdp-rdpdr-<pid>/<label>` mountpoint(s) — and the stale NFS mounts
+/// pointing at its now-dead server — survive. We `umount -f` each child
+/// mountpoint (reusing [`unmount_at`]) and remove the per-pid dir. Only dirs
+/// tagged with a DEAD pid (never our own) are touched, so this is safe to run
+/// while another macrdp instance is live. Best-effort; called once at startup
+/// off the async runtime. `/Volumes/<label>` mounts (the un-tagged primary
+/// location) are NOT reaped — they only occur when running as root, and there's
+/// no pid to gate on.
+pub fn reap_stale() {
+    crate::reaper::for_each_stale(
+        &std::env::temp_dir(),
+        "macrdp-rdpdr-",
+        true,
+        std::process::id() as i32,
+        &crate::reaper::process_is_alive,
+        &mut |dir| {
+            if let Ok(children) = std::fs::read_dir(dir) {
+                for child in children.flatten() {
+                    let mp = child.path();
+                    if mp.is_dir() {
+                        unmount_at(&mp);
+                    }
+                }
+            }
+            let _ = std::fs::remove_dir_all(dir);
+            info!(stale_dir = ?dir, "rdpdr nfs: reaped mount dir from a dead prior macrdp process");
+        },
+    );
+}
+
 /// Mount the loopback NFS export at `mountpoint`. Read-write, NFSv3 over TCP.
 /// Verified to need no root for a `localhost` mount onto a user-owned dir.
 ///

--- a/src/reaper.rs
+++ b/src/reaper.rs
@@ -1,0 +1,171 @@
+//! Startup reaper — sweep leftovers from a PRIOR macrdp process that died
+//! uncleanly.
+//!
+//! The graceful SIGINT/SIGTERM path (`main`'s signal handler →
+//! `file_promise_lazy::shutdown_cleanup` + `rdpdr::shutdown_cleanup`) already
+//! unmounts NFS volumes and removes paste temp dirs. But **SIGKILL / panic /
+//! power-loss skip all of it**, stranding:
+//!   - RDPDR NFS mounts + `$TMPDIR/macrdp-rdpdr-<pid>/<label>` mountpoints,
+//!   - eager-paste `$TMPDIR/macrdp-paste-<pid>-<nanos>` dirs,
+//!   - lazy-paste `$TMPDIR/macrdp-lazy-paste-<pid>-<nanos>` dirs.
+//!
+//! These are all named with the owning **pid** and live under
+//! `std::env::temp_dir()` (= `$TMPDIR`, stable across relaunches for a user), so
+//! a fresh start can find and reap them. The per-module reapers live next to
+//! each module's `shutdown_cleanup` (so each owns its own path scheme); this
+//! module holds the shared, platform-independent primitives.
+//!
+//! **Safety:** a path is only reaped when its embedded pid is **dead** (and never
+//! our own pid). A reused pid reads as alive → we skip (a harmless leftover, not
+//! a wrong delete), so the reaper is safe to run while another macrdp instance
+//! is live.
+
+use std::path::Path;
+
+/// True if a process with `pid` currently exists.
+///
+/// `kill(pid, 0)` does the permission/existence check without sending a signal:
+/// `0` = exists (ours), `EPERM` = exists (not ours → still alive), `ESRCH` = no
+/// such process (dead). Only `ESRCH` means "reap"; everything else is treated as
+/// alive (conservative — we never want a false "dead").
+#[cfg(unix)]
+pub fn process_is_alive(pid: i32) -> bool {
+    if pid <= 0 {
+        return true; // never reap on a nonsense pid
+    }
+    // SAFETY: signal 0 performs error checking only; no signal is delivered.
+    if unsafe { libc::kill(pid as libc::pid_t, 0) } == 0 {
+        return true;
+    }
+    !matches!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ESRCH)
+    )
+}
+
+#[cfg(not(unix))]
+pub fn process_is_alive(_pid: i32) -> bool {
+    true
+}
+
+/// Parse the owning pid out of a macrdp temp-dir name.
+///
+/// `pid_is_last` distinguishes the two schemes:
+/// - RDPDR `macrdp-rdpdr-<pid>` → `true` (pid is the whole remainder),
+/// - paste `macrdp-{paste,lazy-paste}-<pid>-<nanos>` → `false` (pid is the first
+///   `-`-separated field of the remainder).
+///
+/// Prefixes are distinct (`macrdp-paste-` is not a prefix of
+/// `macrdp-lazy-paste-`), so a `strip_prefix` match never cross-classifies.
+pub fn pid_from_tagged(name: &str, prefix: &str, pid_is_last: bool) -> Option<i32> {
+    let rest = name.strip_prefix(prefix)?;
+    let pid_str = if pid_is_last {
+        rest
+    } else {
+        rest.split('-').next()?
+    };
+    pid_str.parse::<i32>().ok().filter(|&p| p > 0)
+}
+
+/// For each immediate child of `base` whose name is `<prefix><pid>…` for a
+/// **dead** pid other than `self_pid`, invoke `action(path)`.
+///
+/// `is_alive` is injected for testability; production callers pass
+/// [`process_is_alive`]. Best-effort: an unreadable `base` is silently skipped.
+pub fn for_each_stale(
+    base: &Path,
+    prefix: &str,
+    pid_is_last: bool,
+    self_pid: i32,
+    is_alive: &dyn Fn(i32) -> bool,
+    action: &mut dyn FnMut(&Path),
+) {
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(pid) = pid_from_tagged(name, prefix, pid_is_last) else {
+            continue;
+        };
+        if pid == self_pid || is_alive(pid) {
+            continue;
+        }
+        action(&entry.path());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn unique_base(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "macrdp-reaptest-{tag}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn pid_from_tagged_parses_both_schemes() {
+        assert_eq!(
+            pid_from_tagged("macrdp-rdpdr-1234", "macrdp-rdpdr-", true),
+            Some(1234)
+        );
+        assert_eq!(
+            pid_from_tagged("macrdp-paste-1234-99", "macrdp-paste-", false),
+            Some(1234)
+        );
+        assert_eq!(
+            pid_from_tagged("macrdp-lazy-paste-1234-99", "macrdp-lazy-paste-", false),
+            Some(1234)
+        );
+        // Cross-classification guard: a lazy dir must not match the eager prefix
+        // with pid_is_last semantics (and even if it did, "lazy" doesn't parse).
+        assert_eq!(
+            pid_from_tagged("macrdp-lazy-paste-1234-99", "macrdp-paste-", false),
+            None
+        );
+        // Garbage / wrong prefix / nonpositive pid.
+        assert_eq!(
+            pid_from_tagged("macrdp-rdpdr-abc", "macrdp-rdpdr-", true),
+            None
+        );
+        assert_eq!(
+            pid_from_tagged("something-else", "macrdp-rdpdr-", true),
+            None
+        );
+        assert_eq!(
+            pid_from_tagged("macrdp-rdpdr-0", "macrdp-rdpdr-", true),
+            None
+        );
+    }
+
+    #[test]
+    fn for_each_stale_only_actions_dead_non_self_dirs() {
+        let base = unique_base("stale");
+        // dead pid 100, alive pid 200, self pid 300.
+        for tag in [
+            "macrdp-paste-100-1",
+            "macrdp-paste-200-2",
+            "macrdp-paste-300-3",
+        ] {
+            std::fs::create_dir_all(base.join(tag)).unwrap();
+        }
+        let is_alive = |pid: i32| pid == 200;
+        let mut reaped: Vec<String> = Vec::new();
+        for_each_stale(&base, "macrdp-paste-", false, 300, &is_alive, &mut |p| {
+            reaped.push(p.file_name().unwrap().to_string_lossy().into_owned());
+        });
+        assert_eq!(reaped, vec!["macrdp-paste-100-1".to_string()]);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}


### PR DESCRIPTION
Tier 2.5 of `docs/production-readiness-roadmap.md` — two reliability gaps for unattended operation. Neither touches the working hot paths or the already-correct graceful-exit path.

## Log rotation (`src/logging.rs`)
tracing went to stdout → launchd redirected it to `~/Library/Logs/macrdp.log` with **no rotation** (grew unbounded). The binary now owns that file: a custom **blocking, size-based** rotating writer that keeps the **stable** name `macrdp.log` (the GUI reads it + scans for `"panicked"`) and rotates logrotate-style to `macrdp.log.1..N`, dropping the oldest.
- Tunables `MACRDP_LOG_MAX_BYTES` (10 MiB) / `MACRDP_LOG_MAX_FILES` (5).
- Sink: `--log-dir`/`LOG_DIR` wins; else a file when headless (stdout not a TTY), stdout when interactive (`cargo run` unchanged).
- A panic hook routes panics through tracing into `macrdp.log` (preserves GUI crash detection).
- Custom writer because `tracing-appender` only does dated files (breaks the stable name) and its `non_blocking` was reverted previously.

## Startup reaper (`src/reaper.rs`)
The graceful SIGTERM/SIGINT path already cleans up; **SIGKILL/panic/power-loss** leak stale NFS mounts + `$TMPDIR/macrdp-{rdpdr,paste,lazy-paste}-<pid>` dirs. On launch (detached thread, before bind) we sweep a **prior DEAD** process's leftovers, gated on `libc::kill(pid,0)==ESRCH` and never our own pid → safe with another instance live. Per-module `reap_stale` fns sit next to each `shutdown_cleanup`; `reaper.rs` holds the shared platform-independent primitives.

## Plist (template + GUI installer)
Drop `StandardOutPath` (the binary owns the file now — a second writer would corrupt it / strand launchd on a rotated inode); `StandardErrorPath` → a small `macrdp.err.log`. Existing installs pick this up on the next `install-launchagent.sh` (bootout+bootstrap).

## Verification
- `cargo fmt`/`clippy -D warnings`/`test` — 114 tests (6 new), green.
- Live: reaper removed dead-pid (rdpdr/eager/lazy) dirs and **preserved** a live-pid dir; rotation capped at `macrdp.log` + N archives, no ANSI in the file.
- **Pending (verify-before-merge):** real-client run (mstsc/FreeRDP) exercising drive redirection + Win→Mac paste, confirming graceful cleanup still works and the rotating file behaves over a longer headless run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)