### PR TITLE
ci(security): scheduled cargo-deny dependency vulnerability scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,122 @@
+name: security
+
+# Dependency vulnerability / supply-chain scanning (cargo-deny against the
+# RustSec advisory DB). This is SEPARATE from ci.yml on purpose:
+#
+#   * It runs on a daily SCHEDULE, not just on push/PR. macrdp pins IronRDP at a
+#     deliberately old rev and ships frozen releases for weeks, so a newly
+#     published advisory against a version we already froze must be caught
+#     WITHOUT a code change triggering it. Only a scheduled re-scan of the
+#     unchanged Cargo.lock does that — the whole point of the job.
+#   * Keeping it out of ci.yml avoids dragging the full macOS test matrix into
+#     the daily cron.
+#
+# A failed scheduled run emails the repo owner (GitHub's default for scheduled
+# workflow failures), so no extra notification wiring is needed.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'vendor/**/Cargo.toml'
+      - 'vendor/**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security.yml'
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'vendor/**/Cargo.toml'
+      - 'vendor/**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security.yml'
+  schedule:
+    # 07:12 UTC daily. Off the hour so it isn't in the top-of-hour runner surge.
+    - cron: '12 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_RETRY: '10'
+  RUST_BACKTRACE: '1'
+
+jobs:
+  cargo-deny:
+    name: cargo-deny (advisories / sources / bans)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # This job installs + runs third-party tooling (cargo-deny) UNATTENDED on a
+      # schedule, so it's the most justified place for a real egress FIREWALL, not
+      # just audit. block = deny all egress except the allow-list below, so a
+      # compromised cargo-deny (or one of its build deps) can't exfiltrate the
+      # token or phone home. The list is deterministic because this job pulls no
+      # GitHub Actions cache (no rust-cache step — see below), whose dynamic Azure
+      # blob endpoints are hard to pin. If a future run FAILS on a blocked
+      # endpoint, the harden-runner run summary names it — add it here.
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            crates.io:443
+            index.crates.io:443
+            static.crates.io:443
+            static.rust-lang.org:443
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: '1.95.0'
+
+      # No rust-cache here on purpose: it wouldn't cache the `cargo install`
+      # (that lands in ~/.cargo/bin), only the registry, so the payoff is tiny —
+      # and it's what would force the hard-to-allowlist GitHub Actions cache
+      # endpoints into the block-mode egress policy. A ~1 min fresh compile on a
+      # daily job is the cheaper trade.
+
+      # VERSION-PINNED (not float-to-latest): the tool you add to DETECT
+      # supply-chain issues shouldn't itself auto-run whatever crates.io serves as
+      # "latest" on an unattended schedule. Bump this pin deliberately in a
+      # reviewed commit (it's a `run:` line, so Dependabot does NOT auto-track it —
+      # swap to a SHA-pinned install-action if you want that). Built from source
+      # via the already-SHA-pinned toolchain to keep the repo's no-unpinned-actions
+      # convention.
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version '=0.19.9' --locked
+
+      # Root scan: the macrdp package resolves the vendored ironrdp-* forks and
+      # every transitive dep through [patch.crates-io] path deps, so this one
+      # Cargo.lock covers the whole shipped tree.
+      - name: cargo-deny — root tree
+        run: cargo deny check advisories bans sources
+
+      # vendor/ironrdp-rdpeudp is a STANDALONE crate (its own Cargo.lock, not a
+      # workspace member — see ci.yml). Scan it separately against the same
+      # deny.toml so an advisory that only appears in its independent lock is
+      # still caught.
+      - name: cargo-deny — vendored ironrdp-rdpeudp
+        run: >
+          cargo deny
+          --manifest-path vendor/ironrdp-rdpeudp/Cargo.toml
+          check --config deny.toml advisories bans sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asn1-rs"
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,92 @@
+# cargo-deny configuration.
+#
+# Primary purpose: scheduled SUPPLY-CHAIN / VULNERABILITY scanning. macrdp pins
+# IronRDP at a deliberately old git rev and freezes releases for weeks, so a new
+# RustSec advisory can land against a dependency version we already shipped with
+# NO code change on our side. The scheduled `security` workflow re-scans this
+# frozen tree daily against a fresh advisory DB to catch exactly that.
+#
+# The CI gate runs `check advisories bans sources` (see .github/workflows/
+# security.yml). The `licenses` check is intentionally NOT in the daily gate —
+# ring / aws-lc-rs (pulled in via rustls) carry non-SPDX / OpenSSL license
+# expressions that would red the build for a non-security reason and drown the
+# vulnerability signal. Run `cargo deny check licenses` locally when you want a
+# license review; the allow-list below makes that run meaningful.
+
+[graph]
+# Scan with every feature enabled (multitransport, egfx, …) so feature-gated
+# deps like ironrdp-rdpeudp are in the graph. Leave `targets` unset so
+# macOS-only deps are scanned too — a vuln in a macOS-gated crate must still
+# surface even though CI runs on Linux.
+all-features = true
+
+[advisories]
+version = 2
+# A yanked crate in the lockfile fails the scan (it was pulled for a reason —
+# often a security or soundness issue).
+yanked = "deny"
+# The gate fails on security VULNERABILITIES and yanked crates. "Unmaintained"
+# advisories are informational (an abandoned-but-not-vulnerable crate) and would
+# otherwise red the daily build on common transitive crates — handle those by
+# review, not by blocking unrelated work. Flip to "all" if you want the
+# maintenance signal to gate too.
+unmaintained = "none"
+# Suppress a specific advisory ONLY with a written justification here (why it's
+# not fixable now AND why it's assessed as not-exploitable in macrdp's usage).
+# Format: "RUSTSEC-XXXX-NNNN". cargo-deny still prints an ignored advisory as a
+# note, so it stays visible; ignoring keeps the daily gate GREEN so it still
+# fires on every OTHER (new) advisory instead of being permanently red on a
+# known-and-triaged one. Re-review these whenever the IronRDP pin is bumped.
+ignore = [
+  # RUSTSEC-2023-0071 — "Marvin Attack": RSA PKCS#1 v1.5 decryption in the `rsa`
+  # crate is not constant-time, leaking key bits via network-observable timing.
+  # Reached transitively through picky -> ironrdp-connector / sspi / winscard
+  # (the CredSSP/NLA + smart-card auth stack), shared by ALL of IronRDP and every
+  # downstream server. Accepted risk because: (1) NO fix exists upstream — the
+  # advisory states "no safe upgrade is available" pending a constant-time
+  # rewrite; (2) it's not droppable without dropping CredSSP/NLA; (3) macrdp's
+  # documented posture is VPN / trusted-LAN only (never a public IP), and TLS is
+  # rustls/aws-lc-rs — unaffected — so an attacker is not positioned to time the
+  # server's RSA private-key operations. Revisit on each IronRDP pin bump.
+  "RUSTSEC-2023-0071",
+]
+
+[bans]
+# Duplicate versions are normal in a large Rust tree — surface them but don't
+# fail the security gate on them.
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+# Catch a dependency sneaking in from an unexpected registry or git remote — a
+# supply-chain tripwire. Any crate NOT from crates.io or the allow-listed git
+# remote below fails the scan.
+unknown-registry = "deny"
+unknown-git = "deny"
+# The only git remote macrdp intentionally pulls from is the pinned IronRDP fork
+# (both the root tree and the standalone vendor/ironrdp-rdpeudp crate resolve
+# ironrdp-* from here via [patch.crates-io]).
+allow-git = [
+  "https://github.com/Devolutions/IronRDP.git",
+]
+
+[licenses]
+# NOT run in the daily CI gate (see the header note); kept so a local
+# `cargo deny check licenses` is meaningful. macrdp itself is MIT OR Apache-2.0;
+# this is the permissive set its dependency tree uses.
+version = 2
+confidence-threshold = 0.9
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  "Zlib",
+  "MPL-2.0",
+  "CC0-1.0",
+  "0BSD",
+]


