### PR TITLE
docs(todo): #1397 merged; note honor-size resource-hardening follow-up

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -231,12 +231,19 @@ then delete; promote a parked item to *In flight* when work actually starts.
 
 - IronRDP forks are effectively permanent (each carries un-upstreamed divergences:
   multitransport, rdpdr server-direction, smartcard, acceptor KLID+MT, audio-lag/resize/dispatch).
-  **#1359 (rdpsnd) MERGED upstream 2026-07-01 (`2d3bdef`); open: #1373 (acceptor honor-size)
-  + #1397 (acceptor keyboard-layout on `AcceptorResult`, the one clean quick win, shipped
-  2026-07-01).** Nothing is currently de-vendorable. **Pin-bump note:** bumping the ironrdp git
-  pin past `2d3bdef` requires `src/audio.rs` to adopt the new rdpsnd handler API (`choose_format`
+  **#1359 (rdpsnd) + #1397 (acceptor keyboard-layout on `AcceptorResult`) MERGED upstream
+  2026-07-01; #1373 (acceptor honor-size) open — reviewed, 4 small changes requested.**
+  Nothing is currently de-vendorable. **Pin-bump note:** bumping the ironrdp git pin past
+  `2d3bdef` requires `src/audio.rs` to adopt the new rdpsnd handler API (`choose_format`
   + fallible `start(&NegotiatedFormat)`), dropping the hand-rolled `wFormatNo` index logic.
 - Upstream-ability of the remaining divergences was surveyed 2026-07-01 (don't re-survey; ranking
   in `project_upstream_ironrdp_open_prs` memory). The other "quick" items (RDPDR decode halves,
   AudioWave `duration_ms`, keyboard-layout handle) are **held** — no upstream consumer yet, so they
   belong with their larger feature (server-RDPDR processor, audio-lag model), not standalone PRs.
+- [ ] **Follow-up (deferred, not part of #1373): harden the honor-size resource angle.** With
+  honor-client-desktop-size ON, the client-controlled size (bounded only by the protocol
+  [200, 8192]) drives the server's encoder/surface allocation — a client can request 8192×8192
+  (~256 MB/frame) as a mild DoS. CBenoit's hint = "a clamp/range policy rather than a bare bool":
+  upgrade the option to an operator-set MAX (honored size = client request clamped to the operator
+  ceiling). Separate future upstream PR. macrdp-side counterpart: a `--max-client-size` (or cap to
+  the Mac's native resolution). Neither blocks #1373. See `project_upstream_ironrdp_open_prs` memory.


### PR DESCRIPTION
Docs-only. Marks IronRDP #1397 (acceptor keyboard-layout) merged, and records the deferred follow-up from CBenoit's #1373 review — upgrading the honor-size on/off flag to an operator-set max size (clamp/range) so a client can't drive a large allocation. Not part of #1373.