### PR TITLE
fix(security): don't lock out reconnecting clients (auth-guard fail-fast heuristic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,16 +363,18 @@ MACRDP_AUDIT_LOG=1                # connection audit log (independent of the gua
 MACRDP_GUARD_RL_MAX=10            # max attempts per window per IP (0 = no rate-limit)        [GUARD_RL_MAX]
 MACRDP_GUARD_RL_WINDOW_SECS=60    # rate-limit sliding window                                 [GUARD_RL_WINDOW_SECS]
 MACRDP_GUARD_FAIL_THRESHOLD=5     # consecutive failures before lockout (0 = no lockout)      [GUARD_FAIL_THRESHOLD]
-MACRDP_GUARD_MIN_SESSION_SECS=10  # a connection shorter than this counts as a failure        [GUARD_MIN_SESSION_SECS]
+MACRDP_GUARD_FAILFAST_SECS=3      # only errored connections that fail this fast (pre-handshake) count toward lockout  [GUARD_FAILFAST_SECS]
 MACRDP_GUARD_COOLDOWN_BASE_SECS=30  # first lockout length, doubles per extra failure          [GUARD_COOLDOWN_BASE_SECS]
 MACRDP_GUARD_COOLDOWN_MAX_SECS=900  # lockout escalation cap (15 min)                          [GUARD_COOLDOWN_MAX_SECS]
 ```
 
 The lockout **escalates and auto-expires** (no manual unlock): with the defaults it triggers
 at the 5th consecutive failure, then 30s → 60 → 120 → 240 → 480 → 900s (cap) as the IP keeps
-failing past each cooldown; **any clean, long-lived session resets that IP to 0**. It's
-heuristic (an errored or very-short connection ⇒ failure), so a single benign disconnect —
-e.g. mstsc's first-connect cert-prompt "Broken pipe" — never locks you out. Audit lines are
+failing past each cooldown; **a clean session — or any connection that got past the handshake
+— resets that IP to 0**. It's heuristic: only a connection that errored *and* failed within
+the fail-fast window (~3s, i.e. never authenticated) counts as a failure, so a reconnecting
+real client (mstsc reconnect-blank, flaky link) and a single benign disconnect (mstsc's
+first-connect cert-prompt "Broken pipe") never lock you out. Audit lines are
 tagged `macrdp::audit`: `grep 'macrdp::audit' ~/Library/Logs/macrdp.log` shows
 `event="accept|reject|disconnect"` with the source IP and (for rejects) the reason and
 retry-after.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,7 +205,7 @@ MACRDP_AUDIT_LOG=1                # connection audit log (independent of the gua
 MACRDP_GUARD_RL_MAX=10            # max attempts per window per IP (0 = no rate-limit)
 MACRDP_GUARD_RL_WINDOW_SECS=60    # rate-limit sliding window
 MACRDP_GUARD_FAIL_THRESHOLD=5     # consecutive failures before lockout (0 = no lockout)
-MACRDP_GUARD_MIN_SESSION_SECS=10  # a connection shorter than this counts as a failure
+MACRDP_GUARD_FAILFAST_SECS=3      # only errored connections that fail within this window (pre-handshake) count toward lockout
 MACRDP_GUARD_COOLDOWN_BASE_SECS=30  # first lockout length (doubles per extra failure)
 MACRDP_GUARD_COOLDOWN_MAX_SECS=900  # lockout escalation cap (15 min)
 ```
