### PR TITLE
chore: soak follow-ups — quiet multitransport logs, sync soak CSV, document posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Short version: **a polished v0 daily-driver for trusted LANs — not an enterpri
 - **The UDP multitransport / lossy-audio paths are EXPERIMENTAL** (opt-in, default OFF) — robust in testing but newer and less soaked than the TCP core, which remains the default everything rides on.
 - **It's a solo v0** built on vendored [IronRDP](https://github.com/Devolutions/IronRDP) forks — no commercial support or SLA.
 
-If your use case is "remote into my own Mac over my LAN/VPN," it's in good shape. If it's unattended production, untrusted networks, or multi-user, it isn't there yet — see [`docs/production-readiness-roadmap.md`](docs/production-readiness-roadmap.md) for what would close that gap (real TLS certs ✓ done; auth hardening ✓ done; a multi-day soak still open) and what can't be (multi-user GUI sessions, on macOS).
+If your use case is "remote into my own Mac over my LAN/VPN," it's in good shape. If it's unattended production, untrusted networks, or multi-user, it isn't there yet — see [`docs/production-readiness-roadmap.md`](docs/production-readiness-roadmap.md) for what would close that gap (real TLS certs ✓ done; auth hardening ✓ done; a multi-day soak — foundation core passed a 31 h leak/drift run, full 48–72 h on the latest build still open) and what can't be (multi-user GUI sessions, on macOS).
 
 ## Quick start
 
@@ -400,6 +400,10 @@ Both restore the original layout when the last client disconnects, and both auto
 ./macrdp
 
 # Accept LAN connections, force a non-$USER account.
+# NETWORK EXPOSURE: --bind 0.0.0.0 opens the port to your LAN. Keep it on a
+# network you control. Do NOT port-forward / expose it to the public internet —
+# even with TLS + NLA/CredSSP + rate-limit/lockout, the production answer for any
+# RDP server is to reach it over a VPN or an RD Gateway, never a raw public IP.
 ./macrdp --bind 0.0.0.0:3390 --username clint
 
 # Higher frame rate, custom cert dir.

--- a/docs/production-readiness-roadmap.md
+++ b/docs/production-readiness-roadmap.md
@@ -39,9 +39,12 @@ are scope limits, not gaps to close.
    (errored/very-short ⇒ failure; clean long session resets), so a benign disconnect never
    locks anyone out. Not done here: precise CredSSP-failure classification (would need a
    vendored signal — intentionally avoided).
-3. **Document the posture honestly.** Even hardened, internet-facing RDP is a bad idea
-   for *any* server — the production answer is "behind a VPN or an RD Gateway." Make that
-   explicit alongside Tier 1.1.
+3. **Document the posture honestly — DONE.** Even hardened, internet-facing RDP is a bad
+   idea for *any* server — the production answer is "behind a VPN or an RD Gateway." This is
+   stated in the README **§Production readiness** (the "Short version" line: don't put it on a
+   public IP, and the trusted-LAN-scope limitation: put internet-facing RDP behind a VPN / RD
+   Gateway), and reinforced by a **Network exposure** note next to the LAN-bind examples in
+   **§Examples**. See also `@docs/macos-gotchas.md` (port 3389 privileged → 3390 default).
 
 ## Tier 2 — Reliability / unattended operation
 

