### PR TITLE
fix(multitransport): clear per-connection state when the offer is skipped

### DIFF
--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -1008,3 +1008,15 @@ AND released — #1276 landing is NOT sufficient.
     marker: "multitransport offer WITHHELD (link RTT above the offer gate)".
     Verified live: threshold-1 loopback trips the gate (link_rtt_ms=1), default
     80 leaves loopback offering normally.
+    **No-offer state reset (2026-07-06, found by the #136 double-check):** when
+    the offer is skipped (cooldown OR RTT gate), `run_connection` now explicitly
+    clears `multitransport_migration` / `udp_tunnel_bound` / the inbound rx and
+    evicts the previous cookie from the registry. Those fields were otherwise
+    only refreshed AT the offer site, so a skipped offer inherited the PREVIOUS
+    connection's state — including a bound-tunnel flag that stays true for up to
+    ~30 s after that session ends (until tunnel-death lowers it), enough for the
+    new connection to route lossy audio into a dead tunnel or fire a bogus
+    Soft-Sync. The cooldown path was safe only by accident (suppression follows
+    a tunnel-death event that already lowered the flag); the RTT gate made the
+    window genuinely reachable (e.g. a WiFi session with a bound tunnel followed
+    within seconds by an auto-reconnect over a high-latency link).

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -1010,6 +1010,31 @@ impl RdpServer {
             }
             gated
         };
+        // No offer for this connection (cooldown or RTT gate): explicitly clear
+        // the per-connection multitransport state so nothing STALE from the
+        // previous connection can act. These fields are otherwise only refreshed
+        // at the offer site below, so a skipped offer would inherit the prior
+        // session's `udp_tunnel_bound` flag (which stays true for up to ~30 s
+        // after that session's tunnel goes silent, until tunnel-death flips it)
+        // and its `MigrationState` — enough for this connection to route lossy
+        // audio waves into a dead tunnel or fire a Soft-Sync naming a tunnel
+        // this client never created. The cooldown path was previously safe only
+        // by accident (suppression follows a tunnel-death event that already
+        // lowered the flag); the RTT gate has no such guarantee — e.g. a WiFi
+        // session with a bound tunnel followed within seconds by the client
+        // auto-reconnecting over a high-latency link.
+        #[cfg(feature = "multitransport")]
+        if self.multitransport.is_some() && (mt_suppressed || mt_rtt_gated) {
+            if let (Some(registry), Some(prev)) = (
+                self.multitransport_cookies.as_ref(),
+                self.multitransport_migration.as_ref(),
+            ) {
+                registry.remove(&prev.cookie);
+            }
+            self.multitransport_migration = None;
+            self.udp_tunnel_bound = None;
+            self.multitransport_tunnel_inbound_rx = None;
+        }
         #[cfg(feature = "multitransport")]
         if let Some(provider) = self
             .multitransport


### PR DESCRIPTION
## Problem (found double-checking #136)

`multitransport_migration`, `udp_tunnel_bound`, and the tunnel inbound rx are refreshed only **at the offer site** — a connection whose offer is skipped (tunnel-death cooldown, or the #136 RTT gate) silently inherits the *previous* connection's state. The stale bound-tunnel flag stays true for up to ~30 s after the prior session ends (until tunnel-death detection lowers it). Within that window the new connection can:

- route lossy-audio waves into the dead tunnel instead of TCP (silent audio until the fallback), and
- with a stale un-consumed `MigrationState`, fire a Soft-Sync naming a tunnel this client never created.

The #133 cooldown path had the same code shape but was safe **by accident**: suppression only ever follows a tunnel-death event, which has already lowered the shared flag. The RTT gate has no such guarantee — a WiFi session with a bound tunnel followed seconds later by an auto-reconnect over a high-latency link (a real mstsc network-switch pattern) hits the window.

## Fix

On the skip path, explicitly clear all three fields and evict the previous cookie from the registry — no-offer connections are now self-consistent instead of timing-dependent. Offered connections are unchanged (the offer site already refreshes everything it needs).

## Testing

160 tests pass, clippy -D warnings clean. The cleared-state behavior matches what a fresh `RdpServer` starts with (all `None`), which is the exact state every pre-multitransport connection already runs in.