### PR TITLE
test(security): cargo-fuzz harness for ironrdp-rdpeudp decoders

### DIFF
--- a/vendor/ironrdp-rdpeudp/fuzz/.gitignore
+++ b/vendor/ironrdp-rdpeudp/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/vendor/ironrdp-rdpeudp/fuzz/Cargo.toml
+++ b/vendor/ironrdp-rdpeudp/fuzz/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "ironrdp-rdpeudp-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+ironrdp-rdpeudp = { path = ".." }
+# For the free `decode::<T>` helper + ReadCursor in the EMT target.
+ironrdp-core = { version = "0.1", features = ["alloc"] }
+
+# This fuzz crate is its own workspace root (see [workspace] below), so the
+# parent's [patch.crates-io] does NOT apply — replicate it. Keep the rev in sync
+# with the root macrdp Cargo.toml and vendor/ironrdp-rdpeudp/Cargo.toml.
+[patch.crates-io]
+ironrdp-core = { git = "https://github.com/Devolutions/IronRDP.git", rev = "879ffed866c32748d30d26b54f9d667ad001c51c" }
+
+[[bin]]
+name = "datagram_decode"
+path = "fuzz_targets/datagram_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "eudp2_packet"
+path = "fuzz_targets/eudp2_packet.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "emt_tunnel"
+path = "fuzz_targets/emt_tunnel.rs"
+test = false
+doc = false
+bench = false
+
+# Isolate this crate from any parent workspace so it never gets swept into the
+# macrdp root build or the standalone-crate CI test.
+[workspace]

--- a/vendor/ironrdp-rdpeudp/fuzz/fuzz_targets/datagram_decode.rs
+++ b/vendor/ironrdp-rdpeudp/fuzz/fuzz_targets/datagram_decode.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// RDPEUDP v1 whole-datagram decoder: parses a raw UDP datagram from anyone who
+// can reach the multitransport port, BEFORE any TLS/auth. It must never panic
+// (or hang / OOM) on malformed input — a panic here is a pre-auth remote DoS.
+fuzz_target!(|data: &[u8]| {
+    let _ = ironrdp_rdpeudp::datagram::Datagram::decode(data);
+});

--- a/vendor/ironrdp-rdpeudp/fuzz/fuzz_targets/emt_tunnel.rs
+++ b/vendor/ironrdp-rdpeudp/fuzz/fuzz_targets/emt_tunnel.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// MS-RDPEMT tunnel PDUs. These ride INSIDE the reliable-UDP TLS tunnel (so
+// post-handshake, lower exposure than the two raw decoders), but the codec still
+// parses attacker-influenced bytes and must not panic.
+fuzz_target!(|data: &[u8]| {
+    let _ = ironrdp_rdpeudp::emt::TunnelCreateRequest::decode(data);
+    let _ = ironrdp_core::decode::<ironrdp_rdpeudp::emt::TunnelHeader>(data);
+});

--- a/vendor/ironrdp-rdpeudp/fuzz/fuzz_targets/eudp2_packet.rs
+++ b/vendor/ironrdp-rdpeudp/fuzz/fuzz_targets/eudp2_packet.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// RDPEUDP2 (0x0101) framing: the other raw pre-TLS datagram decoder. Drive both
+// the full packet parser and the bare header decode. Must never panic on
+// malformed input.
+fuzz_target!(|data: &[u8]| {
+    let _ = ironrdp_rdpeudp::eudp2::Eudp2Packet::parse(data);
+    let _ = ironrdp_rdpeudp::eudp2::Eudp2Header::decode(data);
+});


### PR DESCRIPTION
Adds a reusable `cargo-fuzz` harness for the pre-auth RDPEUDP wire decoders — the raw UDP datagram parsing a malicious client reaches **before any TLS/auth**, and the largest self-written network-facing parser in the project.

**Targets** (`vendor/ironrdp-rdpeudp/fuzz/`):
- `datagram_decode` → `datagram::Datagram::decode` (RDPEUDP v1 whole datagram)
- `eudp2_packet` → `eudp2::Eudp2Packet::parse` + `Eudp2Header::decode` (RDPEUDP2 0x0101)
- `emt_tunnel` → `emt::TunnelCreateRequest::decode` + `decode::<TunnelHeader>` (MS-RDPEMT; post-TLS)

**First run:** ~250M executions across the three, **0 crashes / panics / OOMs / hangs**, RSS flat (the `ensure_size!` guards hold — no length-driven allocation blow-up, incl. `AckVectorHeader`'s guarded `Vec::with_capacity`).

**Isolation:** the fuzz crate is its own workspace with its own `[patch.crates-io]` for `ironrdp-core` at the pinned rev, so it never enters the macrdp build or the standalone-crate CI. `corpus`/`artifacts`/`target` are gitignored.

Needs nightly + cargo-fuzz; run periodically or on `rdpeudp` changes rather than in CI:
```
cd vendor/ironrdp-rdpeudp && cargo +nightly fuzz run <target> -- -max_total_time=N
```

The `state.rs` reliability machine already has proptest coverage, so the decoders were the gap — now closed.