--- a/scripts/soak-monitor.sh
+++ b/scripts/soak-monitor.sh
@@ -71,9 +71,17 @@ cmd_monitor() {
     fi
     echo "monitoring pid $pid every ${interval}s -> $out" >&2
     echo "ts,rss_mb,threads,fds,conns,procs,nfs_mounts,tmp_dirs,log_mb" > "$out"
+    # Flush to disk after every append. At 1 sample/min the cost is nil, and it
+    # guarantees the on-disk CSV always reflects the samples — so pulling the file
+    # mid-run (or an interrupted transfer off the soak box) can't come back with
+    # allocated-but-unflushed blocks reading as zeros (which is what happened once
+    # — see docs/production-readiness-roadmap.md Tier 2.4). `sync` is coarse but
+    # portable; a per-fd F_FULLFSYNC isn't reachable from shell.
+    sync
     while row="$(sample_row "$pid")"; do
         echo "$row" >> "$out"
         echo "$row"
+        sync
         sleep "$interval"
     done
     echo "pid $pid exited; samples in $out" >&2

--- a/vendor/ironrdp-server/src/multitransport/audio_dvc.rs
+++ b/vendor/ironrdp-server/src/multitransport/audio_dvc.rs
@@ -269,7 +269,7 @@ impl DvcProcessor for AudioLossyDvc {
                     Some(idx) => {
                         let is_aac = cf.formats[idx].format == WaveFormat::AAC_MS;
                         self.chosen_format_no = Some(u16::try_from(idx).unwrap_or(0));
-                        warn!(
+                        debug!(
                             channel = self.channel_name,
                             client_formats = cf.formats.len(),
                             chosen_wformatno = idx,
@@ -302,7 +302,7 @@ impl DvcProcessor for AudioLossyDvc {
                 if let (Some(shared), Some(idx)) = (self.negotiated.as_ref(), self.chosen_format_no) {
                     shared.set(idx);
                 }
-                warn!(
+                debug!(
                     channel = self.channel_name,
                     chosen_wformatno = ?self.chosen_format_no,
                     "P2.4b GREEN: reliable audio DVC negotiated + training confirmed over TCP — \

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -720,7 +720,7 @@ async fn run_recv_loop(
                     [0xFE, 0xFD] => "DTLS 1.2",
                     _ => "DTLS",
                 };
-                warn!(
+                debug!(
                     %peer_addr, %dtls,
                     "P2.0 SPIKE GREEN: client opened a LOSSY (UdpFecL) UDP flow — \
                      it sent a {dtls} ClientHello. Lossy multitransport is reachable; \
@@ -838,7 +838,7 @@ async fn run_recv_loop(
                         }
                         if !dtls_err && conn.is_handshake_done() && !*dtls_done_logged {
                             *dtls_done_logged = true;
-                            warn!(
+                            debug!(
                                 %peer_addr,
                                 "P2.1 GREEN: DTLS 1.2 handshake COMPLETE on the LOSSY (UdpFecL) flow — MS-RDPEMT-over-DTLS reachable"
                             );
@@ -865,7 +865,7 @@ async fn run_recv_loop(
                                             let o = sm.enqueue(now_ms, &dg);
                                             send_datagrams(&socket, peer_addr, o.to_send, cfg.mtu).await;
                                         }
-                                        warn!(
+                                        debug!(
                                             %peer_addr,
                                             "P2.4 GREEN: MS-RDPEMT tunnel ESTABLISHED over DTLS (lossy flow) — CREATERESPONSE(S_OK) sent"
                                         );


### PR DESCRIPTION
The three cheap wins surfaced by the Tier 2.4 soak analysis (PR #123).

## #3 — Quiet the multitransport "GREEN" log noise
Demote the `multitransport`/`audio_dvc` status markers from **WARN → DEBUG** (`vendor/ironrdp-server/src/multitransport/{listener,audio_dvc}.rs`, 5 call sites). They're dev-era "P2.x spike" milestones — "tunnel ESTABLISHED", "DTLS handshake COMPLETE", "audio DVC negotiated" — not warnings, and were **135 lines of noise** in the soak log. Genuine warnings in those files (decrypt errors, malformed PDUs, write failures) are left at WARN.

## #4 — Make the soak CSV crash/transfer-safe
`scripts/soak-monitor.sh` now `sync`s after every CSV append. At 1 sample/min the cost is nil, and it guarantees the on-disk file always reflects the samples — so pulling the file mid-run (or an interrupted transfer off the soak box) can't come back **zero-filled**, which is exactly what happened to the first transfer of the 2026-07-01 run.

## #5 — Document the security posture (Tier 1.3 → DONE)
- README **§Examples**: a **Network exposure** note right next to the `--bind 0.0.0.0` example — keep it on a trusted network; internet-facing RDP goes **behind a VPN / RD Gateway**, never a raw public IP (the production answer for any RDP server).
- Marked Tier 1.3 **DONE** in `docs/production-readiness-roadmap.md` (the posture was already stated in README §Production readiness; this makes it explicit at the point of use and closes the roadmap item).
- Refreshed the README's stale soak-status line to the **31 h foundation-core pass**.

## Verification
`cargo build` clean (vendored server compiles with the demotion; `warn` still used, no unused-import); `bash -n scripts/soak-monitor.sh` OK; docs-only otherwise.