### PR TITLE
Serialize all NSPasteboard access to close a use-after-free race

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -94,14 +94,23 @@ then delete; promote a parked item to *In flight* when work actually starts.
   `cursor/mod.rs::clamp_pointer_size` downscales aspect-preserving (hotspot-exact) via the
   existing resampler; unit-tested.
 
-- [ ] **NSPasteboard SIGSEGV crash (main thread) — investigate.** 2026-07-04 19:47:58,
-  crash report `macrdp-2026-07-04-194758.ips`: `objc_msgSend` under
+- [x] **NSPasteboard SIGSEGV crash — FIXED via a global pasteboard mutex (2026-07-07).**
+  2026-07-04 19:47:58 crash `macrdp-2026-07-04-194758.ips`: `objc_msgSend` under
   `-[NSPasteboard _updateTypeCacheIfNeeded]` ← `_typesAtIndex:combinesItems:` during
-  connection churn (~13 s after a client-loop failure + a fresh accept). Suspect the
-  clipboard change-count poller reading a pasteboard item freed under it. Restarted the
-  server via launchd (and wiped the in-process #133 cooldown). Different signature from
-  the 2026-06-28 crash (`UNKNOWN_0x32` on a pthread). One-off so far — gather more
-  occurrences before chasing; keep the .ips files.
+  connection churn (~13 s after a client-loop failure + a fresh accept). **Root cause
+  confirmed:** the process-global `NSPasteboard` (AppKit, NOT thread-safe) was accessed
+  from multiple threads with ZERO serialization — the advertise poller (a tokio worker)
+  walking `pasteboardItems()`/`types()` overlapped a concurrent writer
+  (`clearContents`/`writeObjects`/`setData` from the paste, download, or disconnect-Drop
+  paths, each on its own thread), which corrupts the pasteboard's internal type cache →
+  use-after-free → segfault. The disconnect-Drop clear racing the poller is the churn
+  window. **Fix:** `clipboard::pasteboard_guard()` — a process-global `Mutex<()>` that
+  every `pb::` accessor and every `file_promise*` pasteboard touch holds for the span of
+  its objc calls (poison-recovering, since the guarded data is `()`); the check-then-clear
+  cleanup paths hold it across the changeCount read + the clear so that's atomic too.
+  Serializes reader vs. writer and closes the race. Rare, so unproven-by-repro — keep the
+  `.ips` files and watch for a DIFFERENT signature (the 2026-06-28 `UNKNOWN_0x32` pthread
+  crash is a separate, still-open one-off).
 
 - [ ] **Congestion-responsive encoder rate control + frame dropping** (highest-value
   video-under-loss work — helps BOTH the default TCP path and UDP). **P1 (adaptive bitrate)

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -928,6 +928,23 @@ impl CliprdrBackend for MacCliprdrBackend {
     }
 }
 
