### PR TITLE
release: v0.8.20 — production-readiness arc (TLS certs + auth hardening + log rotation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
-Functional v0 — daily-driver usable on a trusted LAN. **Latest release: v0.8.19**
-(the congestion-responsive rate-control arc + loss-resilient lossy-UDP audio).
+Functional v0 — daily-driver usable on a trusted LAN. **Latest release: v0.8.20**
+(the production-readiness arc: operator-supplied TLS certs `--cert`/`--key`,
+connection rate-limiting + lockout + an auth audit log, and bounded log rotation +
+a startup reaper — Tier 1.1/1.2/2.5 of `@docs/production-readiness-roadmap.md`).
 RDP clients (mstsc, Microsoft Remote Desktop, FreeRDP) connect over TLS and get
 the macOS desktop with keyboard/mouse/clipboard/audio, optional H.264-over-EGFX,
 headless virtual displays, drive + smart-card redirection, and (opt-in) UDP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macrdp"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrdp"
-version = "0.8.19"
+version = "0.8.20"
 edition = "2021"
 description = "Native RDP server for macOS"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version bump to **v0.8.20**. Bundles the production-readiness track landed since v0.8.18:

- **#103** bounded log rotation (`~/Library/Logs/macrdp.log` + N archives) + startup reaper for SIGKILL/panic leftovers (stale NFS mounts + temp dirs). *(Tier 2.5)*
- **#104** operator-supplied TLS certificate via `--cert`/`--key` (real CA / ACME / Let's Encrypt); no silent self-sign fallback; startup expiry warning. *(Tier 1.1)*
- **#105** connection rate-limiting + escalating auto-expiring lockout + an auth audit log (`macrdp::audit`) — on by default, loopback-exempt, env-tunable, zero vendored divergence. *(Tier 1.2)*
- Docs: production-readiness roadmap + README section, full feature/CLI/config docs, macOS sleep/clamshell gotcha.

`Cargo.toml` + `Cargo.lock` → 0.8.20; CLAUDE.md status refreshed. Pre-tag checks green locally (fmt + clippy + 131 tests). After merge, the `v0.8.20` tag triggers `release.yml` (builds + ad-hoc-signed artifacts → **draft** GitHub release for review).