### PR TITLE
docs: Tier 2.6 DECIDED — fork-workers stays opt-in; blank-recovery is the default

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -238,8 +238,11 @@ then delete; promote a parked item to *In flight* when work actually starts.
   log rotation + startup reaper (Tier 2.5, #103) and the **hung-but-alive health-check
   watchdog (`src/health.rs`) — DONE 2026-07-03** (probes the tokio runtime from a
   dedicated OS thread; exits code 70 on a sustained wedge → launchd/supervisor restarts;
-  on by default when headless, env-tunable). **Tier 2.5 now complete.** Still open beyond
-  the soak: the `--fork-workers`-as-default decision (Tier 2.6); Tier 3 polish. Hard
+  on by default when headless, env-tunable). **Tier 2.5 now complete.** Tier 2.6
+  (`--fork-workers` as default) **DECIDED 2026-07-04: NO** — single-process +
+  blank-recovery + ARC stays the default (field-proven, composes with everything);
+  fork-workers stays the documented opt-in for mstsc-heavy no-UDP profiles (see the
+  roadmap for the full rationale). Still open beyond the soak: Tier 3 polish. Hard
   ceiling (NO-GO): multi-user concurrent GUI sessions (macOS limit).
 
 ## Parked — scoped, low priority

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -161,8 +161,16 @@ Useful CLI flags (see `src/main.rs::Args` for the full set):
                           #   internet links on plain TCP until the tunnel
                           #   keepalive/clean-close fix lands (see TODO.md).
                           #   macOS-only.
---fork-workers            # EXPERIMENTAL, opt-in (default OFF; FORK_WORKERS=1 in
-                          #   config.env). xrdp's model on macOS: a thin supervisor
+--fork-workers            # Opt-in (default OFF; FORK_WORKERS=1 in config.env) —
+                          #   and staying opt-in by DECISION (2026-07-04, roadmap
+                          #   Tier 2.6): the production default is single-process +
+                          #   blank-recovery + the auto-reconnect cookie (field-
+                          #   proven, composes with every feature). Choose
+                          #   --fork-workers for mstsc-heavy, no-UDP deployments
+                          #   that want blip-free reconnects + per-connection
+                          #   isolation; it COMPOSES with blank-recovery (recovery
+                          #   drops land on a fresh worker = strongest combo).
+                          #   xrdp's model on macOS: a thin supervisor
                           #   binds the port and fork+execs a FRESH worker process
                           #   per connection (socket via MACRDP_WORKER_FD). The fresh
                           #   process dodges mstsc's reconnect-blank (it re-maps a

--- a/docs/production-readiness-roadmap.md
+++ b/docs/production-readiness-roadmap.md
@@ -107,9 +107,31 @@ are scope limits, not gaps to close.
      on an idle runtime. **Scope:** targets runtime-level hangs (deadlock / all workers blocked);
      a listener-level heartbeat for "accept loop silently stopped while the runtime is healthy"
      is a possible follow-up.
-6. **Make `--fork-workers` the production default.** It's what fixes the mstsc
-   reconnect-blank that bites real users; recommend (or default) it for unattended
-   deployments. Note it's mutually exclusive with `--enable-udp-multitransport`.
+6. **Make `--fork-workers` the production default — DECIDED 2026-07-04: NO.
+   Single-process + blank-recovery + ARC stays the default; `--fork-workers` stays a
+   documented opt-in.** This item was written when fork-workers was the *only* answer to
+   the mstsc reconnect-blank; that's no longer true, and the calculus settled against it:
+   - **Blank-recovery is field-proven; fork-workers isn't.** The v0.8.22 recovery +
+     v0.8.24 drop-first tuning healed real blanks repeatedly and unattended in the wild
+     (the 2026-07-04 ZeroTier cycle: detect → drop → ARC auto-reconnect → render, ×2,
+     zero false positives). fork-workers has demo-grade verification, zero soak hours,
+     and still leaves a residual ~1/7 blank that needs a reconnect — i.e. even under
+     fork-workers, **blank-recovery is what completes the story**; the reverse isn't true.
+   - **A default must compose with everything; fork-workers doesn't.** Mutually exclusive
+     with `--enable-udp-multitransport`, requires supervisor-owned persistent state
+     (virtual display / blanking / HUD / caffeinate), and adds a whole process-lifecycle
+     surface (fd passing, worker serialization, the SCK-exit trap — two non-obvious bugs
+     were fixed just getting it working).
+   - **Soak asymmetry.** Single-process has the 31 h clean Tier 2.4 foundation run;
+     defaulting to fork-workers would invalidate that evidence and demand a fresh soak of
+     the *more* complex model.
+   - **The motivating pain shrank.** The reconnect-blank is now ~6–8 s of self-healing on
+     LAN (detect window scales with QoE cadence on slow links), no user action.
+   **Recommendation stands in the docs:** `--fork-workers` for mstsc-heavy, no-UDP
+   deployments that want blip-free reconnects + per-connection isolation — and it
+   COMPOSES with blank-recovery (recovery drops land on a fresh worker process, the
+   strongest combination). Revisit only if the re-soak or field use surfaces a
+   single-process weakness that process isolation would fix.
 
 ## Tier 3 — Polish / nice-to-have
 


### PR DESCRIPTION
Closes the last open production-readiness **decision**. Single-process + blank-recovery + ARC stays the default (field-proven in the 2026-07-04 ZeroTier cycle; composes with every feature; carries the 31 h soak evidence). `--fork-workers` stays the documented opt-in for mstsc-heavy no-UDP profiles — and composes with blank-recovery (recovery drops land on a fresh worker, the strongest combination). Full rationale in the roadmap; flag text + TODO updated to match.

With this, **Tier 1 + Tier 2 are all done or decided except the 48–72 h re-soak** (Tier 2.4).