@@ -225,10 +225,14 @@ consecutive failure and doubles from 30 s as the IP keeps failing past each cool
 There is **no manual unlock** — each cooldown auto-expires, then the next attempt is
 allowed through. Escalation requires *actually failing again after* each cooldown
 clears (while locked out, attempts are rejected pre-handshake and don't count as new
-failures), and **any clean, long-lived session resets the IP to 0**. The lockout is
-**heuristic** (an errored or very-short connection counts as a failure; a clean
-session resets), so a single benign disconnect — e.g. mstsc's first-connect
-cert-prompt "Broken pipe" — never locks you out. Audit lines are tagged
+failures), and **a clean session — or any connection that got past the handshake —
+resets the IP to 0**. The lockout is **heuristic**: only a connection that errored
+*and* failed within the fail-fast window (`MACRDP_GUARD_FAILFAST_SECS`, ~3s — i.e.
+never authenticated, the brute-force signature) counts as a failure. A client that
+connected for several seconds and *then* errored (e.g. mstsc's reconnect-blank or a
+flaky link) is treated as legitimate and does **not** accrue toward a lockout — so a
+reconnecting real client is never locked out, and a single benign disconnect (mstsc's
+first-connect cert-prompt "Broken pipe") never does either. Audit lines are tagged
 `macrdp::audit`: `grep 'macrdp::audit' ~/Library/Logs/macrdp.log` shows
 `event="accept|reject|disconnect"` with the source IP and (for rejects) the reason
 and retry-after.

--- a/packaging/config.env.example
+++ b/packaging/config.env.example
@@ -42,7 +42,10 @@ USE_KEYCHAIN=1
 # GUARD_RL_MAX=10            # max attempts per window per IP (0 = no rate-limit)
 # GUARD_RL_WINDOW_SECS=60    # rate-limit sliding window
 # GUARD_FAIL_THRESHOLD=5     # consecutive failures before lockout (0 = no lockout)
-# GUARD_MIN_SESSION_SECS=10  # a connection shorter than this counts as a failure
+# GUARD_FAILFAST_SECS=3      # only an errored connection that failed within this
+#                            # window (never got past the handshake) counts toward
+#                            # lockout; a client that connected longer then errored
+#                            # is treated as legit (won't lock out reconnecting clients)
 # GUARD_COOLDOWN_BASE_SECS=30  # first lockout length, doubles per extra failure:
 #                              # 5 fails=30s, 6=60s, 7=120s, 8=240s, 9=480s, 10+=cap.
 #                              # Auto-expires (no manual unlock); a clean session resets.

