### PR TITLE
feat(security): connection rate-limiting + lockout + audit log (Tier 1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ v0 — daily-driver usable on a trusted LAN. **Latest release: [v0.8.19](https:/
 Short version: **a polished v0 daily-driver for trusted LANs — not an enterprise RDP server.** Use it to reach your own Mac over a network you control; don't put it on a public IP or treat it as multi-user/critical infrastructure.
 
 **What's solid (verified on real mstsc / Microsoft Remote Desktop / FreeRDP):**
-- Real auth — TLS + NLA/CredSSP against the macOS account via PAM, password from the Keychain. TLS can use a real CA / ACME / Let's Encrypt cert (`--cert`/`--key`), or the self-signed default.
+- Real auth — TLS + NLA/CredSSP against the macOS account via PAM, password from the Keychain. TLS can use a real CA / ACME / Let's Encrypt cert (`--cert`/`--key`), or the self-signed default. Per-IP connection **rate-limiting + lockout + an audit log** sit in front of the auth gate (on by default, loopback-exempt).
 - The full daily workflow — display, keyboard/mouse (incl. non-US layouts, Cmd+Tab, optional Ctrl→Cmd), clipboard text/images/files both ways, system audio, drive + smart-card redirection, headless virtual displays.
 - H.264/EGFX with **congestion-responsive rate control** — under packet loss it degrades gracefully (bitrate backs off → fps sheds at the floor → stays choppy-but-in-sync) instead of freezing, and audio can ride a loss-resilient lossy-UDP path.
 - Deployable — signed + notarized `.app`, a LaunchAgent, and a menu-bar GUI controller; TCC grants survive rebuilds.
-- Tested — 120 unit tests + a regression harness, run in CI on every push.
+- Tested — 130+ unit tests + a regression harness, run in CI on every push.
 
 **Known limitations — read before relying on it:**
-- **Trusted-LAN scope is load-bearing.** TLS now supports a real CA / ACME cert (`--cert`/`--key`) — lifting the self-signed-only caveat — but the rest isn't hardened for internet exposure or hostile networks (no auth rate-limiting/audit log yet). Even with a real cert, **put internet-facing RDP behind a VPN or an RD Gateway** — that's the production answer for any RDP server, not just this one.
+- **Trusted-LAN scope is load-bearing.** TLS supports a real CA / ACME cert (`--cert`/`--key`) and there's now per-IP connection rate-limiting + lockout + an audit log — but it still isn't hardened for full internet exposure or hostile networks. Even with all that, **put internet-facing RDP behind a VPN or an RD Gateway** — that's the production answer for any RDP server, not just this one.
 - **Single session, single user.** No multi-monitor (client-side multi-display) and no printer redirection.
 - **Some content can't be captured, by OS design** — DRM video (Netflix etc.) and password-manager vault windows render blank; macOS excludes protected content from screen capture and that can't (and shouldn't) be overridden.
 - **Synthetic input can't reach secure contexts** — the login window, lock screen, and secure-input password fields are OS-blocked.
@@ -32,7 +32,7 @@ Short version: **a polished v0 daily-driver for trusted LANs — not an enterpri
 - **The UDP multitransport / lossy-audio paths are EXPERIMENTAL** (opt-in, default OFF) — robust in testing but newer and less soaked than the TCP core, which remains the default everything rides on.
 - **It's a solo v0** built on vendored [IronRDP](https://github.com/Devolutions/IronRDP) forks — no commercial support or SLA.
 
-If your use case is "remote into my own Mac over my LAN/VPN," it's in good shape. If it's unattended production, untrusted networks, or multi-user, it isn't there yet — see [`docs/production-readiness-roadmap.md`](docs/production-readiness-roadmap.md) for what would close that gap (real TLS certs ✓ done; auth hardening + a multi-day soak still open) and what can't be (multi-user GUI sessions, on macOS).
+If your use case is "remote into my own Mac over my LAN/VPN," it's in good shape. If it's unattended production, untrusted networks, or multi-user, it isn't there yet — see [`docs/production-readiness-roadmap.md`](docs/production-readiness-roadmap.md) for what would close that gap (real TLS certs ✓ done; auth hardening ✓ done; a multi-day soak still open) and what can't be (multi-user GUI sessions, on macOS).
 
 ## Quick start
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,19 @@
 ```
 src/main.rs       CLI, TCC preflight, TLS cert mgmt, RdpServer assembly
 src/auth.rs       Startup PAM auth against the macOS account (libpam FFI)
+src/auth_guard.rs Connection-level auth hardening (Tier 1.2): per-source-IP
+                  rate-limiting + escalating auto-expiring lockout + a greppable
+                  `macrdp::audit` log, in front of the NLA/CredSSP gate. Pure,
+                  platform-independent AuthGuardCore (decide/record_outcome, time
+                  passed in for deterministic tests) + the ConnectionHandler
+                  adapter (AuthGuardHandler) for the single-process path; the
+                  --fork-workers supervisor (main.rs) drives the SAME core in its
+                  own accept loop (classifying each worker by exit code + duration).
+                  On by default, loopback-exempt, env-tunable (MACRDP_CONN_GUARD /
+                  MACRDP_GUARD_* / MACRDP_AUDIT_LOG), zero vendored divergence
+                  (reuses ironrdp-server's existing ConnectionHandler seam).
+                  Lockout is heuristic (errored/short ⇒ failure, clean long
+                  session resets) so a benign disconnect never locks anyone out.
 src/capture.rs    ScreenCaptureKit → BgrA32 BitmapUpdate, dirty-rect driven
 src/cursor.rs     NSCursor → RGBAPointer, hashed for change detection
 src/input.rs      RDP scancodes/mouse PDUs → CGEvent synthesis (US ANSI by

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -192,6 +192,30 @@ Useful CLI flags (see `src/main.rs::Args` for the full set):
                           #   Config key: LOG_DIR.
 ```
 
+Auth hardening (env-only, **on by default**). macrdp rate-limits and briefly
+(escalating) locks out source IPs that hammer the port with connection attempts,
+in front of the existing NLA/CredSSP gate, and writes a per-connection audit line.
+**Loopback (`127.0.0.1`/`::1`) is always exempt** — these only bite when `--bind`
+exposes the server to other hosts, and you can't lock yourself out locally. The
+defaults are conservative; tune or disable via env (settable through `config.env`
+— see the matching keys there — or the LaunchAgent plist `EnvironmentVariables`):
+```
+MACRDP_CONN_GUARD=1               # master switch (0/off = disable rate-limit + lockout)
+MACRDP_AUDIT_LOG=1                # connection audit log (independent of the guard)
+MACRDP_GUARD_RL_MAX=10            # max attempts per window per IP (0 = no rate-limit)
+MACRDP_GUARD_RL_WINDOW_SECS=60    # rate-limit sliding window
+MACRDP_GUARD_FAIL_THRESHOLD=5     # consecutive failures before lockout (0 = no lockout)
+MACRDP_GUARD_MIN_SESSION_SECS=10  # a connection shorter than this counts as a failure
+MACRDP_GUARD_COOLDOWN_BASE_SECS=30  # first lockout length (doubles per extra failure)
+MACRDP_GUARD_COOLDOWN_MAX_SECS=900  # lockout escalation cap (15 min)
+```
+The lockout is **heuristic** (an errored or very-short connection counts as a
+failure; a clean, long-lived session resets that IP's counter), so a single benign
+disconnect — e.g. mstsc's first-connect cert-prompt "Broken pipe" — never locks you
+out. Audit lines are tagged `macrdp::audit`:
+`grep 'macrdp::audit' ~/Library/Logs/macrdp.log` shows `event="accept|reject|disconnect"`
+with the source IP and (for rejects) the reason and retry-after.
+
 Testing against the server:
 ```bash
 # FreeRDP — easiest to script and get verbose logs from.

--- a/docs/production-readiness-roadmap.md
+++ b/docs/production-readiness-roadmap.md
@@ -28,9 +28,17 @@ are scope limits, not gaps to close.
    Support/macrdp` remains the zero-config default. (Dropping `cert.pem`/`key.pem` into
    the cert dir also still works.) Not done here: ACME auto-renewal (operator tooling's
    job — replace the file + restart) and hot reload (a cert change needs a restart).
-2. **Auth hardening.** NLA/CredSSP is already the pre-auth gate (good). Add:
-   connection **rate-limiting**, **failed-attempt backoff/lockout**, and an **auth audit
-   log** (who connected, from where, when, success/fail). Moderate effort, real value.
+2. **Auth hardening — DONE (2026-06-30).** In front of the NLA/CredSSP pre-auth gate,
+   macrdp now does per-source-IP connection **rate-limiting** + escalating auto-expiring
+   **failed-attempt lockout** + a greppable **auth audit log** (`macrdp::audit` lines:
+   who connected, from where, accept/reject/disconnect + outcome). On by default with
+   conservative tunable thresholds (env / `config.env`); **loopback is exempt** so you
+   can't self-lock. Lives in `src/auth_guard.rs` (a pure, unit-tested decision core) wired
+   through the existing `ConnectionHandler` seam (single-process) and the `--fork-workers`
+   supervisor loop — **zero vendored divergence**. The lockout is deliberately **heuristic**
+   (errored/very-short ⇒ failure; clean long session resets), so a benign disconnect never
+   locks anyone out. Not done here: precise CredSSP-failure classification (would need a
+   vendored signal — intentionally avoided).
 3. **Document the posture honestly.** Even hardened, internet-facing RDP is a bad idea
    for *any* server — the production answer is "behind a VPN or an RD Gateway." Make that
    explicit alongside Tier 1.1.
@@ -85,9 +93,10 @@ Don't chase these — they're scope limits, not bugs:
 
 If picking a starting batch, do these three:
 
-1. **Real TLS certs** (Tier 1.1) — cleanest, highest-trust, lowest-risk; natural first step.
-2. **Auth rate-limit + audit log** (Tier 1.2).
-3. **A 48–72 h soak to shake out leaks/drift** (Tier 2.4).
+1. **Real TLS certs** (Tier 1.1) — **DONE (2026-06-30).**
+2. **Auth rate-limit + lockout + audit log** (Tier 1.2) — **DONE (2026-06-30).**
+3. **A 48–72 h soak to shake out leaks/drift** (Tier 2.4) — next.
 
 That trio takes it from "daily-driver I babysit" to "I can deploy this and walk away on a
-network I control." Everything else is incremental.
+network I control." With 1.1 + 1.2 landed, the remaining high-value item is the soak (2.4);
+everything else is incremental.

--- a/packaging/config.env.example
+++ b/packaging/config.env.example
@@ -30,6 +30,22 @@ USE_KEYCHAIN=1
 # TLS_CERT="/etc/letsencrypt/live/mac.example.com/fullchain.pem"
 # TLS_KEY="/etc/letsencrypt/live/mac.example.com/privkey.pem"
 
+# Auth hardening (on by default). macrdp rate-limits and (briefly, escalating)
+# locks out source IPs that hammer the port with connection attempts, and writes
+# an audit line per connection (accept/reject/disconnect + outcome) to the log.
+# Loopback (127.0.0.1/::1) is always exempt, so you can never lock yourself out
+# locally — these only matter when BIND exposes the server to other hosts. The
+# defaults are conservative and won't bite a normal user; tune or disable only if
+# needed. Audit lines are tagged `macrdp::audit` (grep ~/Library/Logs/macrdp.log).
+# CONN_GUARD=1               # master switch (0 = disable rate-limit + lockout)
+# AUDIT_LOG=1                # connection audit log (independent of CONN_GUARD)
+# GUARD_RL_MAX=10            # max attempts per window per IP (0 = no rate-limit)
+# GUARD_RL_WINDOW_SECS=60    # rate-limit sliding window
+# GUARD_FAIL_THRESHOLD=5     # consecutive failures before lockout (0 = no lockout)
+# GUARD_MIN_SESSION_SECS=10  # a connection shorter than this counts as a failure
+# GUARD_COOLDOWN_BASE_SECS=30  # first lockout length (doubles per extra failure)
+# GUARD_COOLDOWN_MAX_SECS=900  # lockout escalation cap (15 min)
+
 # Feature toggles (1 = on, 0 = off).
 ENABLE_H264=0
 ENABLE_AAC=0

--- a/src/auth_guard.rs
+++ b/src/auth_guard.rs
@@ -1,0 +1,674 @@
+//! Connection-level auth hardening (Tier 1.2 of the production-readiness
+//! roadmap): per-source-IP **rate-limiting**, escalating auto-expiring
+//! **failed-attempt lockout**, and a greppable **auth audit log**.
+//!
+//! This sits in front of macrdp's existing NLA/CredSSP pre-auth gate. It does
+//! NOT replace authentication — it bounds how fast and how often a remote peer
+//! may *attempt* to connect, and records who connected from where.
+//!
+//! ## Design
+//! - [`AuthGuardCore`] is a **pure, platform-independent** decision core
+//!   (`IpAddr`/`Instant`/`Duration` only — no macOS deps), so it unit-tests on
+//!   Linux CI exactly like [`crate::reaper`]. It holds per-IP state and answers
+//!   two questions: [`AuthGuardCore::decide`] (accept this attempt?) and
+//!   [`AuthGuardCore::record_outcome`] (was the finished connection a success or
+//!   a failure?). Time is passed in as `now: Instant` so tests time-travel
+//!   deterministically.
+//! - [`AuthGuardHandler`] is the thin `ironrdp_server::ConnectionHandler` adapter
+//!   for the **single-process** server path. The `--fork-workers` **supervisor**
+//!   has its own accept loop (it never builds an `RdpServer`) and so drives the
+//!   same `AuthGuardCore` directly — sharing the *code*, not an *instance* (the
+//!   two run modes are mutually exclusive at runtime).
+//!
+//! ## Heuristic lockout (deliberate)
+//! `on_disconnected` only sees `Option<&anyhow::Error>`, which can't cleanly
+//! distinguish a wrong-password CredSSP failure from a benign disconnect (the
+//! documented mstsc first-connect "Broken pipe" cert prompt). Rather than carry a
+//! vendored-server signal, we classify by **outcome heuristic**: an errored OR
+//! very-short connection is a `Failure`; a clean, long-lived session is a
+//! `Success` that resets the IP's counter. This is forgiving by design — a single
+//! benign error can never reach the lockout threshold because the immediate clean
+//! reconnect resets it.
+//!
+//! ## Scope
+//! Loopback (`127.0.0.1`/`::1`, incl. IPv4-mapped) is **exempt** (the default
+//! `BIND` is `127.0.0.1:3390`, so the operator can never lock themselves out
+//! locally). The auxiliary **UDP multitransport** listener is out of scope: a UDP
+//! peer only binds *after* a full TCP+TLS+cookie-bound session already exists, so
+//! it is unreachable without first passing this guarded TCP accept.
+//!
+//! Everything is **on by default** with conservative thresholds, tunable via
+//! `MACRDP_*` env vars and fully disable-able (see [`GuardConfig::from_env`]).
+
+use std::collections::{HashMap, VecDeque};
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+/// Hard cap on distinct tracked IPs, to bound memory under a spoofed-source-IP
+/// flood. When exceeded, the entries with the oldest `last_touch` are evicted.
+const MAX_TRACKED_IPS: usize = 50_000;
+
+/// Interpret an on/off env toggle by *value*, not mere presence. `true` unless
+/// set to a falsey spelling. Mirrors `crate::multitransport::env_truthy`; kept
+/// local so this module stays self-contained and platform-independent.
+fn env_on(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => default,
+    }
+}
+
+/// Parse a `u64` env var, falling back to `default` on unset/garbage. `0` is a
+/// legal value (it disables the corresponding lever), so it is NOT filtered out.
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+/// Canonicalize an IP for keying + loopback checks: fold IPv4-mapped IPv6
+/// (`::ffff:a.b.c.d`) down to its IPv4 form so a mapped address isn't tracked
+/// under two keys and a mapped loopback is still recognized as loopback.
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(v6),
+        },
+        v4 => v4,
+    }
+}
+
+/// Resolved thresholds (read once at startup from the environment).
+#[derive(Debug, Clone, Copy)]
+pub struct GuardConfig {
+    /// Sliding window over which connection attempts are counted.
+    window: Duration,
+    /// Max attempts per `window` per IP before rate-limiting kicks in.
+    /// `0` disables rate-limiting.
+    max_attempts: usize,
+    /// Consecutive failures before the first lockout. `0` disables lockout.
+    failure_threshold: u32,
+    /// A connection shorter than this (or errored) counts as a failure; one at
+    /// least this long *and* clean counts as a success.
+    min_session: Duration,
+    /// First lockout length; doubles per failure past the threshold.
+    base_cooldown: Duration,
+    /// Cap on the escalated cooldown.
+    max_cooldown: Duration,
+}
+
+impl GuardConfig {
+    /// Resolve thresholds from `MACRDP_GUARD_*` env vars, falling back to the
+    /// conservative defaults documented in `docs/cli.md` / `config.env.example`.
+    pub fn from_env() -> Self {
+        Self {
+            window: Duration::from_secs(env_u64("MACRDP_GUARD_RL_WINDOW_SECS", 60)),
+            max_attempts: env_u64("MACRDP_GUARD_RL_MAX", 10) as usize,
+            failure_threshold: env_u64("MACRDP_GUARD_FAIL_THRESHOLD", 5) as u32,
+            min_session: Duration::from_secs(env_u64("MACRDP_GUARD_MIN_SESSION_SECS", 10)),
+            base_cooldown: Duration::from_secs(env_u64("MACRDP_GUARD_COOLDOWN_BASE_SECS", 30)),
+            max_cooldown: Duration::from_secs(env_u64("MACRDP_GUARD_COOLDOWN_MAX_SECS", 900)),
+        }
+    }
+
+    fn rate_limit_enabled(&self) -> bool {
+        self.max_attempts > 0
+    }
+
+    fn lockout_enabled(&self) -> bool {
+        self.failure_threshold > 0
+    }
+}
+
+/// Per-IP tracking state.
+#[derive(Debug)]
+struct PerIp {
+    /// Attempt timestamps within the sliding window (oldest first).
+    attempts: VecDeque<Instant>,
+    /// Consecutive failures; reset to 0 on a successful outcome.
+    consecutive_failures: u32,
+    /// Active lockout expiry, if any (auto-expires when `now >= cooldown_until`).
+    cooldown_until: Option<Instant>,
+    /// Last time this entry was touched, for stale-entry eviction.
+    last_touch: Instant,
+}
+
+impl PerIp {
+    fn new(now: Instant) -> Self {
+        Self {
+            attempts: VecDeque::new(),
+            consecutive_failures: 0,
+            cooldown_until: None,
+            last_touch: now,
+        }
+    }
+
+    /// True once this entry carries no useful state and may be evicted.
+    fn is_idle(&self, now: Instant) -> bool {
+        self.attempts.is_empty()
+            && self.consecutive_failures == 0
+            && self.cooldown_until.is_none_or(|t| now >= t)
+    }
+}
+
+/// The decision returned by [`AuthGuardCore::decide`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Allow the connection to proceed to the handshake.
+    Accept,
+    /// Reject: too many attempts within the sliding window.
+    RejectRateLimit { window_attempts: usize },
+    /// Reject: the IP is in an active lockout cooldown.
+    RejectCooldown { retry_after: Duration },
+}
+
+/// The classified result of a finished connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    Success,
+    Failure,
+}
+
+/// Pure per-IP rate-limit + lockout decision core. See the module docs.
+pub struct AuthGuardCore {
+    ips: HashMap<IpAddr, PerIp>,
+    cfg: GuardConfig,
+}
+
+impl AuthGuardCore {
+    /// Build a core from the environment, or `None` if the master switch
+    /// (`MACRDP_CONN_GUARD`) is off — callers then skip the guard entirely
+    /// (zero overhead, vendored default accept-all path).
+    pub fn from_env() -> Option<Self> {
+        if !env_on("MACRDP_CONN_GUARD", true) {
+            return None;
+        }
+        Some(Self::with_config(GuardConfig::from_env()))
+    }
+
+    fn with_config(cfg: GuardConfig) -> Self {
+        Self {
+            ips: HashMap::new(),
+            cfg,
+        }
+    }
+
+    /// The "long-lived session" bar used to classify outcomes.
+    pub fn min_session(&self) -> Duration {
+        self.cfg.min_session
+    }
+
+    /// Decide whether to accept a fresh attempt from `ip` at `now`.
+    pub fn decide(&mut self, now: Instant, ip: IpAddr) -> Decision {
+        let ip = canonical_ip(ip);
+        if ip.is_loopback() {
+            return Decision::Accept;
+        }
+
+        self.evict_stale(now);
+
+        let window = self.cfg.window;
+        let cfg = self.cfg;
+        let entry = self.ips.entry(ip).or_insert_with(|| PerIp::new(now));
+        entry.last_touch = now;
+
+        // Drop attempts that have aged out of the sliding window.
+        let cutoff = now.checked_sub(window);
+        while let Some(&front) = entry.attempts.front() {
+            match cutoff {
+                Some(c) if front < c => {
+                    entry.attempts.pop_front();
+                }
+                _ => break,
+            }
+        }
+
+        // Active lockout?
+        if cfg.lockout_enabled() {
+            if let Some(until) = entry.cooldown_until {
+                if now < until {
+                    return Decision::RejectCooldown {
+                        retry_after: until.saturating_duration_since(now),
+                    };
+                }
+                // Expired — clear it so a later success/failure starts fresh.
+                entry.cooldown_until = None;
+            }
+        }
+
+        // Rate-limit: a rejected attempt is NOT pushed, so a reject can't
+        // self-extend the window.
+        if cfg.rate_limit_enabled() && entry.attempts.len() >= cfg.max_attempts {
+            return Decision::RejectRateLimit {
+                window_attempts: entry.attempts.len(),
+            };
+        }
+
+        entry.attempts.push_back(now);
+        Decision::Accept
+    }
+
+    /// Record the classified outcome of a finished connection from `ip`.
+    pub fn record_outcome(&mut self, now: Instant, ip: IpAddr, outcome: Outcome) {
+        let ip = canonical_ip(ip);
+        if ip.is_loopback() {
+            return;
+        }
+        let cfg = self.cfg;
+        let entry = self.ips.entry(ip).or_insert_with(|| PerIp::new(now));
+        entry.last_touch = now;
+
+        match outcome {
+            Outcome::Success => {
+                entry.consecutive_failures = 0;
+                entry.cooldown_until = None;
+            }
+            Outcome::Failure => {
+                entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+                if cfg.lockout_enabled() && entry.consecutive_failures >= cfg.failure_threshold {
+                    let cooldown = escalated_cooldown(
+                        entry.consecutive_failures,
+                        cfg.failure_threshold,
+                        cfg.base_cooldown,
+                        cfg.max_cooldown,
+                    );
+                    entry.cooldown_until = Some(now + cooldown);
+                }
+            }
+        }
+    }
+
+    /// Lazily drop fully-idle entries, and hard-cap total tracked IPs.
+    fn evict_stale(&mut self, now: Instant) {
+        // Prune every entry's window first (the per-decision prune only touches
+        // the IP being decided), so an IP whose attempts have all aged out — and
+        // which carries no failure/cooldown state — becomes idle and is dropped.
+        let cutoff = now.checked_sub(self.cfg.window);
+        self.ips.retain(|_, v| {
+            if let Some(c) = cutoff {
+                while let Some(&front) = v.attempts.front() {
+                    if front < c {
+                        v.attempts.pop_front();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            !v.is_idle(now)
+        });
+
+        if self.ips.len() >= MAX_TRACKED_IPS {
+            // Evict ~10% of the oldest-touched entries so this doesn't run every
+            // call once at the cap.
+            let to_drop = self.ips.len() / 10 + 1;
+            let mut by_age: Vec<(IpAddr, Instant)> =
+                self.ips.iter().map(|(k, v)| (*k, v.last_touch)).collect();
+            by_age.sort_by_key(|(_, t)| *t);
+            for (ip, _) in by_age.into_iter().take(to_drop) {
+                self.ips.remove(&ip);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn tracks(&self, ip: IpAddr) -> bool {
+        self.ips.contains_key(&canonical_ip(ip))
+    }
+}
+
+/// `base << (n - threshold)`, saturating, capped at `max`.
+fn escalated_cooldown(n: u32, threshold: u32, base: Duration, max: Duration) -> Duration {
+    let steps = n.saturating_sub(threshold);
+    // Saturate the shift so a huge failure count doesn't overflow.
+    let factor = 1u64.checked_shl(steps).unwrap_or(u64::MAX);
+    let scaled = base
+        .checked_mul(factor.min(u32::MAX as u64) as u32)
+        .unwrap_or(max);
+    scaled.min(max)
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+/// Whether the audit log is enabled (`MACRDP_AUDIT_LOG`, default on). Independent
+/// of the guard so audit lines flow even with enforcement disabled.
+pub fn audit_enabled() -> bool {
+    env_on("MACRDP_AUDIT_LOG", true)
+}
+
+/// Audit-log an accepted connection.
+pub fn audit_accept(ip: IpAddr, port: u16) {
+    if audit_enabled() {
+        tracing::info!(target: "macrdp::audit", event = "accept", %ip, port);
+    }
+}
+
+/// Audit-log a rejected connection (the `Decision` carries the reason).
+pub fn audit_reject(ip: IpAddr, decision: Decision) {
+    if !audit_enabled() {
+        return;
+    }
+    match decision {
+        Decision::RejectRateLimit { window_attempts } => {
+            tracing::warn!(
+                target: "macrdp::audit",
+                event = "reject",
+                reason = "rate_limit",
+                %ip,
+                window_attempts,
+            );
+        }
+        Decision::RejectCooldown { retry_after } => {
+            tracing::warn!(
+                target: "macrdp::audit",
+                event = "reject",
+                reason = "lockout",
+                %ip,
+                retry_after_secs = retry_after.as_secs(),
+            );
+        }
+        Decision::Accept => {}
+    }
+}
+
+/// Audit-log a finished connection and its classified outcome.
+pub fn audit_disconnect(ip: IpAddr, duration: Duration, outcome: Outcome) {
+    if audit_enabled() {
+        tracing::info!(
+            target: "macrdp::audit",
+            event = "disconnect",
+            %ip,
+            duration_ms = duration.as_millis() as u64,
+            outcome = match outcome {
+                Outcome::Success => "success",
+                Outcome::Failure => "failure",
+            },
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Single-process ConnectionHandler adapter
+// ---------------------------------------------------------------------------
+
+/// `ironrdp_server::ConnectionHandler` adapter wrapping an [`AuthGuardCore`], for
+/// the single-process server path. Constructed via [`AuthGuardHandler::from_env`].
+pub struct AuthGuardHandler {
+    core: AuthGuardCore,
+}
+
+impl AuthGuardHandler {
+    /// Build the boxed handler, or `None` when the guard is disabled (so the
+    /// builder gets `None` and the vendored default accept-all path runs).
+    pub fn from_env() -> Option<Box<dyn ironrdp_server::ConnectionHandler>> {
+        AuthGuardCore::from_env()
+            .map(|core| Box::new(Self { core }) as Box<dyn ironrdp_server::ConnectionHandler>)
+    }
+}
+
+impl ironrdp_server::ConnectionHandler for AuthGuardHandler {
+    fn on_accept(&mut self, peer: std::net::SocketAddr) -> bool {
+        match self.core.decide(Instant::now(), peer.ip()) {
+            Decision::Accept => {
+                audit_accept(peer.ip(), peer.port());
+                true
+            }
+            reject => {
+                audit_reject(peer.ip(), reject);
+                false
+            }
+        }
+    }
+
+    fn on_disconnected(
+        &mut self,
+        peer: std::net::SocketAddr,
+        duration: Duration,
+        error: Option<&anyhow::Error>,
+    ) -> ironrdp_server::PostConnectionAction {
+        let outcome = if error.is_some() || duration < self.core.min_session() {
+            Outcome::Failure
+        } else {
+            Outcome::Success
+        };
+        self.core.record_outcome(Instant::now(), peer.ip(), outcome);
+        audit_disconnect(peer.ip(), duration, outcome);
+        // The guard must never halt the server.
+        ironrdp_server::PostConnectionAction::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn test_cfg() -> GuardConfig {
+        GuardConfig {
+            window: Duration::from_secs(60),
+            max_attempts: 10,
+            failure_threshold: 5,
+            min_session: Duration::from_secs(10),
+            base_cooldown: Duration::from_secs(30),
+            max_cooldown: Duration::from_secs(900),
+        }
+    }
+
+    fn core() -> AuthGuardCore {
+        AuthGuardCore::with_config(test_cfg())
+    }
+
+    fn ip(n: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, n))
+    }
+
+    #[test]
+    fn rate_limit_trips_at_cap_then_recovers_after_window() {
+        let mut c = core();
+        let t0 = Instant::now();
+        let peer = ip(1);
+        // First 10 attempts accepted.
+        for i in 0..10 {
+            assert_eq!(
+                c.decide(t0 + Duration::from_secs(i), peer),
+                Decision::Accept,
+                "attempt {i} should be accepted"
+            );
+        }
+        // 11th within the window is rate-limited.
+        assert_eq!(
+            c.decide(t0 + Duration::from_secs(10), peer),
+            Decision::RejectRateLimit {
+                window_attempts: 10
+            }
+        );
+        // After the window has fully elapsed, accepted again.
+        assert_eq!(
+            c.decide(t0 + Duration::from_secs(61), peer),
+            Decision::Accept
+        );
+    }
+
+    #[test]
+    fn rejected_attempt_not_counted_in_window() {
+        let mut c = core();
+        let t0 = Instant::now();
+        let peer = ip(2);
+        // 10 accepts spread 1s apart (t0..t0+9) so timestamps age out one at a time.
+        for i in 0..10 {
+            assert_eq!(
+                c.decide(t0 + Duration::from_secs(i), peer),
+                Decision::Accept
+            );
+        }
+        // Several rejects at t0+9 — if any of these pushed a timestamp the window
+        // would hold 11+ entries and the recovery check below would still reject.
+        for _ in 0..5 {
+            assert!(matches!(
+                c.decide(t0 + Duration::from_secs(9), peer),
+                Decision::RejectRateLimit { .. }
+            ));
+        }
+        // At t0+61 only the t0 attempt has aged out (t0 < t0+1), freeing exactly
+        // ONE slot → exactly one accept, then reject again. This only holds if the
+        // rejects above were NOT counted.
+        assert_eq!(
+            c.decide(t0 + Duration::from_secs(61), peer),
+            Decision::Accept
+        );
+        assert!(matches!(
+            c.decide(t0 + Duration::from_secs(61), peer),
+            Decision::RejectRateLimit { .. }
+        ));
+    }
+
+    #[test]
+    fn cooldown_escalates_and_auto_expires() {
+        let mut c = core();
+        let t0 = Instant::now();
+        let peer = ip(3);
+        // 5 consecutive failures → first lockout (base = 30s).
+        for _ in 0..5 {
+            c.record_outcome(t0, peer, Outcome::Failure);
+        }
+        match c.decide(t0, peer) {
+            Decision::RejectCooldown { retry_after } => {
+                assert_eq!(retry_after, Duration::from_secs(30));
+            }
+            other => panic!("expected cooldown, got {other:?}"),
+        }
+        // One more failure → escalate to 60s (measured from the new failure time).
+        c.record_outcome(t0, peer, Outcome::Failure);
+        match c.decide(t0, peer) {
+            Decision::RejectCooldown { retry_after } => {
+                assert_eq!(retry_after, Duration::from_secs(60));
+            }
+            other => panic!("expected escalated cooldown, got {other:?}"),
+        }
+        // After it expires, accepted again.
+        assert_eq!(
+            c.decide(t0 + Duration::from_secs(61), peer),
+            Decision::Accept
+        );
+    }
+
+    #[test]
+    fn cooldown_is_capped() {
+        // 5 + 20 extra failures would be base << 20 ≈ 30s * 1M, far over the cap.
+        let dur = escalated_cooldown(25, 5, Duration::from_secs(30), Duration::from_secs(900));
+        assert_eq!(dur, Duration::from_secs(900));
+    }
+
+    #[test]
+    fn success_resets_failures() {
+        let mut c = core();
+        let t0 = Instant::now();
+        let peer = ip(4);
+        // 4 failures (below threshold), then a success.
+        for _ in 0..4 {
+            c.record_outcome(t0, peer, Outcome::Failure);
+        }
+        c.record_outcome(t0, peer, Outcome::Success);
+        // 4 more failures still below threshold → no lockout.
+        for _ in 0..4 {
+            c.record_outcome(t0, peer, Outcome::Failure);
+        }
+        assert_eq!(c.decide(t0, peer), Decision::Accept);
+    }
+
+    #[test]
+    fn benign_single_error_then_success_never_locks() {
+        let mut c = core();
+        let t0 = Instant::now();
+        let peer = ip(5);
+        // The documented mstsc pattern: one broken-pipe failure, then a clean
+        // session, repeated many times. Must never reach lockout.
+        for k in 0..50 {
+            let t = t0 + Duration::from_secs(k * 20);
+            c.record_outcome(t, peer, Outcome::Failure);
+            c.record_outcome(t + Duration::from_secs(1), peer, Outcome::Success);
+            assert_eq!(
+                c.decide(t + Duration::from_secs(2), peer),
+                Decision::Accept,
+                "iteration {k} must stay accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn loopback_is_exempt_and_untracked() {
+        let mut c = core();
+        let t0 = Instant::now();
+        for lo in [
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            // IPv4-mapped loopback.
+            IpAddr::V6(Ipv4Addr::LOCALHOST.to_ipv6_mapped()),
+        ] {
+            for _ in 0..100 {
+                c.record_outcome(t0, lo, Outcome::Failure);
+            }
+            for _ in 0..100 {
+                assert_eq!(c.decide(t0, lo), Decision::Accept);
+            }
+            assert!(!c.tracks(lo), "loopback must never be tracked: {lo}");
+        }
+    }
+
+    #[test]
+    fn ipv4_mapped_keys_to_v4() {
+        let mut c = core();
+        let t0 = Instant::now();
+        let v4 = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7));
+        let mapped = IpAddr::V6(Ipv4Addr::new(198, 51, 100, 7).to_ipv6_mapped());
+        // Failures recorded under the mapped form must count toward the V4 key.
+        for _ in 0..5 {
+            c.record_outcome(t0, mapped, Outcome::Failure);
+        }
+        assert!(matches!(c.decide(t0, v4), Decision::RejectCooldown { .. }));
+    }
+
+    #[test]
+    fn stale_entries_are_evicted() {
+        let mut c = core();
+        let t0 = Instant::now();
+        let peer = ip(6);
+        assert_eq!(c.decide(t0, peer), Decision::Accept);
+        assert!(c.tracks(peer));
+        // Decide for a different IP well after the window → the first entry is
+        // now idle (attempt aged out, no failures, no cooldown) and evicted.
+        let _ = c.decide(t0 + Duration::from_secs(120), ip(7));
+        assert!(!c.tracks(peer), "idle entry should have been evicted");
+    }
+
+    #[test]
+    fn disabled_lockout_threshold_zero() {
+        let mut cfg = test_cfg();
+        cfg.failure_threshold = 0;
+        let mut c = AuthGuardCore::with_config(cfg);
+        let t0 = Instant::now();
+        let peer = ip(8);
+        for _ in 0..50 {
+            c.record_outcome(t0, peer, Outcome::Failure);
+        }
+        assert_eq!(c.decide(t0, peer), Decision::Accept);
+    }
+
+    #[test]
+    fn disabled_rate_limit_max_zero() {
+        let mut cfg = test_cfg();
+        cfg.max_attempts = 0;
+        let mut c = AuthGuardCore::with_config(cfg);
+        let t0 = Instant::now();
+        let peer = ip(9);
+        for _ in 0..1000 {
+            assert_eq!(c.decide(t0, peer), Decision::Accept);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
 mod aac;
 mod audio;
 mod auth;
+mod auth_guard;
 mod avc444;
 mod capture;
 mod clipboard;
@@ -793,7 +794,22 @@ async fn run_fork_supervisor(
     // after fixing the worker to process::exit — a fast reconnect could still
     // overlap the new worker's capture with the dying worker's not-yet-released
     // SCStream.
-    let mut prev_worker: Option<std::process::Child> = None;
+    // Tuple carries the peer IP + spawn instant alongside the child so, when this
+    // worker is drained on the NEXT accept, the auth guard can classify its outcome
+    // (exit code + session duration) and record it against the right IP.
+    let mut prev_worker: Option<(std::process::Child, std::net::IpAddr, std::time::Instant)> = None;
+
+    // Auth hardening (Tier 1.2): the fork-workers supervisor owns its own accept
+    // loop (it never builds an RdpServer), so it drives the shared AuthGuardCore
+    // directly — pre-spawn rate-limit/lockout + per-IP outcome recording on worker
+    // drain. `None` when MACRDP_CONN_GUARD is off. Loopback is exempt in the core.
+    let mut guard = auth_guard::AuthGuardCore::from_env();
+    // "Long-lived session" bar for the supervisor's outcome heuristic; falls back
+    // to the documented default when the guard is disabled but audit is still on.
+    let min_session = guard
+        .as_ref()
+        .map(|g| g.min_session())
+        .unwrap_or_else(|| std::time::Duration::from_secs(10));
 
     // SCK capture-slot settle, env-overridable for hardware-in-the-loop tuning.
     let sck_settle = std::env::var(WORKER_SCK_SETTLE_ENV)
@@ -831,31 +847,36 @@ async fn run_fork_supervisor(
             }
         };
 
-        // Engage headless blanking on the first connection (continuous).
-        if !headless_engaged && blank != BlankMode::None {
-            headless_engaged = true;
-            if let Some(id) = vd_id {
-                engage_headless_blank(
-                    blank,
-                    id,
-                    detach_slot.clone(),
-                    capture_slot.clone(),
-                    primary_slot.clone(),
-                );
-            }
-        }
-
-        // Drain the previous worker before this connection captures.
-        if let Some(prev) = prev_worker.take() {
+        // Drain the previous worker FIRST (before the rate-limit gate) so its
+        // outcome is recorded and its capture slot is freed regardless of whether
+        // THIS connection is accepted.
+        if let Some((prev, prev_ip, started)) = prev_worker.take() {
             let prev_pid = prev.id();
+            let dur = started.elapsed();
             let waited = tokio::time::timeout(
                 WORKER_WAIT_TIMEOUT,
                 tokio::task::spawn_blocking(move || {
                     let mut prev = prev;
-                    let _ = prev.wait();
+                    prev.wait()
                 }),
             )
             .await;
+            // Classify the finished worker for the guard's lockout heuristic. The
+            // worker exits 0 on a clean connection end / 1 on error (see the worker
+            // branch's process::exit). Clean + long-lived ⇒ success; nonzero or
+            // short ⇒ failure; a wait/join error ⇒ don't penalize; a >timeout
+            // still-alive worker is clearly a long-lived session ⇒ success.
+            let outcome = match &waited {
+                Ok(Ok(Ok(status))) => {
+                    if status.success() && dur >= min_session {
+                        auth_guard::Outcome::Success
+                    } else {
+                        auth_guard::Outcome::Failure
+                    }
+                }
+                Ok(_) => auth_guard::Outcome::Success,
+                Err(_) => auth_guard::Outcome::Success,
+            };
             if waited.is_err() {
                 // Timed out: the old connection is still alive. The detached
                 // spawn_blocking keeps running and reaps it; proceed anyway so a
@@ -870,9 +891,44 @@ async fn run_fork_supervisor(
                     "previous worker exited; capture slot freed"
                 );
             }
+            if let Some(g) = guard.as_mut() {
+                g.record_outcome(std::time::Instant::now(), prev_ip, outcome);
+            }
+            auth_guard::audit_disconnect(prev_ip, dur, outcome);
             // Let SCK's daemon release the capture slot before the next SCStream.
             tokio::time::sleep(sck_settle).await;
         }
+
+        // Rate-limit / lockout gate (pre-handshake, before spawning a worker).
+        // Loopback is exempt inside the core. audit_accept/_reject self-gate on
+        // MACRDP_AUDIT_LOG, so they run even when the guard itself is disabled.
+        match guard.as_mut() {
+            Some(g) => match g.decide(std::time::Instant::now(), peer.ip()) {
+                auth_guard::Decision::Accept => auth_guard::audit_accept(peer.ip(), peer.port()),
+                reject => {
+                    auth_guard::audit_reject(peer.ip(), reject);
+                    drop(stream);
+                    continue;
+                }
+            },
+            None => auth_guard::audit_accept(peer.ip(), peer.port()),
+        }
+
+        // Engage headless blanking on the first ACCEPTED connection (continuous) —
+        // after the gate so a rejected port-scan doesn't blank the panel.
+        if !headless_engaged && blank != BlankMode::None {
+            headless_engaged = true;
+            if let Some(id) = vd_id {
+                engage_headless_blank(
+                    blank,
+                    id,
+                    detach_slot.clone(),
+                    capture_slot.clone(),
+                    primary_slot.clone(),
+                );
+            }
+        }
+
         // Take ownership of the raw fd and stop tokio/std from closing it; the
         // child inherits it across fork, and we close the parent's copy after
         // spawn. `into_std` then `into_raw_fd` detaches it from Rust's RAII.
@@ -916,10 +972,11 @@ async fn run_fork_supervisor(
                     fd,
                     "spawned worker process for connection"
                 );
-                // Hold the child so the NEXT accept waits for it to exit before
-                // spawning (the serialization above) — that wait is also what
-                // reaps it, so it never becomes a lingering zombie.
-                prev_worker = Some(child);
+                // Hold the child (+ peer IP and spawn instant) so the NEXT accept
+                // waits for it to exit before spawning (the serialization above) —
+                // that wait is also what reaps it (never a lingering zombie) and
+                // what feeds the auth guard this worker's outcome.
+                prev_worker = Some((child, peer.ip(), std::time::Instant::now()));
             }
             Err(e) => error!(error = ?e, "failed to spawn worker process"),
         }
@@ -1565,6 +1622,30 @@ fn args_from_config(path: &Path) -> Result<Args> {
             argv.push(path.clone());
         }
     }
+    // Auth-guard tunables are env-only (read at startup by auth_guard::*_from_env).
+    // Bridge the friendly config.env keys to their MACRDP_* env vars here so
+    // menu-bar / LaunchAgent users can tune them via config.env without editing
+    // the plist's EnvironmentVariables. Unset keys keep the on-by-default defaults.
+    for (cfg_key, env_var) in [
+        ("CONN_GUARD", "MACRDP_CONN_GUARD"),
+        ("AUDIT_LOG", "MACRDP_AUDIT_LOG"),
+        ("GUARD_RL_MAX", "MACRDP_GUARD_RL_MAX"),
+        ("GUARD_RL_WINDOW_SECS", "MACRDP_GUARD_RL_WINDOW_SECS"),
+        ("GUARD_FAIL_THRESHOLD", "MACRDP_GUARD_FAIL_THRESHOLD"),
+        ("GUARD_MIN_SESSION_SECS", "MACRDP_GUARD_MIN_SESSION_SECS"),
+        (
+            "GUARD_COOLDOWN_BASE_SECS",
+            "MACRDP_GUARD_COOLDOWN_BASE_SECS",
+        ),
+        ("GUARD_COOLDOWN_MAX_SECS", "MACRDP_GUARD_COOLDOWN_MAX_SECS"),
+    ] {
+        if let Some(val) = cfg.get(cfg_key) {
+            if !val.is_empty() {
+                std::env::set_var(env_var, val);
+            }
+        }
+    }
+
     // EXTRA_FLAGS: space-separated escape hatch, appended verbatim.
     if let Some(extra) = cfg.get("EXTRA_FLAGS") {
         for tok in extra.split_whitespace() {
@@ -2301,6 +2382,17 @@ async fn async_main() -> Result<()> {
             None
         };
 
+    // Auth hardening (Tier 1.2): per-IP rate-limit + lockout + audit log via the
+    // server's pre-handshake/post-disconnect ConnectionHandler seam. On by default
+    // (MACRDP_CONN_GUARD=0 disables). A fork *worker* bypasses the accept loop
+    // (run_connection directly), so its handler is never consulted — pass None to
+    // avoid dead weight; the supervisor drives the same core in its own loop.
+    let conn_handler: Option<Box<dyn ironrdp_server::ConnectionHandler>> = if worker_fd.is_none() {
+        auth_guard::AuthGuardHandler::from_env()
+    } else {
+        None
+    };
+
     let mut server = RdpServer::builder()
         .with_addr(args.bind)
         .with_hybrid(tls, spki_der)
@@ -2311,6 +2403,7 @@ async fn async_main() -> Result<()> {
         .with_rdpdr_factory(rdpdr_factory)
         .with_bitmap_codecs(bitmap_codecs())
         .with_gfx_factory(gfx_factory)
+        .with_connection_handler(conn_handler)
         .build();
 
     // Hand the shared suppress flag to the server so its per-connection


### PR DESCRIPTION
## What

Production-readiness **Tier 1.2 — auth hardening**. In front of the existing NLA/CredSSP pre-auth gate, macrdp now does:

- **Per-source-IP connection rate-limiting** — caps attempts per sliding window (default 10/60s), rejected pre-handshake.
- **Escalating, auto-expiring failed-attempt lockout** — after N consecutive failures (default 5) an IP gets a cooldown that doubles per extra failure (30s → 900s cap) and self-heals.
- **Auth audit log** — a `macrdp::audit` line per connection (`accept`/`reject`/`disconnect`, source IP, reason, outcome), flowing through the existing rotating log file.

**On by default**, conservative thresholds, **loopback exempt** (can't self-lock — the default bind is `127.0.0.1:3390`), fully tunable + disable-able via env / `config.env`.

## How

`src/auth_guard.rs`:
- `AuthGuardCore` — a **pure, platform-independent** decision core (`decide`/`record_outcome`, time passed in for deterministic tests). Per-IP sliding-window attempts + consecutive-failure counter + auto-expiring cooldown; loopback (incl. IPv4-mapped) exempt; idle-entry eviction + hard cap.
- `AuthGuardHandler` — the `ironrdp_server::ConnectionHandler` adapter (single-process path). Lockout is **heuristic** (errored or very-short connection ⇒ failure; clean long-lived session resets), so a benign disconnect — e.g. mstsc's first-connect cert-prompt "Broken pipe" — never locks anyone out.

**Zero vendored divergence** — reuses ironrdp-server's existing `with_connection_handler` seam. Two call sites share the one core:
- **single-process**: `.with_connection_handler(...)` in the builder chain.
- **`--fork-workers`**: the supervisor (its own accept loop) drives the same core — drain previous worker (classify by exit code + duration) → rate-limit/lockout gate → engage headless blank only on an accepted connection → spawn. A rejected port-scan no longer blanks the panel.

## Verification

- **11 unit tests** for the core (window recovery, escalation + cap + auto-expire, success-reset, loopback/IPv4-mapped exemption, eviction, disable switches); **131 total tests pass**.
- **Live raw-TCP smoke test** against the binary on a non-loopback bind (loopback is exempt, so test connects to the LAN IP; the guard rejects pre-handshake and the lockout heuristic only needs a short/errored connection — no RDP/TLS/mstsc needed):
  - single-process: rate-limit (5 accept → 3 `rate_limit` rejects), lockout (`lockout` reject → auto-expire → accepted again), loopback-exempt (20 hammers, 0 rejects).
  - fork-workers supervisor: rate-limit gate fires (3 accept → 3 `rate_limit` rejects).
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` all green.

Not live-tested (unit-tested only): a clean **success** outcome resetting the counter needs a full RDP session — a normal mstsc/FreeRDP connect shows `outcome="success"`.

## Out of scope

- Precise CredSSP-failure classification (would need a vendored signal — intentionally avoided in favor of the heuristic).