### PR TITLE
fix(multitransport): tunnel-state lifecycle — cookie eviction, third strand site, wedge adjudication

### DIFF
--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -1044,3 +1044,31 @@ AND released — #1276 landing is NOT sufficient.
     every worker connection as LAN, re-arming the #135 false positive for
     FORK_WORKERS-over-VPN deployments. Also fixed the interleaved
     check_dead_tunnels/gc_idle_peers doc blocks (cosmetic).
+
+    Tunnel-state lifecycle fixes (2026-07-06, from the second sweep's
+    concurrency audit — extends the #138 hardening): (F1) the offer-site
+    cookie registration leaked one registry entry per connection that died
+    before activation (mstsc cert-prompt broken pipe, CredSSP failures,
+    probes) because eviction was keyed off MigrationState, set only in
+    client_accepted. New `current_offer_cookie` field, set at the offer site
+    and evicted in the post-connection reset (runs on every run_connection
+    return path) — which also closes (F3): a client's LATE tunnel bind (UDP
+    handshake outliving a fast session end) could consume the stale cookie,
+    re-raise the retired bound flag, and produce a zombie peer whose eventual
+    "death" started a spurious 10-min cooldown. (F2) the SYN stale-peer
+    replacement is the THIRD Peer-removal site and now also lowers a
+    surviving bound flag (mid-session re-SYN from a reused port stranded the
+    server flag true = permanent audio silence — same class as the #138 GC
+    fix). (F4) check_dead_tunnels now adjudicates retired flags AT the first
+    tick the lowering is observed: already-silent-past-threshold at
+    retirement = the wedge predated the session end → death + cooldown still
+    fire (an early session end no longer launders a real wedge into "benign
+    teardown", which could have resurrected the reset cycle cooldown-free on
+    sub-80ms flapping links); recently-active at retirement = quiet retire.
+    A wedge younger than the threshold at session end intentionally reads as
+    teardown (inherently ambiguous). (F5) MACRDP_UDP_TUNNEL_DEAD_SECS is
+    clamped below the 60 s idle GC with a warn — at/above it the GC won the
+    race and the cooldown protection silently never engaged. Audit also
+    confirmed clean: per-offer flag Arc identity (no cross-connection
+    retirement), CookieRegistry lock ordering/poisoning, inbound-sink
+    lifetime, Relaxed ordering adequacy.