--- a/scripts/soak-monitor.sh
+++ b/scripts/soak-monitor.sh
@@ -41,12 +41,15 @@ sample_row() {
     rss=$(ps -o rss= -p "$pid" 2>/dev/null | awk '{print int($1/1024)}')
     thr=$(ps -M "$pid" 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
     fds=$(lsof -p "$pid" 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
-    scs=$(lsof -p "$pid" 2>/dev/null | grep -ci 'ScreenCaptureKit\|CoreMedia')
+    # Established inbound connections = "is a client connected right now". More
+    # reliable than trying to detect an SCStream: system frameworks live in the
+    # dyld shared cache, so `lsof | grep ScreenCaptureKit` never matched.
+    conns=$(lsof -nP -p "$pid" -iTCP -sTCP:ESTABLISHED 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
     procs=$(pgrep -f "$MACRDP_RE" 2>/dev/null | wc -l | tr -d ' ')
     nfs=$(mount 2>/dev/null | grep -c 'macrdp-rdpdr\|localhost:/')
     tmp=$(ls -d "${TMPDIR:-/tmp/}"macrdp-* /tmp/macrdp-* 2>/dev/null | wc -l | tr -d ' ')
     logmb=$(stat -f%z "$DEFAULT_LOGS" 2>/dev/null | awk '{print int($1/1048576)}')
-    echo "$(date '+%Y-%m-%dT%H:%M:%S'),${rss:-0},${thr:-0},${fds:-0},${scs:-0},${procs:-0},${nfs:-0},${tmp:-0},${logmb:-0}"
+    echo "$(date '+%Y-%m-%dT%H:%M:%S'),${rss:-0},${thr:-0},${fds:-0},${conns:-0},${procs:-0},${nfs:-0},${tmp:-0},${logmb:-0}"
 }
 
 cmd_monitor() {
@@ -67,7 +70,7 @@ cmd_monitor() {
         exit 1
     fi
     echo "monitoring pid $pid every ${interval}s -> $out" >&2
-    echo "ts,rss_mb,threads,fds,scstreams,procs,nfs_mounts,tmp_dirs,log_mb" > "$out"
+    echo "ts,rss_mb,threads,fds,conns,procs,nfs_mounts,tmp_dirs,log_mb" > "$out"
     while row="$(sample_row "$pid")"; do
         echo "$row" >> "$out"
         echo "$row"
@@ -108,7 +111,7 @@ cmd_analyze() {
         echo "  rss_mb     : $(col_stats "$csv" 2)"
         echo "  threads    : $(col_stats "$csv" 3)"
         echo "  fds        : $(col_stats "$csv" 4)"
-        echo "  scstreams  : $(col_stats "$csv" 5)"
+        echo "  conns      : $(col_stats "$csv" 5)   (established client connections)"
         echo "  procs      : $(col_stats "$csv" 6)"
         echo "  nfs_mounts : $(col_stats "$csv" 7)"
         echo "  tmp_dirs   : $(col_stats "$csv" 8)"
@@ -134,6 +137,21 @@ cmd_analyze() {
     # shellcheck disable=SC2086
     grep -hiE 'writer stalled|self-heal|de-migrat|watchdog|resync|too many open files|EMFILE' $logs 2>/dev/null \
         | strip | sort | uniq -c | sort -rn | head -20
+    echo
+    echo "==> AUTH GUARD (macrdp::audit) — rejections mean a client was blocked:"
+    # shellcheck disable=SC2086
+    lock=$(grep -h 'macrdp::audit' $logs 2>/dev/null | grep -c 'reason=.\?lockout')
+    rl=$(grep -h 'macrdp::audit' $logs 2>/dev/null | grep -c 'reason=.\?rate_limit')
+    accepts=$(grep -h 'macrdp::audit' $logs 2>/dev/null | grep -c 'event=.\?accept')
+    echo "  accepts=$accepts  rate_limit_rejects=$rl  lockout_rejects=$lock"
+    if [ "$lock" -gt 0 ] || [ "$rl" -gt 0 ]; then
+        echo "  ⚠️  a client was blocked by the connection guard. If it was a LEGIT client,"
+        echo "     loosen/disable it: MACRDP_CONN_GUARD=0 (or raise thresholds) in config.env."
+        echo "     Most-recent rejections:"
+        # shellcheck disable=SC2086
+        grep -h 'macrdp::audit' $logs 2>/dev/null | grep -E 'reason=.\?(lockout|rate_limit)' \
+            | strip | tail -5 | sed 's/^/       /'
+    fi
     echo
     echo "  tip: re-run analyze later and compare WATCH counts — flat/slow = healthy,"
     echo "  growing fast = a real issue. Any CRITICAL hit means dig into that log."

--- a/src/auth_guard.rs
+++ b/src/auth_guard.rs
@@ -22,13 +22,17 @@
 //!
 //! ## Heuristic lockout (deliberate)
 //! `on_disconnected` only sees `Option<&anyhow::Error>`, which can't cleanly
-//! distinguish a wrong-password CredSSP failure from a benign disconnect (the
-//! documented mstsc first-connect "Broken pipe" cert prompt). Rather than carry a
-//! vendored-server signal, we classify by **outcome heuristic**: an errored OR
-//! very-short connection is a `Failure`; a clean, long-lived session is a
-//! `Success` that resets the IP's counter. This is forgiving by design — a single
-//! benign error can never reach the lockout threshold because the immediate clean
-//! reconnect resets it.
+//! distinguish a wrong-password CredSSP failure from a benign disconnect. Rather
+//! than carry a vendored-server signal, we classify by a **fail-fast heuristic**
+//! (see [`classify_outcome`]): only a connection that errored *and* ended within
+//! the fail-fast window — i.e. never got past the handshake, the brute-force
+//! signature — counts as a `Failure`. Any connection that ran longer (even if it
+//! later errored) is a `Success` that resets the counter, because it authenticated
+//! and is a legitimate client with session trouble, not a login attack. This is
+//! forgiving by design: a reconnecting real client (e.g. the mstsc reconnect-blank
+//! or a flaky link, which errors a few seconds *into* a session) is never locked
+//! out — the pre-fix `errored || short` rule was too aggressive and locked out
+//! legit clients (observed in a soak 2026-07-01).
 //!
 //! ## Scope
 //! Loopback (`127.0.0.1`/`::1`, incl. IPv4-mapped) is **exempt** (the default
@@ -93,9 +97,14 @@ pub struct GuardConfig {
     max_attempts: usize,
     /// Consecutive failures before the first lockout. `0` disables lockout.
     failure_threshold: u32,
-    /// A connection shorter than this (or errored) counts as a failure; one at
-    /// least this long *and* clean counts as a success.
-    min_session: Duration,
+    /// Fail-fast window: an errored connection counts as a lockout **failure**
+    /// only if it ended *within* this window — i.e. it never got past the
+    /// TLS/CredSSP handshake, the brute-force / port-scan signature. A connection
+    /// that ran *longer* than this (even if it later errored) is assumed to have
+    /// authenticated — a legitimate client with session trouble — and resets the
+    /// counter instead of accruing toward a lockout. Keep it short (a few
+    /// seconds), just past the handshake.
+    failfast_window: Duration,
     /// First lockout length; doubles per failure past the threshold.
     base_cooldown: Duration,
     /// Cap on the escalated cooldown.
@@ -110,7 +119,7 @@ impl GuardConfig {
             window: Duration::from_secs(env_u64("MACRDP_GUARD_RL_WINDOW_SECS", 60)),
             max_attempts: env_u64("MACRDP_GUARD_RL_MAX", 10) as usize,
             failure_threshold: env_u64("MACRDP_GUARD_FAIL_THRESHOLD", 5) as u32,
-            min_session: Duration::from_secs(env_u64("MACRDP_GUARD_MIN_SESSION_SECS", 10)),
+            failfast_window: Duration::from_secs(env_u64("MACRDP_GUARD_FAILFAST_SECS", 3)),
             base_cooldown: Duration::from_secs(env_u64("MACRDP_GUARD_COOLDOWN_BASE_SECS", 30)),
             max_cooldown: Duration::from_secs(env_u64("MACRDP_GUARD_COOLDOWN_MAX_SECS", 900)),
         }
@@ -174,6 +183,29 @@ pub enum Outcome {
     Failure,
 }
 
+/// Classify a finished connection for lockout accounting.
+///
+/// A [`Outcome::Failure`] (which accrues toward a lockout) is recorded **only**
+/// when the connection both errored *and* ended within `failfast_window` — i.e.
+/// it never got past the TLS/CredSSP handshake, the brute-force / port-scan
+/// signature. Anything else is a [`Outcome::Success`] that resets the counter:
+/// a clean disconnect, or — crucially — a connection that ran *longer* than the
+/// window before erroring, which is a legitimate client that authenticated and
+/// then hit session trouble (e.g. the mstsc reconnect-blank or a flaky link),
+/// not a login attack. This is what stops a reconnecting real client from being
+/// locked out (the pre-fix heuristic counted any errored connection as a
+/// failure, which locked out legit clients — observed in a soak 2026-07-01).
+///
+/// `errored` is the transport-agnostic error signal: `Some(err)` on the
+/// single-process path, or a non-zero worker exit on the `--fork-workers` path.
+pub fn classify_outcome(errored: bool, duration: Duration, failfast_window: Duration) -> Outcome {
+    if errored && duration < failfast_window {
+        Outcome::Failure
+    } else {
+        Outcome::Success
+    }
+}
+
 /// Pure per-IP rate-limit + lockout decision core. See the module docs.
 pub struct AuthGuardCore {
     ips: HashMap<IpAddr, PerIp>,
@@ -198,9 +230,9 @@ impl AuthGuardCore {
         }
     }
 
-    /// The "long-lived session" bar used to classify outcomes.
-    pub fn min_session(&self) -> Duration {
-        self.cfg.min_session
+    /// The fail-fast window used to classify outcomes (see [`classify_outcome`]).
+    pub fn failfast_window(&self) -> Duration {
+        self.cfg.failfast_window
     }
 
     /// Decide whether to accept a fresh attempt from `ip` at `now`.
@@ -432,11 +464,7 @@ impl ironrdp_server::ConnectionHandler for AuthGuardHandler {
         duration: Duration,
         error: Option<&anyhow::Error>,
     ) -> ironrdp_server::PostConnectionAction {
-        let outcome = if error.is_some() || duration < self.core.min_session() {
-            Outcome::Failure
-        } else {
-            Outcome::Success
-        };
+        let outcome = classify_outcome(error.is_some(), duration, self.core.failfast_window());
         self.core.record_outcome(Instant::now(), peer.ip(), outcome);
         audit_disconnect(peer.ip(), duration, outcome);
         // The guard must never halt the server.
@@ -454,9 +482,65 @@ mod tests {
             window: Duration::from_secs(60),
             max_attempts: 10,
             failure_threshold: 5,
-            min_session: Duration::from_secs(10),
+            failfast_window: Duration::from_secs(3),
             base_cooldown: Duration::from_secs(30),
             max_cooldown: Duration::from_secs(900),
+        }
+    }
+
+    #[test]
+    fn classify_outcome_only_counts_fast_errored_connections() {
+        let w = Duration::from_secs(3);
+        // Fast + errored = the brute-force/scan signature → Failure.
+        assert_eq!(
+            classify_outcome(true, Duration::from_millis(1), w),
+            Outcome::Failure
+        );
+        assert_eq!(
+            classify_outcome(true, Duration::from_millis(900), w),
+            Outcome::Failure
+        );
+        // Errored but ran past the window = a client that authenticated then hit
+        // session trouble (the soak false-lockout case) → Success (resets).
+        assert_eq!(
+            classify_outcome(true, Duration::from_secs(7), w),
+            Outcome::Success
+        );
+        assert_eq!(
+            classify_outcome(true, Duration::from_millis(3001), w),
+            Outcome::Success
+        );
+        // Clean disconnects never count, short or long.
+        assert_eq!(
+            classify_outcome(false, Duration::from_millis(1), w),
+            Outcome::Success
+        );
+        assert_eq!(
+            classify_outcome(false, Duration::from_secs(3600), w),
+            Outcome::Success
+        );
+    }
+
+    #[test]
+    fn reconnecting_client_with_session_errors_is_not_locked_out() {
+        // Regression for the 2026-07-01 soak: a legit client whose sessions
+        // establish then error at ~7s must NOT accrue toward a lockout.
+        let mut c = core();
+        let t0 = Instant::now();
+        let peer = ip(20);
+        let w = c.failfast_window();
+        for k in 0..20 {
+            let dur = Duration::from_secs(7); // errored after authenticating
+            c.record_outcome(
+                t0 + Duration::from_secs(k * 10),
+                peer,
+                classify_outcome(true, dur, w),
+            );
+            assert_eq!(
+                c.decide(t0 + Duration::from_secs(k * 10 + 1), peer),
+                Decision::Accept,
+                "iteration {k}: a reconnecting client must stay accepted"
+            );
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -804,12 +804,12 @@ async fn run_fork_supervisor(
     // directly — pre-spawn rate-limit/lockout + per-IP outcome recording on worker
     // drain. `None` when MACRDP_CONN_GUARD is off. Loopback is exempt in the core.
     let mut guard = auth_guard::AuthGuardCore::from_env();
-    // "Long-lived session" bar for the supervisor's outcome heuristic; falls back
-    // to the documented default when the guard is disabled but audit is still on.
-    let min_session = guard
+    // Fail-fast window for the supervisor's outcome heuristic; falls back to the
+    // documented default when the guard is disabled but audit is still on.
+    let failfast_window = guard
         .as_ref()
-        .map(|g| g.min_session())
-        .unwrap_or_else(|| std::time::Duration::from_secs(10));
+        .map(|g| g.failfast_window())
+        .unwrap_or_else(|| std::time::Duration::from_secs(3));
 
     // SCK capture-slot settle, env-overridable for hardware-in-the-loop tuning.
     let sck_settle = std::env::var(WORKER_SCK_SETTLE_ENV)
@@ -863,20 +863,13 @@ async fn run_fork_supervisor(
             .await;
             // Classify the finished worker for the guard's lockout heuristic. The
             // worker exits 0 on a clean connection end / 1 on error (see the worker
-            // branch's process::exit). Clean + long-lived ⇒ success; nonzero or
-            // short ⇒ failure; a wait/join error ⇒ don't penalize; a >timeout
-            // still-alive worker is clearly a long-lived session ⇒ success.
-            let outcome = match &waited {
-                Ok(Ok(Ok(status))) => {
-                    if status.success() && dur >= min_session {
-                        auth_guard::Outcome::Success
-                    } else {
-                        auth_guard::Outcome::Failure
-                    }
-                }
-                Ok(_) => auth_guard::Outcome::Success,
-                Err(_) => auth_guard::Outcome::Success,
-            };
+            // branch's process::exit). Only a FAST errored worker (exited non-zero
+            // within the fail-fast window — never got past the handshake) counts as
+            // a lockout failure; an errored worker that ran longer authenticated
+            // and is a legit client with session trouble, and a wait timeout /
+            // join error is treated as not-errored. See classify_outcome.
+            let errored = matches!(&waited, Ok(Ok(Ok(status))) if !status.success());
+            let outcome = auth_guard::classify_outcome(errored, dur, failfast_window);
             if waited.is_err() {
                 // Timed out: the old connection is still alive. The detached
                 // spawn_blocking keeps running and reaps it; proceed anyway so a
@@ -1632,7 +1625,7 @@ fn args_from_config(path: &Path) -> Result<Args> {
         ("GUARD_RL_MAX", "MACRDP_GUARD_RL_MAX"),
         ("GUARD_RL_WINDOW_SECS", "MACRDP_GUARD_RL_WINDOW_SECS"),
         ("GUARD_FAIL_THRESHOLD", "MACRDP_GUARD_FAIL_THRESHOLD"),
-        ("GUARD_MIN_SESSION_SECS", "MACRDP_GUARD_MIN_SESSION_SECS"),
+        ("GUARD_FAILFAST_SECS", "MACRDP_GUARD_FAILFAST_SECS"),
         (
             "GUARD_COOLDOWN_BASE_SECS",
             "MACRDP_GUARD_COOLDOWN_BASE_SECS",


### PR DESCRIPTION
Fixes a real false-lockout in v0.8.20's Tier 1.2 auth guard, **found by the Tier 2.4 soak**.

## The bug
The lockout heuristic counted **any** errored connection as a failed-auth attempt (`error || short`). So a legitimate client whose sessions established and then errored a few seconds in (mstsc reconnect-blank, a flaky network path) accrued consecutive "failures" and got locked out with escalating cooldowns. Observed live in the soak (2026-07-01):

```
accept 192.168.0.149 → disconnect duration_ms=6605..10550 outcome="failure"   (repeatedly)
reject 192.168.0.149 reason="lockout" retry_after_secs=25 → 59 → 118 → 239     (escalating)
```

Those were ~7–10 s sessions — clearly past auth — yet each errored one counted as a login attack, and mstsc's auto-retries escalated the cooldown into minutes ("couldn't log in again"). Meanwhile a different path (`10.241.251.37`) ran clean multi-hour sessions.

## The fix
Only a **fast** failure counts toward lockout: a connection that errored **and** ended within a short **fail-fast window** (default 3 s, `MACRDP_GUARD_FAILFAST_SECS`) — i.e. never got past the TLS/CredSSP handshake, the brute-force/scan signature. A connection that ran longer before erroring is treated as an authenticated legit client and **resets** the counter. Rate-limiting (attempts/window) remains the primary brute-force defense.

- New pure `classify_outcome(errored, duration, failfast_window)` shared by the single-process `ConnectionHandler` and the `--fork-workers` supervisor; unit-tested, incl. a regression reproducing the soak case.
- Renames `MACRDP_GUARD_MIN_SESSION_SECS` → `MACRDP_GUARD_FAILFAST_SECS` (default 10 → 3). Docs updated.

## Soak tooling (same finding exposed two gaps)
- `soak-monitor.sh`: `scstreams` detection was broken (system frameworks are in the dyld shared cache, so `lsof | grep ScreenCaptureKit` never matched) → replaced with **`conns`** = established client TCP connections (a reliable "client connected" signal).
- `analyze` now prints an **AUTH GUARD** section (accepts / rate-limit / lockout counts) so a lockout is visible in the report instead of needing a manual grep.

Local: fmt / clippy `-D warnings` / `cargo test` (133) green.