### PR TITLE
release: v0.8.21 — fix auth-guard false-lockout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
-Functional v0 — daily-driver usable on a trusted LAN. **Latest release: v0.8.20**
+Functional v0 — daily-driver usable on a trusted LAN. **Latest release: v0.8.21**
 (the production-readiness arc: operator-supplied TLS certs `--cert`/`--key`,
 connection rate-limiting + lockout + an auth audit log, and bounded log rotation +
-a startup reaper — Tier 1.1/1.2/2.5 of `@docs/production-readiness-roadmap.md`).
+a startup reaper — Tier 1.1/1.2/2.5 of `@docs/production-readiness-roadmap.md`.
+v0.8.21 fixes an auth-guard false-lockout that could block a legitimately
+reconnecting client — surfaced by the Tier 2.4 soak).
 RDP clients (mstsc, Microsoft Remote Desktop, FreeRDP) connect over TLS and get
 the macOS desktop with keyboard/mouse/clipboard/audio, optional H.264-over-EGFX,
 headless virtual displays, drive + smart-card redirection, and (opt-in) UDP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macrdp"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrdp"
-version = "0.8.20"
+version = "0.8.21"
 edition = "2021"
 description = "Native RDP server for macOS"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release over v0.8.20. Bundles **#115** (auth-guard fail-fast heuristic — stop locking out legitimately reconnecting clients, found by the Tier 2.4 soak).

`Cargo.toml` + `Cargo.lock` → 0.8.21; CLAUDE.md status refreshed. After merge, the `v0.8.21` tag triggers `release.yml` (builds + ad-hoc-signed artifacts → **draft** GitHub release).