### PR TITLE
feat(health): health-check watchdog to bounce a hung-but-alive process

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Short version: **a polished v0 daily-driver for trusted LANs — not an enterpri
 - Real auth — TLS + NLA/CredSSP against the macOS account via PAM, password from the Keychain. TLS can use a real CA / ACME / Let's Encrypt cert (`--cert`/`--key`), or the self-signed default. Per-IP connection **rate-limiting + lockout + an audit log** sit in front of the auth gate (on by default, loopback-exempt).
 - The full daily workflow — display, keyboard/mouse (incl. non-US layouts, Cmd+Tab, optional Ctrl→Cmd), clipboard text/images/files both ways, system audio, drive + smart-card redirection, headless virtual displays.
 - H.264/EGFX with **congestion-responsive rate control** — under packet loss it degrades gracefully (bitrate backs off → fps sheds at the floor → stays choppy-but-in-sync) instead of freezing, and audio can ride a loss-resilient lossy-UDP path.
-- Deployable — signed + notarized `.app`, a LaunchAgent, and a menu-bar GUI controller; TCC grants survive rebuilds.
+- Deployable — signed + notarized `.app`, a LaunchAgent, and a menu-bar GUI controller; TCC grants survive rebuilds. A **health-check watchdog** bounces a hung-but-alive process so launchd restarts it (not just on crash).
 - Tested — 130+ unit tests + a regression harness, run in CI on every push.
 
 **Known limitations — read before relying on it:**

--- a/TODO.md
+++ b/TODO.md
@@ -212,9 +212,12 @@ then delete; promote a parked item to *In flight* when work actually starts.
   rate-limit + lockout + audit log (`src/auth_guard.rs`) **DONE 2026-06-30 #105**; (3) a
   48–72 h **soak to shake out leaks/drift — IN FLIGHT (Tier 2.4, running 2026-07-01; see
   the In flight section above + `scripts/soak-monitor.sh`)**. Also done:
