### PR TITLE
fix(multitransport): tunnel-death hardening from the post-#136 regression sweep

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2462,7 +2462,7 @@ async fn async_main() -> Result<()> {
     // The server samples the kernel's smoothed TCP RTT for each accepted
     // connection (divergence 15) into this cell; the H.264 pipeline reads it
     // for link-aware blank-recovery gating + adaptive-bitrate seeding.
-    server.set_link_rtt_handle(link_rtt_ms);
+    server.set_link_rtt_handle(link_rtt_ms.clone());
 
     // Client-resolution auto-adopt: the vendored acceptor reads the desktop
     // size the client requests in its GCC Client Core Data and negotiates
@@ -2668,7 +2668,22 @@ async fn async_main() -> Result<()> {
             .context("set inherited worker socket non-blocking")?;
         let stream = tokio::net::TcpStream::from_std(std_stream)
             .context("adopt inherited worker socket into tokio")?;
-        info!(fd, user = %username, "worker: serving one connection on inherited socket");
+        // Divergence-15 RTT sample for the worker path: the accept-loop sample
+        // site never runs here (the supervisor accepted the socket), so without
+        // this the shared cell stays 0 = "unknown" and every link-aware feature
+        // (blank-recovery RTT gate, bitrate seed, offer gate) treats a slow link
+        // as LAN — re-arming the exact blank-recovery false positive #135 fixed
+        // for fork-workers deployments reached over VPN/ZeroTier.
+        link_rtt_ms.store(
+            ironrdp_server::tcp_srtt_ms(&stream).unwrap_or(0),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        info!(
+            fd,
+            user = %username,
+            link_rtt_ms = link_rtt_ms.load(std::sync::atomic::Ordering::Relaxed),
+            "worker: serving one connection on inherited socket"
+        );
         let res = server.run_connection(stream).await;
         // CRITICAL (fork-workers): force-exit the worker PROCESS here instead of
         // returning and letting the runtime unwind. Once an SCStream is live,

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -1020,3 +1020,27 @@ AND released — #1276 landing is NOT sufficient.
     a tunnel-death event that already lowered the flag); the RTT gate made the
     window genuinely reachable (e.g. a WiFi session with a bound tunnel followed
     within seconds by an auto-reconnect over a high-latency link).
+
+    Final-check hardening (2026-07-06, from the post-#136 regression sweep —
+    one live finding + two review findings): (a) **abandoned-tunnel false
+    cooldown (LIVE, the big one):** every ended session's tunnel went
+    inbound-silent and 30 s later `check_dead_tunnels` declared it DEAD +
+    started the 10-min offer cooldown — downgrading subsequent healthy-LAN
+    connections to plain TCP (observed twice in the deploy-night log after a
+    blank-recovery drop). Fix: the post-connection reset now RETIRES the
+    tunnel (lowers the shared `udp_tunnel_bound` flag), and the death check
+    treats an already-lowered flag as benign teardown (debug "retiring
+    quietly", no cooldown; peer ages out via the 60 s GC). A tunnel that
+    wedges while its session is ALIVE still fires death + cooldown unchanged.
+    (b) **GC flag strand (review):** `gc_idle_peers` now lowers a surviving
+    `bound_flag` on eviction — otherwise `MACRDP_UDP_TUNNEL_DEAD_SECS >= 60`
+    (the GC timeout) let eviction win the race and strand the server-side
+    flag true forever (no cooldown ever + lossy audio routed into a
+    nonexistent tunnel with no TCP fallback). (c) **fork-workers RTT gap
+    (review):** `tcp_srtt_ms` is now `pub` (re-exported) and macrdp's worker
+    branch samples the inherited socket into the shared cell before
+    `run_connection` — the accept-loop sample site never runs in a worker, so
+    the link-aware features (blank gate / seed / offer gate) silently treated
+    every worker connection as LAN, re-arming the #135 false positive for
+    FORK_WORKERS-over-VPN deployments. Also fixed the interleaved
+    check_dead_tunnels/gc_idle_peers doc blocks (cosmetic).

--- a/vendor/ironrdp-server/src/lib.rs
+++ b/vendor/ironrdp-server/src/lib.rs
@@ -49,8 +49,8 @@ pub use rdpdr::{
 #[cfg(feature = "helper")]
 pub use helper::TlsIdentityCtx;
 pub use server::{
-    ConnectionHandler, Credentials, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent,
-    ServerEventSender,
+    tcp_srtt_ms, ConnectionHandler, Credentials, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity,
+    ServerEvent, ServerEventSender,
 };
 pub use sound::{AudioWave, RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -289,13 +289,6 @@ async fn pump_peers_on_timer(
 /// activity-based backstop must be generous enough not to reap an idle-but-live client.
 const PEER_IDLE_TIMEOUT_MS: u64 = 60_000;
 
-/// (M3c) Idle-timeout garbage collection. Drop every peer whose last *inbound*
-/// datagram is older than `PEER_IDLE_TIMEOUT_MS`, along with any `bound_addrs`
-/// cookie→addr mapping pointing at it. Without this, peers inserted by
-/// `run_recv_loop` are never removed: a client whose RDP/TCP session has gone away
-/// stops acking but the reliability SM keeps RTO-retransmitting unacked EGFX to it
-/// forever (`pump_peers_on_timer`), and over a long-running server dead peers
-/// accumulate unbounded. Activity-based, so it covers graceful, abrupt, and crashed
 /// Tunnel-death detection: a peer with a BOUND tunnel (`bound_flag` kept from
 /// the cookie bind) that has been inbound-silent past `dead_ms` has lost its
 /// UDP path — an overlay network (ZeroTier) dropping UDP, a NAT rebind, a
@@ -312,6 +305,14 @@ const PEER_IDLE_TIMEOUT_MS: u64 = 60_000;
 ///   over ZeroTier).
 /// The flag is cleared after firing so a peer is declared dead exactly once;
 /// the 60 s idle GC still evicts it later. O(peers) per tick.
+///
+/// A peer whose shared flag has ALREADY been lowered by the server (the
+/// post-connection reset retires the tunnel when its owning TCP session ends)
+/// is benign teardown, not a wedge: the marker is dropped silently and the
+/// peer just ages out via the idle GC — no death declaration, no cooldown.
+/// Without that distinction every ended session's abandoned tunnel "died"
+/// ~30 s later and put healthy links into the 10-min offer cooldown (observed
+/// live 2026-07-06 on LAN after a blank-recovery drop).
 fn check_dead_tunnels(
     peers: &mut HashMap<SocketAddr, Peer>,
     cookie_registry: Option<&CookieRegistry>,
@@ -327,6 +328,15 @@ fn check_dead_tunnels(
             continue;
         }
         let flag = peer.bound_flag.take().expect("checked is_none above");
+        if !flag.load(core::sync::atomic::Ordering::Relaxed) {
+            // Already retired by the server (session over) — benign, not a wedge.
+            debug!(
+                peer_addr = %addr,
+                idle_ms = now_ms.saturating_sub(peer.last_seen_ms),
+                "abandoned UDP tunnel from an ended session — retiring quietly (no cooldown)"
+            );
+            continue;
+        }
         flag.store(false, core::sync::atomic::Ordering::Relaxed);
         if cooldown_secs > 0 {
             if let Some(reg) = cookie_registry {
@@ -346,6 +356,13 @@ fn check_dead_tunnels(
     }
 }
 
+/// (M3c) Idle-timeout garbage collection. Drop every peer whose last *inbound*
+/// datagram is older than `PEER_IDLE_TIMEOUT_MS`, along with any `bound_addrs`
+/// cookie→addr mapping pointing at it. Without this, peers inserted by
+/// `run_recv_loop` are never removed: a client whose RDP/TCP session has gone away
+/// stops acking but the reliability SM keeps RTO-retransmitting unacked EGFX to it
+/// forever (`pump_peers_on_timer`), and over a long-running server dead peers
+/// accumulate unbounded. Activity-based, so it covers graceful, abrupt, and crashed
 /// disconnects uniformly. O(peers) on each `retransmit_tick`; peers is a handful.
 fn gc_idle_peers(
     peers: &mut HashMap<SocketAddr, Peer>,
@@ -358,10 +375,23 @@ fn gc_idle_peers(
         .map(|(addr, _)| *addr)
         .collect();
     for addr in gone {
-        let idle_ms = peers
-            .remove(&addr)
-            .map(|p| now_ms.saturating_sub(p.last_seen_ms))
-            .unwrap_or(0);
+        let idle_ms = match peers.remove(&addr) {
+            Some(p) => {
+                // Defensive: lower the shared tunnel-bound flag on eviction. With
+                // the default thresholds tunnel-death (30 s) always fires before
+                // this GC (60 s) and takes the flag itself — but if an operator
+                // raises MACRDP_UDP_TUNNEL_DEAD_SECS to >= the GC timeout, the
+                // eviction would otherwise strand the server-side flag TRUE
+                // forever: no death declared, no cooldown, and lossy audio keeps
+                // routing into a tunnel that no longer exists (permanent silence
+                // with no TCP fallback).
+                if let Some(flag) = p.bound_flag {
+                    flag.store(false, core::sync::atomic::Ordering::Relaxed);
+                }
+                now_ms.saturating_sub(p.last_seen_ms)
+            }
+            None => 0,
+        };
         // Drop any cookie→addr bindings for the evicted peer so a stale cookie can't
         // route server tunnel data to it (or to a later peer that reuses the addr).
         bound_addrs.retain(|_, a| *a != addr);

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -344,7 +344,7 @@ fn migrate_egfx_lossy() -> bool {
 /// without the option (Linux CI compiles the stub); a sub-ms LAN RTT maps to 1
 /// so 0 stays reserved for "unknown".
 #[cfg(target_os = "macos")]
-fn tcp_srtt_ms(stream: &tokio::net::TcpStream) -> Option<u32> {
+pub fn tcp_srtt_ms(stream: &tokio::net::TcpStream) -> Option<u32> {
     use std::os::fd::AsRawFd;
     let fd = stream.as_raw_fd();
     let mut info: libc::tcp_connection_info = unsafe { core::mem::zeroed() };
@@ -368,7 +368,7 @@ fn tcp_srtt_ms(stream: &tokio::net::TcpStream) -> Option<u32> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn tcp_srtt_ms(_stream: &tokio::net::TcpStream) -> Option<u32> {
+pub fn tcp_srtt_ms(_stream: &tokio::net::TcpStream) -> Option<u32> {
     None
 }
 
@@ -1237,6 +1237,20 @@ impl RdpServer {
                             // newly-migrated EGFX straight back to TCP.
                             if let Some(handle) = &self.demigrate_request {
                                 handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                            }
+                            // Retire this connection's tunnel: lower the shared bound
+                            // flag so the listener's tunnel-death check (which skips
+                            // lowered flags) treats the now-abandoned tunnel as benign
+                            // teardown — it just ages out via the idle GC. Without
+                            // this, every ended session's tunnel "dies" ~30 s later
+                            // and starts the multitransport-offer COOLDOWN, silently
+                            // downgrading the next 10 min of healthy-LAN connections
+                            // to plain TCP (observed live 2026-07-06 after a
+                            // blank-recovery drop). A tunnel that wedges while its
+                            // session is ALIVE still declares death + cooldown exactly
+                            // as before (its flag is still up when the check runs).
+                            if let Some(flag) = &self.udp_tunnel_bound {
+                                flag.store(false, std::sync::atomic::Ordering::Relaxed);
                             }
                         }
 


### PR DESCRIPTION
Final regression check on the #133–#137 arc (live log inspection + an adversarial review of the full diff). Core verdict: nothing wrong-by-default in the merged range — but one live finding and two review findings, all in the tunnel-death machinery's edges:

## 1. Abandoned tunnels triggered the offer cooldown (found LIVE tonight)
Every ended session leaves its UDP tunnel inbound-silent; ~30 s later `check_dead_tunnels` declared it DEAD and started the **10-minute offer cooldown** — so after any session churn on a healthy LAN (tonight: a blank-recovery drop + reconnect), subsequent connections got `offer SUPPRESSED` and silently lost lossy audio for 10 minutes. Both `tunnel DEAD` events in tonight's deploy log were tunnels of already-ended sessions.

**Fix:** the post-connection reset retires the tunnel (lowers the shared `udp_tunnel_bound` flag); `check_dead_tunnels` treats an already-lowered flag as benign teardown — debug `retiring quietly`, no cooldown, peer ages out via the 60 s GC. A tunnel that wedges while its session is **alive** (the real #133 ZeroTier pathology) still declares death + cooldown unchanged.

## 2. GC could strand the bound flag true forever (review finding)
`gc_idle_peers` dropped evicted peers without lowering a surviving `bound_flag`. With `MACRDP_UDP_TUNNEL_DEAD_SECS >= 60` (the GC timeout), eviction wins the race: no death ever declared, no cooldown, and `lossy_audio_target` keeps routing audio into a nonexistent tunnel for the rest of the session — permanent silence with no TCP fallback. Now the flag is lowered on eviction.

## 3. fork-workers never sampled RTT (review finding)
The divergence-15 sample site lives in the accept loop, which never runs in a worker (the supervisor accepts and passes the fd) — so the RTT cell stayed 0 and the blank-recovery gate / bitrate seed / offer gate all treated worker connections as LAN, re-arming the #135 false positive for `FORK_WORKERS` deployments reached over VPN/ZeroTier. `tcp_srtt_ms` is now `pub` (re-exported) and the worker branch samples the inherited socket before `run_connection`, logging the value.

Plus a cosmetic fix: the `check_dead_tunnels`/`gc_idle_peers` doc blocks were interleaved by the #133 insertion.

## Testing
160 tests pass, clippy -D warnings clean, fmt clean. Live verification of (1): next LAN session churn should log `abandoned UDP tunnel from an ended session — retiring quietly (no cooldown)` instead of `tunnel DEAD` + suppression.