+/// Serializes every access to the process-global `NSPasteboard`. AppKit's
+/// pasteboard is NOT thread-safe — its internal type cache
+/// (`_updateTypeCacheIfNeeded`) corrupts if a reader (the advertise poller
+/// walking `pasteboardItems()`/`types()`) overlaps a writer (`clearContents` /
+/// `writeObjects` / `setData` from the paste, download, or disconnect-Drop
+/// paths, all on different threads), which segfaulted `objc_msgSend` during
+/// connection churn. Every `pb::` accessor and every `file_promise*`
+/// pasteboard touch holds this for the span of its raw objc calls; results are
+/// copied into owned Rust types before the guard drops, so the lock only spans
+/// the unsafe access. Poison is recovered (the guarded data is `()` — there is
+/// no state to corrupt) so one panicking access can't cascade-poison the rest.
+#[cfg(target_os = "macos")]
+pub(crate) fn pasteboard_guard() -> std::sync::MutexGuard<'static, ()> {
+    static PB_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PB_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 #[cfg(target_os = "macos")]
 mod pb {
     use objc2::rc::autoreleasepool;
@@ -938,6 +955,7 @@ mod pb {
     use objc2_foundation::{NSData, NSString, NSURL};
 
     pub fn change_count() -> i64 {
+        let _pb_guard = super::pasteboard_guard();
         unsafe {
             let pb = NSPasteboard::generalPasteboard();
             pb.changeCount() as i64
@@ -985,6 +1003,7 @@ mod pb {
     /// to prevent cycles. Unreadable paths or directories we can't open are
     /// logged but don't abort the rest of the walk.
     pub fn read_files() -> Vec<FileEntry> {
+        let _pb_guard = super::pasteboard_guard();
         autoreleasepool(|_| unsafe {
             let pb = NSPasteboard::generalPasteboard();
             let Some(items) = pb.pasteboardItems() else {
@@ -1114,6 +1133,7 @@ mod pb {
     }
 
     fn has_type(target: &objc2_app_kit::NSPasteboardType) -> bool {
+        let _pb_guard = super::pasteboard_guard();
         unsafe {
             let pb = NSPasteboard::generalPasteboard();
             let Some(types) = pb.types() else {
@@ -1130,6 +1150,7 @@ mod pb {
     }
 
     pub fn read_string() -> Option<String> {
+        let _pb_guard = super::pasteboard_guard();
         autoreleasepool(|_| unsafe {
             let pb = NSPasteboard::generalPasteboard();
             pb.stringForType(NSPasteboardTypeString)
@@ -1138,6 +1159,7 @@ mod pb {
     }
 
     pub fn write_string(s: &str) {
+        let _pb_guard = super::pasteboard_guard();
         unsafe {
             let pb = NSPasteboard::generalPasteboard();
             pb.clearContents();
@@ -1150,6 +1172,7 @@ mod pb {
     /// PNG first, falls back to TIFF (which we re-encode in clipboard.rs
     /// via the `image` crate so this returns PNG either way).
     pub fn read_image_bytes() -> Option<(ImageEncoding, Vec<u8>)> {
+        let _pb_guard = super::pasteboard_guard();
         autoreleasepool(|_| unsafe {
             let pb = NSPasteboard::generalPasteboard();
             if let Some(d) = pb.dataForType(NSPasteboardTypePNG) {
@@ -1163,6 +1186,7 @@ mod pb {
     }
 
     pub fn write_png(bytes: &[u8]) {
+        let _pb_guard = super::pasteboard_guard();
         unsafe {
             let pb = NSPasteboard::generalPasteboard();
             pb.clearContents();

--- a/src/file_promise.rs
+++ b/src/file_promise.rs
@@ -403,6 +403,10 @@ fn publish_to_pasteboard(paths: &[PathBuf], self_change_count: &SelfChangeCount)
         .map(ProtocolObject::from_retained)
         .collect();
     let array = NSArray::from_vec(writers);
+    // Serialize against the advertise poller + every other pasteboard toucher
+    // (NSPasteboard is not thread-safe). The changeCount read stays inside the
+    // guard so no other writer can bump it between our write and the capture.
+    let _pb_guard = crate::clipboard::pasteboard_guard();
     let new_change_count = unsafe {
         let pb = NSPasteboard::generalPasteboard();
         pb.clearContents();

--- a/src/file_promise_lazy.rs
+++ b/src/file_promise_lazy.rs
@@ -503,6 +503,10 @@ pub fn clear_pasteboard_if_stale(self_change_count: &SelfChangeCount) {
     if our_cc < 0 {
         return;
     }
+    // Hold the pasteboard guard across the changeCount check AND the clear so
+    // it's atomic (no other writer can bump changeCount between them) and race-
+    // free against the advertise poller (NSPasteboard is not thread-safe).
+    let _pb_guard = crate::clipboard::pasteboard_guard();
     let current_cc = unsafe { NSPasteboard::generalPasteboard().changeCount() } as i64;
     if current_cc != our_cc {
         // Something else owns the clipboard now — leave it alone.
@@ -551,6 +555,9 @@ pub fn cleanup_on_disconnect(
         // We never published; nothing to clear.
         return;
     }
+    // Atomic check-then-clear under the shared pasteboard guard (NSPasteboard is
+    // not thread-safe; this Drop path races the advertise poller during churn).
+    let _pb_guard = crate::clipboard::pasteboard_guard();
     let current_cc = unsafe { NSPasteboard::generalPasteboard().changeCount() } as i64;
     if current_cc == our_cc {
         unsafe {
@@ -613,6 +620,9 @@ fn publish_to_pasteboard(urls: &[SendRetained<NSURL>], self_change_count: &SelfC
         .map(|u| ProtocolObject::from_retained(u.0.clone()))
         .collect();
     let array = NSArray::from_vec(writers);
+    // Serialize against the advertise poller + other pasteboard writers, and
+    // keep the changeCount capture inside the guard so it's our write's count.
+    let _pb_guard = crate::clipboard::pasteboard_guard();
     let new_change_count = unsafe {
         let pb = NSPasteboard::generalPasteboard();
         pb.clearContents();


### PR DESCRIPTION
## The bug

A rare `SIGSEGV` in `objc_msgSend` under `-[NSPasteboard _updateTypeCacheIfNeeded]` ← `_typesAtIndex:combinesItems:`, observed during connection churn (crash report `macrdp-2026-07-04-194758.ips`, ~13 s after a client-loop failure + a fresh accept).

## Root cause (confirmed)

The process-global `NSPasteboard` (`generalPasteboard`) is **not thread-safe**, and macrdp accessed it from multiple threads with **zero serialization**:

- **Reader:** the clipboard advertise **poller** (a `tokio::spawn` worker) → `pb::read_files()` walks `pasteboardItems()` + `stringForType(...)` — the exact call chain behind `_updateTypeCacheIfNeeded`.
- **Writers, on other threads:** `pb::write_string`/`write_png` (`clearContents`+`setData`, ironrdp client-loop task), `file_promise*` publish (`clearContents`+`writeObjects`, download tasks), and `cleanup_on_disconnect` (`clearContents`, run synchronously inside `MacCliprdrBackend::drop`).

A write frees/reallocs the pasteboard's internal type cache while the poller is mid-read → use-after-free → segfault. Connection churn is the window (the old backend's `Drop` clearing the pasteboard while the poller is still active).

## Fix

`clipboard::pasteboard_guard()` — a process-global `Mutex<()>` that **every** `pb::` accessor and every `file_promise*` pasteboard touch holds for the span of its raw objc calls. Results are copied into owned Rust types before the guard drops, so the lock only spans the unsafe access; contention is negligible (poller reads 4×/s, writes sub-ms). The check-then-clear cleanup paths hold the guard across the `changeCount` read **and** the clear, making that atomic too. Poison-recovering (guarded data is `()`), so one panicking access can't cascade.

`NSPasteboard` doesn't require the main thread — only non-concurrent access — so a mutex is the proportionate fix (vs. routing everything onto one thread).

## Verification

- `cargo build --release`, `cargo clippy --release --all-targets`, `cargo test` — all green (163 tests).
- Every `generalPasteboard()` site audited as guarded.
- macOS-only: the guard fn and all call sites are behind `cfg(target_os = "macos")` (`file_promise*` are whole-module `#![cfg(target_os = "macos")]`), so the Linux build is unaffected.
- Rare race, so unproven-by-repro; the `.ips` files are kept to watch for any *different* signature.