--- a/vendor/ironrdp-server/src/multitransport/listener.rs
+++ b/vendor/ironrdp-server/src/multitransport/listener.rs
@@ -324,19 +324,51 @@ fn check_dead_tunnels(
         return;
     }
     for (addr, peer) in peers.iter_mut() {
-        if peer.bound_flag.is_none() || now_ms.saturating_sub(peer.last_seen_ms) <= dead_ms {
+        let Some(flag_ref) = peer.bound_flag.as_ref() else {
+            continue;
+        };
+        let idle_ms = now_ms.saturating_sub(peer.last_seen_ms);
+        if !flag_ref.load(core::sync::atomic::Ordering::Relaxed) {
+            // The server retired this tunnel (its TCP session ended). Adjudicate
+            // AT THE FIRST TICK we observe the lowering — idle time then tells
+            // wedge from teardown: a tunnel that was already inbound-silent past
+            // the death threshold when its session ended had wedged BEFORE the
+            // end (the end was likely a casualty: TCP error on the same dying
+            // link, a recovery drop), so death + cooldown still apply — without
+            // this, any session end within the detection window laundered a
+            // real wedge into "benign teardown" and the reset cycle could
+            // recur cooldown-free. A tunnel that was recently active when the
+            // session ended is normal teardown: retire quietly, no cooldown.
+            // (A wedge younger than the threshold at session end is inherently
+            // ambiguous and intentionally reads as teardown.)
+            let _ = peer.bound_flag.take();
+            if idle_ms > dead_ms {
+                if cooldown_secs > 0 {
+                    if let Some(reg) = cookie_registry {
+                        reg.suppress_multitransport(std::time::Duration::from_secs(cooldown_secs));
+                    }
+                }
+                warn!(
+                    peer_addr = %addr,
+                    idle_ms,
+                    dead_ms,
+                    cooldown_secs,
+                    "UDP tunnel DEAD (wedged before its session ended) — multitransport \
+                     offers are suppressed for the cooldown"
+                );
+            } else {
+                debug!(
+                    peer_addr = %addr,
+                    idle_ms,
+                    "abandoned UDP tunnel from an ended session — retiring quietly (no cooldown)"
+                );
+            }
             continue;
         }
-        let flag = peer.bound_flag.take().expect("checked is_none above");
-        if !flag.load(core::sync::atomic::Ordering::Relaxed) {
-            // Already retired by the server (session over) — benign, not a wedge.
-            debug!(
-                peer_addr = %addr,
-                idle_ms = now_ms.saturating_sub(peer.last_seen_ms),
-                "abandoned UDP tunnel from an ended session — retiring quietly (no cooldown)"
-            );
+        if idle_ms <= dead_ms {
             continue;
         }
+        let flag = peer.bound_flag.take().expect("checked is_some above");
         flag.store(false, core::sync::atomic::Ordering::Relaxed);
         if cooldown_secs > 0 {
             if let Some(reg) = cookie_registry {
@@ -640,6 +672,22 @@ async fn run_recv_loop(
         .and_then(|s| s.trim().parse::<u64>().ok())
         .map(|s| s * 1000)
         .unwrap_or(30_000);
+    // Clamp below the idle GC: at >= PEER_IDLE_TIMEOUT_MS the GC would evict the
+    // peer before death is ever declared — audio would still fall back (the GC
+    // lowers the flag) but the offer COOLDOWN would silently never engage,
+    // resurrecting the dead-tunnel reset cycle the detection exists to break.
+    let tunnel_dead_ms = if tunnel_dead_ms >= PEER_IDLE_TIMEOUT_MS {
+        let clamped = PEER_IDLE_TIMEOUT_MS - 5_000;
+        warn!(
+            requested_ms = tunnel_dead_ms,
+            clamped_ms = clamped,
+            "MACRDP_UDP_TUNNEL_DEAD_SECS must stay below the {}s idle GC — clamped",
+            PEER_IDLE_TIMEOUT_MS / 1000
+        );
+        clamped
+    } else {
+        tunnel_dead_ms
+    };
     // Multitransport-offer cooldown after a tunnel death (0 = no suppression).
     let mt_cooldown_secs: u64 = std::env::var("MACRDP_UDP_MT_COOLDOWN_SECS")
         .ok()
@@ -773,7 +821,17 @@ async fn run_recv_loop(
         // binds cleanly. (A SYN on a still-HANDSHAKING peer is a normal SYN
         // retransmit — `is_established()` gates that out.)
         if is_syn_family(data) && peers.get(&peer_addr).is_some_and(|p| p.sm.is_established()) {
-            peers.remove(&peer_addr);
+            if let Some(stale) = peers.remove(&peer_addr) {
+                // Third Peer-removal site (after tunnel-death and the idle GC):
+                // lower a surviving bound flag so the server's per-wave
+                // `lossy_audio_target` check falls audio back to TCP instead of
+                // routing waves at a peer that no longer exists (a mid-session
+                // re-SYN from a reused source port would otherwise leave the
+                // server-side flag stranded true = permanent silence).
+                if let Some(flag) = stale.bound_flag {
+                    flag.store(false, core::sync::atomic::Ordering::Relaxed);
+                }
+            }
             bound_addrs.retain(|_, a| *a != peer_addr);
             debug!(%peer_addr, "RDPEUDP SYN on an established peer — replacing stale peer (port reuse / reconnect)");
         }

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -431,6 +431,18 @@ pub struct RdpServer {
     /// adaptive-bitrate seeding in `h264.rs`) hold a clone. 0 = unknown /
     /// unsupported platform; a sub-millisecond LAN RTT stores as 1.
     link_rtt_ms: Option<Arc<AtomicU32>>,
+    /// (vendored, extends divergence 12) The cookie registered for the CURRENT
+    /// connection's multitransport offer, so the post-connection reset can
+    /// evict it from the registry no matter how the connection ended. Without
+    /// this, eviction keyed off `MigrationState` (set only in `client_accepted`)
+    /// — so any connection dying between the offer and activation (mstsc's
+    /// cert-prompt broken pipe, CredSSP failures, port scans) leaked its
+    /// registry entry forever, and a client's LATE tunnel bind (UDP handshake
+    /// completing after a fast session end) could consume the stale cookie and
+    /// re-raise a retired bound flag → zombie peer → spurious death + 10-min
+    /// offer cooldown.
+    #[cfg(feature = "multitransport")]
+    current_offer_cookie: Option<[u8; 16]>,
     /// (vendored, divergence 13) Optional Server Auto-Reconnect Cookie
     /// (MS-RDPBCGR 2.2.4.3 ARC_SC_PRIVATE_PACKET). When set, the server sends a
     /// Save Session Info PDU carrying it once per TCP connection, right after
@@ -638,6 +650,8 @@ impl RdpServer {
             display_suppressed: Arc::new(AtomicBool::new(false)),
             keyboard_layout: None,
             link_rtt_ms: None,
+            #[cfg(feature = "multitransport")]
+            current_offer_cookie: None,
             auto_reconnect_cookie: None,
             auto_reconnect_sent: false,
             honor_client_desktop_size: false,
@@ -1060,6 +1074,7 @@ impl RdpServer {
                 // match, and the EGFX dispatch path reads it to fire Soft-Sync.
                 self.udp_tunnel_bound = Some(registry.register(offer.cookie, in_tx));
             }
+            self.current_offer_cookie = Some(offer.cookie);
             acceptor.set_advertise_extended_client_data(true);
             acceptor.set_multitransport_offer(Some(offer));
         }
@@ -1251,6 +1266,21 @@ impl RdpServer {
                             // as before (its flag is still up when the check runs).
                             if let Some(flag) = &self.udp_tunnel_bound {
                                 flag.store(false, std::sync::atomic::Ordering::Relaxed);
+                            }
+                            // Evict the connection's offer cookie no matter how it
+                            // ended. Eviction used to be keyed off `MigrationState`
+                            // (set only at activation), so a connection dying
+                            // earlier — mstsc's cert-prompt broken pipe, CredSSP
+                            // failures, probes — leaked one registry entry per
+                            // attempt forever, and a LATE tunnel bind (the client's
+                            // UDP handshake outliving a fast session end) could
+                            // still consume the stale cookie and re-raise the
+                            // retired flag → zombie peer → spurious death + a
+                            // 10-min offer cooldown on a healthy setup.
+                            if let Some(cookie) = self.current_offer_cookie.take() {
+                                if let Some(registry) = self.multitransport_cookies.as_ref() {
+                                    registry.remove(&cookie);
+                                }
                             }
                         }
 


### PR DESCRIPTION
Second regression sweep (concurrency/interleaving audit of the tunnel state machine, including an independent review of #138). Four findings, four fixes:

## F1+F3 — cookie leak + zombie-peer cooldown (one fix)
The offer registers its cookie at the top of `run_connection`, but eviction was keyed off `MigrationState` — set only in `client_accepted`. Any connection dying in between (**every mstsc cert-prompt broken pipe**, CredSSP failures, probes) leaked a registry entry permanently. And since the stale cookie stayed live indefinitely, a client's **late tunnel bind** (UDP handshake outliving a fast session end) could `take()` it, re-raise the retired bound flag, and create a zombie peer — whose eventual 30-s 'death' declared a **spurious 10-min offer cooldown** (the exact false-cooldown class #138 fixed, resurrected through a window it didn't close). Fix: new `current_offer_cookie` field, evicted in the post-connection reset, which runs on every `run_connection` return path.

## F2 — third flag-strand site
#138 fixed the GC strand; the audit found the **SYN stale-peer replacement** is a third `Peer`-removal site with the same bug: a mid-session re-SYN from a reused source port dropped the peer with the server flag stranded true → every audio wave routed to a nonexistent tunnel, permanent silence, no TCP fallback. Now lowers the flag like the other two sites.

## F4 — early session end no longer launders a real wedge
#138's 'retired = benign' heuristic had a gap: if anything ended the TCP session before the 30-s death check (a TCP error on the same dying link, a recovery drop), the retirement suppressed the cooldown and the reconnect got a fresh offer to the same wedging path — on a flapping sub-80 ms link (where the #136 RTT gate doesn't apply) the reset cycle could recur indefinitely with the protection never arming. `check_dead_tunnels` now adjudicates at the first tick it observes the lowering: **already silent past the threshold at retirement = the wedge predated the end** → death + cooldown still fire. Recently-active at retirement = quiet retire (the LAN fix preserved). A wedge younger than the threshold at session end intentionally reads as teardown (inherently ambiguous).

## F5 — config residual
`MACRDP_UDP_TUNNEL_DEAD_SECS >= 60` let the idle GC win the race: audio fallback survived (#138) but the cooldown protection silently never engaged. Now clamped below the GC with a warning.

## Audit confirmed clean (no action)
Per-offer flag Arc identity (connection N can never retire N+1's tunnel — serialized accept loop + fresh Arc per offer), CookieRegistry lock ordering + poisoned-mutex fail-open, inbound-sink lifetime across connections, Relaxed ordering adequacy, #138's worker RTT sample + pub re-export (compiles on non-macOS).

## Testing
160 tests pass, clippy -D warnings clean, fmt clean.