-  log rotation + startup reaper (Tier 2.5, #103). Still open beyond the soak: Tier 2.5
-  hung-but-alive health-check/bounce; Tier 3 polish. Hard ceiling (NO-GO): multi-user
-  concurrent GUI sessions (macOS limit).
+  log rotation + startup reaper (Tier 2.5, #103) and the **hung-but-alive health-check
+  watchdog (`src/health.rs`) — DONE 2026-07-03** (probes the tokio runtime from a
+  dedicated OS thread; exits code 70 on a sustained wedge → launchd/supervisor restarts;
+  on by default when headless, env-tunable). **Tier 2.5 now complete.** Still open beyond
+  the soak: the `--fork-workers`-as-default decision (Tier 2.6); Tier 3 polish. Hard
+  ceiling (NO-GO): multi-user concurrent GUI sessions (macOS limit).
 
 ## Parked — scoped, low priority
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,6 +198,22 @@ src/reaper.rs     Startup reaper — on launch, sweeps leftovers from a PRIOR ma
                   instance live. Called once from async_main on a detached thread
                   (a stale umount can't block startup); covers single-process,
                   the fork supervisor, and each worker.
+src/health.rs     Health-check watchdog (Tier 2.5) — turns a hung-but-alive
+                  process into a clean exit so launchd KeepAlive / the
+                  --fork-workers supervisor restarts a fresh one (KeepAlive only
+                  catches an outright crash, not a wedge). A dedicated OS thread
+                  (NOT a tokio task, so it ticks even when the runtime is wedged)
+                  submits a trivial probe onto the tokio runtime each interval and
+                  waits a bounded time; a deadlocked runtime never runs it, and
+                  after N consecutive misses it process::exits with code 70. Pure,
+                  unit-tested decision + parsing (should_arm / HealthConfig); armed
+                  from async_main on the long-lived launchd-watched process
+                  (single-process OR supervisor), skipped on short-lived fork
+                  workers and (by default) interactively (stdout a TTY).
+                  Conservative defaults (15s interval / 30s timeout / 2 misses ⇒
+                  ~90s to bounce). Env: MACRDP_HEALTHCHECK=0/1 +
+                  MACRDP_HEALTHCHECK_{INTERVAL_SECS,TIMEOUT_SECS,FAILURES}
+                  (config.env HEALTH_CHECK / HEALTHCHECK_*). Cross-platform.
 build.rs          Bakes Xcode Swift-runtime rpath into the final binary
 
 vendor/ironrdp-server/    Local fork of ironrdp-server 0.10.0, pulled in via

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -237,6 +237,29 @@ first-connect cert-prompt "Broken pipe") never does either. Audit lines are tagg
 `event="accept|reject|disconnect"` with the source IP and (for rejects) the reason
 and retry-after.
 
+Health-check watchdog (env-only; **on by default when headless**). Detects a
+**hung-but-alive** process — the tokio runtime deadlocked / all workers blocked —
+and exits (code 70) so the LaunchAgent `KeepAlive` (or the `--fork-workers`
+supervisor) restarts a fresh one. `KeepAlive` alone only restarts on an outright
+crash, not a wedge; this closes that gap. It's armed on the long-lived
+launchd-watched process (single-process serve or the supervisor) and **skipped on
+short-lived fork workers** and, by default, **interactively** (stdout is a TTY,
+e.g. `cargo run` — a false bounce there would just kill a dev session, and nothing
+would restart it). Defaults are conservative — a wedge must persist ~90 s before a
+bounce, so load spikes never trip it. Tune / force / disable via env (or the
+matching `config.env` keys):
+```
+MACRDP_HEALTHCHECK=1                 # force on (even interactive); 0/off = disable
+MACRDP_HEALTHCHECK_INTERVAL_SECS=15  # delay between liveness probes
+MACRDP_HEALTHCHECK_TIMEOUT_SECS=30   # max time a probe may take before it's a miss
+MACRDP_HEALTHCHECK_FAILURES=2        # consecutive misses before the process exits
+```
+The mechanism: a dedicated OS thread (not a tokio task, so it keeps ticking even
+when the runtime it watches is wedged) submits a trivial probe onto the runtime
+each interval and waits `TIMEOUT_SECS` for it to run; a deadlocked runtime never
+runs it. A bounce logs `health-check watchdog: tokio runtime wedged …` before
+exiting.
+
 Testing against the server:
 ```bash
 # FreeRDP — easiest to script and get verbose logs from.

--- a/docs/production-readiness-roadmap.md
+++ b/docs/production-readiness-roadmap.md
@@ -81,7 +81,7 @@ are scope limits, not gaps to close.
      periodically (or tee key events to the crash-durable macOS unified log) so a transfer/
      interruption can't zero-fill the record; and the `multitransport`/`audio_dvc` "GREEN"
      status lines log at WARN — demote to INFO/DEBUG to cut soak noise.
-5. **Robust teardown + log rotation.** *(log rotation + startup reaper SHIPPED 2026-06-30.)*
+5. **Robust teardown + log rotation.** *(log rotation + startup reaper SHIPPED 2026-06-30; health-check watchdog SHIPPED 2026-07-03 — Tier 2.5 complete.)*
    - **Log rotation — DONE.** `~/Library/Logs/macrdp.log` is now a self-owned, size-bounded
      rotating file (`src/logging.rs`: `macrdp.log` + N logrotate-style archives, default
      10 MiB × 5; tunable via `MACRDP_LOG_MAX_BYTES`/`MACRDP_LOG_MAX_FILES`). The plist no
@@ -93,8 +93,20 @@ are scope limits, not gaps to close.
      `$TMPDIR/macrdp-{rdpdr,paste,lazy-paste}-<pid>` dirs), dead-pid-gated so it's safe with
      another instance live. (SCStreams / virtual display / blanking were already process-scoped
      and auto-restore.)
-   - **Still TODO:** a lightweight **health-check** that detects a hung-but-alive process and
-     bounces it (LaunchAgent `KeepAlive` already restarts on outright crash, but not on a hang).
+   - **Health-check watchdog — DONE (2026-07-03).** `src/health.rs`: a dedicated OS thread
+     (not a tokio task, so it survives a wedged runtime) periodically submits a trivial probe
+     onto the tokio runtime and waits a bounded time for it to run. A deadlocked runtime never
+     runs it; after N consecutive misses the watchdog `process::exit`s with a distinct code
+     (70/EX_SOFTWARE) so `KeepAlive`/the `--fork-workers` supervisor restarts a fresh process —
+     closing the "alive but wedged" gap `KeepAlive` alone can't. Conservative by default (15 s
+     interval, 30 s timeout, 2 misses ⇒ a wedge must persist ~90 s before a bounce, so load
+     spikes never trip it). Armed on the long-lived launchd-watched process (single-process serve
+     OR the supervisor); skipped on short-lived fork *workers* and, by default, interactively
+     (stdout a TTY). Env: `MACRDP_HEALTHCHECK=0/1` + `MACRDP_HEALTHCHECK_{INTERVAL_SECS,TIMEOUT_SECS,FAILURES}`
+     (config.env keys `HEALTH_CHECK` / `HEALTHCHECK_*`). Verified: arms headless, no false bounce
+     on an idle runtime. **Scope:** targets runtime-level hangs (deadlock / all workers blocked);
+     a listener-level heartbeat for "accept loop silently stopped while the runtime is healthy"
+     is a possible follow-up.
 6. **Make `--fork-workers` the production default.** It's what fixes the mstsc
    reconnect-blank that bites real users; recommend (or default) it for unattended
    deployments. Note it's mutually exclusive with `--enable-udp-multitransport`.

--- a/packaging/config.env.example
+++ b/packaging/config.env.example
@@ -51,6 +51,17 @@ USE_KEYCHAIN=1
 #                              # Auto-expires (no manual unlock); a clean session resets.
 # GUARD_COOLDOWN_MAX_SECS=900  # lockout escalation cap (15 min)
 
+# --- Health-check watchdog (on by default when headless / under launchd) ---
+# Detects a hung-but-alive process (deadlocked tokio runtime / all workers
+# blocked) and exits so the LaunchAgent restarts a fresh one — KeepAlive alone
+# only restarts on an outright crash, not a wedge. Skipped on --fork-workers
+# workers and, by default, interactively. Conservative defaults (~90 s to bounce)
+# so load spikes never trip it. Rarely need changing.
+# HEALTH_CHECK=1                # force on even interactive; 0/off = disable
+# HEALTHCHECK_INTERVAL_SECS=15  # delay between liveness probes
+# HEALTHCHECK_TIMEOUT_SECS=30   # max time a probe may take before it's a miss
+# HEALTHCHECK_FAILURES=2        # consecutive misses before the process exits
+
 # Feature toggles (1 = on, 0 = off).
 ENABLE_H264=0
 ENABLE_AAC=0

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,267 @@
+//! Health-check watchdog — turn a hung-but-alive process into a clean exit so
+//! the launchd `KeepAlive` (or, under `--fork-workers`, the supervisor) revives
+//! a fresh one.
+//!
+//! `launchd` only restarts macrdp when the process *dies*. A process that is
+//! alive but **wedged** — the tokio runtime deadlocked, every worker thread
+//! blocked on a poisoned mutex or a blocking syscall, the accept loop stuck —
+//! keeps running and unreachable, and nothing revives it. That's the one
+//! production gap `KeepAlive` can't close on its own; this watchdog closes it.
+//!
+//! ## Mechanism
+//!
+//! A dedicated **OS thread** (deliberately *not* a tokio task, so it keeps
+//! ticking even when the runtime it watches is wedged) periodically submits a
+//! trivial probe task onto the runtime and waits a bounded time for it to run.
+//! A healthy runtime executes the probe in microseconds; a deadlocked one never
+//! does. After `failures_before_exit` consecutive misses the watchdog logs and
+//! [`std::process::exit`]s with a distinct code, so the supervisor/launchd
+//! starts a clean process.
+//!
+//! It is intentionally conservative — a generous timeout plus a
+//! multiple-consecutive-miss requirement — so a merely busy runtime (a heavy
+//! encode burst, a GC pause) is never mistaken for a wedge. It only fires on a
+//! genuine, sustained inability to run *any* task, which is exactly the
+//! hung-but-alive failure mode.
+//!
+//! ## What it does NOT catch
+//!
+//! A logic bug that silently stops the *accept loop* while the runtime itself
+//! stays healthy (tasks still run) is out of scope — detecting that without
+//! false-positiving on a legitimately idle server needs a listener-level
+//! heartbeat, a separate follow-up. This watchdog targets runtime-level hangs,
+//! which are the common "alive but wedged" case.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use tracing::{error, info, warn};
+
+/// Exit code used when the watchdog fires. `launchd`'s `KeepAlive` restarts on
+/// any nonzero exit; a distinct, stable code (EX_SOFTWARE from `sysexits.h`)
+/// makes "the watchdog bounced us" greppable in the logs / crash reports.
+pub const WATCHDOG_EXIT_CODE: i32 = 70;
+
+/// Watchdog timing. Defaults are deliberately generous (a wedge must persist
+/// ~60–90 s before a bounce) so normal load spikes never trip it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HealthConfig {
+    /// Delay between probes.
+    pub probe_interval: Duration,
+    /// Max time a single probe may take before it counts as a miss.
+    pub timeout: Duration,
+    /// Consecutive misses required before exiting.
+    pub failures_before_exit: u32,
+}
+
+impl Default for HealthConfig {
+    fn default() -> Self {
+        Self {
+            probe_interval: Duration::from_secs(15),
+            timeout: Duration::from_secs(30),
+            failures_before_exit: 2,
+        }
+    }
+}
+
+impl HealthConfig {
+    /// Read tunables from the environment, falling back to [`Self::default`] for
+    /// any unset / unparsable / zero value:
+    /// `MACRDP_HEALTHCHECK_INTERVAL_SECS`, `_TIMEOUT_SECS`, `_FAILURES`.
+    pub fn from_env() -> Self {
+        let d = Self::default();
+        Self {
+            probe_interval: parse_secs(
+                std::env::var("MACRDP_HEALTHCHECK_INTERVAL_SECS")
+                    .ok()
+                    .as_deref(),
+                d.probe_interval,
+            ),
+            timeout: parse_secs(
+                std::env::var("MACRDP_HEALTHCHECK_TIMEOUT_SECS")
+                    .ok()
+                    .as_deref(),
+                d.timeout,
+            ),
+            failures_before_exit: parse_u32(
+                std::env::var("MACRDP_HEALTHCHECK_FAILURES").ok().as_deref(),
+                d.failures_before_exit,
+            ),
+        }
+    }
+}
+
+/// Decide whether to arm the watchdog for this process.
+///
+/// - A fork **worker** never arms it: the worker is short-lived (one connection
+///   then exits) and the supervisor owns its liveness.
+/// - An explicit `MACRDP_HEALTHCHECK=1/0` (on/off/true/false/yes/no) wins.
+/// - Otherwise the default is **on when headless** (stdout is not a TTY, i.e.
+///   running under launchd, which will restart a bounced process) and **off**
+///   interactively (`cargo run` in a terminal — a false bounce there just kills
+///   a dev session, and nothing would restart it anyway).
+pub fn should_arm(is_worker: bool, stdout_is_tty: bool, env_override: Option<&str>) -> bool {
+    if is_worker {
+        return false;
+    }
+    match env_override
+        .map(|s| s.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("1") | Some("on") | Some("true") | Some("yes") => true,
+        Some("0") | Some("off") | Some("false") | Some("no") => false,
+        _ => !stdout_is_tty,
+    }
+}
+
+/// Spawn the watchdog OS thread against `handle` (a handle to the tokio runtime
+/// whose liveness is probed). Returns immediately; the thread runs for the
+/// process lifetime, or until it fires and exits the process.
+pub fn spawn(handle: tokio::runtime::Handle, cfg: HealthConfig) {
+    info!(
+        interval_secs = cfg.probe_interval.as_secs(),
+        timeout_secs = cfg.timeout.as_secs(),
+        failures = cfg.failures_before_exit,
+        "health-check watchdog armed"
+    );
+    let _ = std::thread::Builder::new()
+        .name("macrdp-watchdog".into())
+        .spawn(move || run(handle, cfg));
+}
+
+fn run(handle: tokio::runtime::Handle, cfg: HealthConfig) {
+    let mut consecutive_misses: u32 = 0;
+    loop {
+        std::thread::sleep(cfg.probe_interval);
+        if probe_ok(&handle, cfg.timeout) {
+            if consecutive_misses > 0 {
+                info!("health-check watchdog: tokio runtime responsive again");
+            }
+            consecutive_misses = 0;
+            continue;
+        }
+        consecutive_misses += 1;
+        warn!(
+            miss = consecutive_misses,
+            of = cfg.failures_before_exit,
+            timeout_secs = cfg.timeout.as_secs(),
+            "health-check watchdog: tokio runtime did not answer a liveness probe"
+        );
+        if consecutive_misses >= cfg.failures_before_exit {
+            error!(
+                exit_code = WATCHDOG_EXIT_CODE,
+                misses = consecutive_misses,
+                "health-check watchdog: tokio runtime wedged across consecutive probes — \
+                 exiting so the supervisor / launchd restarts a fresh process"
+            );
+            // Flush is best-effort; the wedge is by definition unrecoverable
+            // in-process, and a restart is the only cure.
+            std::process::exit(WATCHDOG_EXIT_CODE);
+        }
+    }
+}
+
+/// Submit a trivial task onto the runtime and wait up to `timeout` for it to
+/// run. Returns `false` only if the runtime could not execute it in time.
+fn probe_ok(handle: &tokio::runtime::Handle, timeout: Duration) -> bool {
+    let (tx, rx) = mpsc::sync_channel::<()>(1);
+    // Spawning on a runtime that is being torn down (clean process shutdown)
+    // can panic; catch it so the watchdog thread can never itself crash the
+    // process on the exit path. A missing runtime means we're already exiting —
+    // report healthy so we don't race a spurious bounce against a clean stop.
+    let spawned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        handle.spawn(async move {
+            let _ = tx.send(());
+        });
+    }));
+    if spawned.is_err() {
+        return true;
+    }
+    // Blocks this OS thread (not a runtime thread) until the probe runs or the
+    // deadline passes. If the runtime is merely slow, a later-arriving probe
+    // just sends on the already-dropped receiver and is discarded — no leak.
+    rx.recv_timeout(timeout).is_ok()
+}
+
+/// Parse a positive-seconds env value, falling back to `default` for
+/// unset/unparsable/zero.
+fn parse_secs(raw: Option<&str>, default: Duration) -> Duration {
+    raw.and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(default)
+}
+
+/// Parse a positive `u32` env value, falling back to `default` for
+/// unset/unparsable/zero.
+fn parse_u32(raw: Option<&str>, default: u32) -> u32 {
+    raw.and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_never_arms_even_with_env_on() {
+        assert!(!should_arm(true, false, Some("1")));
+        assert!(!should_arm(true, false, None));
+    }
+
+    #[test]
+    fn explicit_env_override_wins_over_tty() {
+        // Forced on even in an interactive terminal.
+        assert!(should_arm(false, true, Some("1")));
+        assert!(should_arm(false, true, Some("on")));
+        assert!(should_arm(false, true, Some(" TRUE ")));
+        // Forced off even when headless.
+        assert!(!should_arm(false, false, Some("0")));
+        assert!(!should_arm(false, false, Some("off")));
+    }
+
+    #[test]
+    fn default_is_on_headless_off_interactive() {
+        assert!(should_arm(false, false, None)); // headless -> on
+        assert!(!should_arm(false, true, None)); // TTY -> off
+                                                 // An unrecognized override falls through to the TTY default.
+        assert!(should_arm(false, false, Some("maybe")));
+    }
+
+    #[test]
+    fn parse_secs_falls_back_on_bad_or_zero() {
+        let d = Duration::from_secs(30);
+        assert_eq!(parse_secs(Some("45"), d), Duration::from_secs(45));
+        assert_eq!(parse_secs(Some("0"), d), d); // zero is nonsensical -> default
+        assert_eq!(parse_secs(Some("nope"), d), d);
+        assert_eq!(parse_secs(None, d), d);
+    }
+
+    #[test]
+    fn parse_u32_falls_back_on_bad_or_zero() {
+        assert_eq!(parse_u32(Some("3"), 2), 3);
+        assert_eq!(parse_u32(Some("0"), 2), 2); // must fail at least once
+        assert_eq!(parse_u32(Some(""), 2), 2);
+        assert_eq!(parse_u32(None, 2), 2);
+    }
+
+    #[test]
+    fn default_config_is_conservative() {
+        let c = HealthConfig::default();
+        // A wedge must persist well over a minute before a bounce.
+        let worst = (c.probe_interval + c.timeout) * c.failures_before_exit;
+        assert!(worst >= Duration::from_secs(60));
+    }
+
+    #[test]
+    fn probe_reports_healthy_on_a_live_runtime() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        // A healthy runtime runs the probe well within the deadline.
+        assert!(probe_ok(&rt.handle().clone(), Duration::from_secs(5)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod file_promise;
 mod file_promise_lazy;
 #[cfg(target_os = "macos")]
 mod h264;
+mod health;
 mod input;
 mod keyboard_layout;
 mod logging;
@@ -37,7 +38,7 @@ mod videotoolbox;
 mod virtual_display;
 
 use std::fs;
-use std::io::BufReader;
+use std::io::{BufReader, IsTerminal};
 use std::net::SocketAddr;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
@@ -1641,6 +1642,18 @@ fn args_from_config(path: &Path) -> Result<Args> {
             "MACRDP_GUARD_COOLDOWN_BASE_SECS",
         ),
         ("GUARD_COOLDOWN_MAX_SECS", "MACRDP_GUARD_COOLDOWN_MAX_SECS"),
+        // Health-check watchdog (env-driven like the auth guard; on by default
+        // when headless). See src/health.rs.
+        ("HEALTH_CHECK", "MACRDP_HEALTHCHECK"),
+        (
+            "HEALTHCHECK_INTERVAL_SECS",
+            "MACRDP_HEALTHCHECK_INTERVAL_SECS",
+        ),
+        (
+            "HEALTHCHECK_TIMEOUT_SECS",
+            "MACRDP_HEALTHCHECK_TIMEOUT_SECS",
+        ),
+        ("HEALTHCHECK_FAILURES", "MACRDP_HEALTHCHECK_FAILURES"),
     ] {
         if let Some(val) = cfg.get(cfg_key) {
             if !val.is_empty() {
@@ -1713,6 +1726,25 @@ async fn async_main() -> Result<()> {
     let supervisor_vd_id: Option<u32> = std::env::var(WORKER_VD_ID_ENV)
         .ok()
         .and_then(|s| s.parse::<u32>().ok());
+
+    // Arm the health-check watchdog on the long-lived, launchd-watched process
+    // (single-process serve OR the --fork-workers supervisor) so a hung-but-alive
+    // runtime — which KeepAlive can't tell from a healthy one — gets bounced into
+    // a restart. Skipped on a fork *worker* (short-lived; the supervisor owns its
+    // liveness) and, by default, when interactive (stdout is a TTY, e.g.
+    // `cargo run`, where nothing would restart a bounce). MACRDP_HEALTHCHECK=0/1
+    // overrides; see src/health.rs.
+    if health::should_arm(
+        worker_fd.is_some(),
+        std::io::stdout().is_terminal(),
+        std::env::var("MACRDP_HEALTHCHECK").ok().as_deref(),
+    ) {
+        health::spawn(
+            tokio::runtime::Handle::current(),
+            health::HealthConfig::from_env(),
+        );
+    }
+
     if args.fork_workers && worker_fd.is_none() {
         // Supervisor role.
         //


### PR DESCRIPTION
Closes the last open **Tier 2.5** production-readiness gap.

## Problem
launchd's `KeepAlive` only restarts macrdp when the process *dies*. A process that is alive but **wedged** — the tokio runtime deadlocked, every worker thread blocked, the accept loop stuck — keeps running and unreachable, and nothing revives it.

## Fix — `src/health.rs`
A dedicated **OS thread** (not a tokio task, so it keeps ticking even when the runtime it watches is wedged) periodically submits a trivial probe onto the tokio runtime and waits a bounded time for it to run. A healthy runtime runs it in microseconds; a deadlocked one never does. After N consecutive misses it `process::exit`s with a distinct code (70 / `EX_SOFTWARE`) so `KeepAlive` / the `--fork-workers` supervisor restarts a fresh process.

- **Conservative by default** — 15 s interval, 30 s timeout, 2 misses ⇒ a wedge must persist ~90 s before a bounce, so load spikes (encode bursts, GC pauses) never trip it.
- **Scoped to the right process** — armed on the long-lived launchd-watched process (single-process serve **or** the supervisor); **skipped** on short-lived fork *workers* (the supervisor owns their liveness) and, by default, **interactively** (stdout a TTY — a false bounce in `cargo run` would just kill a dev session, and nothing would restart it).
- **Env-driven** like the auth guard: `MACRDP_HEALTHCHECK=0/1` + `MACRDP_HEALTHCHECK_{INTERVAL_SECS,TIMEOUT_SECS,FAILURES}` (config.env keys `HEALTH_CHECK` / `HEALTHCHECK_*`).
- **Narrow seam** — one new self-contained module + a ~10-line arm call in `async_main`; the default path is byte-unchanged when disabled/interactive.

## Verification
- 7 unit tests (pure `should_arm` decision matrix, env parsing fallback, a live-runtime probe returning healthy). Full suite 146 pass.
- Live smoke test: launched headless with a fast probe (2 s/2 s/2), armed cleanly (`health-check watchdog armed …`), ran ~6 probe cycles on an idle runtime, **no false bounce** — exited only on SIGTERM.
- `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.

## Scope / follow-up
Targets **runtime-level** hangs (deadlock / all workers blocked). A logic bug that silently stops the *accept loop* while the runtime stays healthy is out of scope — detecting that without false-positiving on a legitimately idle server needs a listener-level heartbeat, a possible follow-up.