### PR DESCRIPTION
## What

Adds daily-scheduled dependency vulnerability scanning via **cargo-deny**, plus the two lockfile fixes its first run turned up.

- **`deny.toml`** — gate on `advisories` + `bans` + `sources`. `licenses` is intentionally *not* in the gate (ring/aws-lc-rs carry non-SPDX/OpenSSL expressions that would red the build for a non-security reason and drown the vuln signal; the allow-list is kept for local `cargo deny check licenses`). Sources are locked to crates.io + the one IronRDP git remote.
- **`.github/workflows/security.yml`** — separate from `ci.yml` so the cron doesn't drag the macOS test matrix. Runs on a **daily schedule** + push/PR (path-filtered to `Cargo.*`/`deny.toml`) + `workflow_dispatch`. Scans the root tree *and* the standalone vendored `ironrdp-rdpeudp` crate.
- **`Cargo.lock`** — `anyhow` 1.0.102→1.0.103, `crossbeam-epoch` 0.9.18→0.9.20 (the two fixable advisories below).

## Why scheduled

macrdp pins IronRDP at an old rev and ships frozen releases for weeks, so a new advisory can hit a version we already shipped with **no code change** to trigger a scan. Only a scheduled re-scan of the unchanged `Cargo.lock` catches that. Failed scheduled runs email the repo owner (GitHub default) — no extra notification wiring.

## Supply-chain hardening of the scanner itself

The job runs third-party tooling unattended, so:
- cargo-deny is **version-pinned** (`=0.19.9`), not float-to-latest.
- harden-runner runs in **`block`** mode with an explicit egress allow-list.
- **no `rust-cache`** step — keeps the allow-list deterministic (avoids the GitHub Actions cache's dynamic endpoints); tiny perf cost on a daily job.
- token is `contents: read`, no secrets.

> First live block-mode run doubles as the allow-list test — if it fails on a blocked endpoint, harden-runner's summary names it (one-line add).

## First-run findings

| Advisory | Crate (path) | Disposition |
|---|---|---|
| RUSTSEC-2026-0190 | `anyhow` `downcast_mut()` unsoundness | **Fixed** — `cargo update -p anyhow` |
| RUSTSEC-2026-0204 | `crossbeam-epoch` invalid ptr deref (via `rayon`→`ironrdp-server`) | **Fixed** — `cargo update -p crossbeam-epoch` |
| RUSTSEC-2023-0071 | "Marvin" RSA timing side-channel in `rsa` (via `sspi`/`picky`/`winscard`) | **Ignored, justified** |

RUSTSEC-2023-0071 is ignored (with a written rationale in `deny.toml`) because: no upstream fix exists, it's inherited by all of IronRDP and every downstream server, it's not droppable without dropping CredSSP/NLA, and macrdp's posture is VPN/trusted-LAN only with rustls/aws-lc-rs TLS (unaffected). **Re-review this ignore on each IronRDP pin bump.**

## Scope

This is dependency-CVE coverage — *reactive* by nature (catches a supply-chain compromise only once a RustSec advisory exists). The proactive layer stays the committed `Cargo.lock` + `--locked` + deliberate pinning already in place. Not a code audit of the pre-auth parse surface.

## Verification

`advisories ok, bans ok, sources ok` on both scans locally; clean build; **163 tests pass** after the lockfile bumps.