### PR TITLE
security(rdpeusb): fix decoder panics on truncated URBDRC PDUs + fuzz harness

### DIFF
--- a/vendor/ironrdp-rdpeusb/CLAUDE.md
+++ b/vendor/ironrdp-rdpeusb/CLAUDE.md
@@ -88,3 +88,21 @@ dropped because we live outside the IronRDP cargo workspace (mirrors
     server's `parse_configuration` fills it from the fetched config descriptor. Verified
     live: mstsc `SelectConfiguration` succeeds (pipe handles returned) for a camera +
     audio/HID device; FreeRDP mass storage unaffected. Upstreamable with (1)/(2).
+
+(4) **Panic-hardening: bound wire-controlled `read_slice` lengths in the
+    completion decoders** (`src/pdu/completion/mod.rs`, `src/pdu/completion/
+    ts_urb_result.rs`). Found 2026-07-09 by `cargo fuzz` (the `client_pdu` target
+    in `fuzz/`, over `UrbdrcClientPdu::decode` — the client→server PDUs the macrdp
+    server parses). Three decode sites read a length field off the wire and passed
+    it straight to `ReadCursor::read_slice(n)` **without an `ensure_size!` guard**,
+    so a truncated PDU panicked (`range end index N out of range`) instead of
+    returning a clean `DecodeError` — an attacker-influenced panic (the URBDRC DVC
+    is post-NLA + opt-in + entitled-only, so low severity, but a decode path must
+    never panic): (a) `TsUrbResult::decode` — `read_slice(urb_size - 8)`;
+    (b) `IoControlCompletion::decode` — `read_slice(information)`;
+    (c) `TsUsbdInterfaceInfoResult::decode` — `read_slice(length - 2)`. Fix: an
+    `ensure_size!(in: src, size: n)` before each slice (the exact idiom the sibling
+    `UrbCompletion::decode` already uses for `cb_ts_urb_result` / `output_buffer_size`).
+    After the fix, 107M fuzz execs clean. This is an **upstream bug** (not
+    macrdp-specific) — offer the guards upstream alongside (1)/(2)/(3); the
+    regression guard is the `fuzz/` harness (needs nightly + cargo-fuzz; not in CI).

--- a/vendor/ironrdp-rdpeusb/fuzz/.gitignore
+++ b/vendor/ironrdp-rdpeusb/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/vendor/ironrdp-rdpeusb/fuzz/Cargo.toml
+++ b/vendor/ironrdp-rdpeusb/fuzz/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "ironrdp-rdpeusb-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+ironrdp-rdpeusb = { path = ".." }
+# For the free `decode::<T>` helper.
+ironrdp-core = { version = "0.1", features = ["alloc"] }
+
+# This fuzz crate is its own workspace root (see [workspace] below), so the root
+# macrdp Cargo.toml's [patch.crates-io] does NOT apply. ironrdp-rdpeusb itself
+# carries NO patch block (it relies on the root's), so replicate the full git
+# pin set here — otherwise its ironrdp-* deps resolve to mismatched crates.io
+# versions. Keep the rev in sync with the root macrdp Cargo.toml on a pin bump.
+# (Unused entries just warn; included wholesale so the transitive graph resolves
+# to one consistent git rev, matching the macrdp build.)
+[patch.crates-io]
+ironrdp-str            = { git = "https://github.com/Devolutions/IronRDP.git", rev = "879ffed866c32748d30d26b54f9d667ad001c51c" }
+ironrdp-error          = { git = "https://github.com/Devolutions/IronRDP.git", rev = "879ffed866c32748d30d26b54f9d667ad001c51c" }
+ironrdp-core           = { git = "https://github.com/Devolutions/IronRDP.git", rev = "879ffed866c32748d30d26b54f9d667ad001c51c" }
+ironrdp-pdu            = { git = "https://github.com/Devolutions/IronRDP.git", rev = "879ffed866c32748d30d26b54f9d667ad001c51c" }
+ironrdp-graphics       = { git = "https://github.com/Devolutions/IronRDP.git", rev = "879ffed866c32748d30d26b54f9d667ad001c51c" }
+
+[[bin]]
+name = "client_pdu"
+path = "fuzz_targets/client_pdu.rs"
+test = false
+doc = false
+bench = false
+
+# Isolate from any parent workspace so it never enters the macrdp build or the
+# standalone-crate CI.
+[workspace]

--- a/vendor/ironrdp-rdpeusb/fuzz/fuzz_targets/client_pdu.rs
+++ b/vendor/ironrdp-rdpeusb/fuzz/fuzz_targets/client_pdu.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// The URBDRC client→server PDU decoder — what the macrdp SERVER parses off the
+// (post-auth, opt-in, entitled) URBDRC dynamic virtual channel: capability
+// responses, AddDevice announcements, and URB/IOCTL completions. Untrusted
+// client input; must never panic / OOM / hang on malformed bytes.
+fuzz_target!(|data: &[u8]| {
+    let _ = ironrdp_core::decode::<ironrdp_rdpeusb::pdu::UrbdrcClientPdu>(data);
+});

--- a/vendor/ironrdp-rdpeusb/src/pdu/completion/mod.rs
+++ b/vendor/ironrdp-rdpeusb/src/pdu/completion/mod.rs
@@ -111,6 +111,10 @@ impl IoControlCompletion {
             // #[expect(clippy::as_conversions)]
             0 | HRESULT_FROM_WIN32_ERROR_INSUFFICIENT_BUFFER => {
                 let n = information.try_into().map_err(|e| other_err!(source: e))?;
+                // `information` is attacker-controlled; guard before slicing or
+                // `read_slice` panics on a truncated PDU (matches the guarded
+                // `output_buffer_size` read in UrbCompletion::decode below).
+                ensure_size!(in: src, size: n);
                 Vec::from(src.read_slice(n))
             }
             // > For any other case [OutputBufferSize] MUST be set to 0

--- a/vendor/ironrdp-rdpeusb/src/pdu/completion/ts_urb_result.rs
+++ b/vendor/ironrdp-rdpeusb/src/pdu/completion/ts_urb_result.rs
@@ -43,7 +43,12 @@ impl Decode<'_> for TsUrbResult {
         if urb_size < ACTUAL_HEADER_SIZE {
             return Err(invalid_field_err!("TS_URB_RESULT_HEADER::Size", "is smaller than 8"));
         }
-        let payload = TsUrbResultPayload::decode(&mut ReadCursor::new(src.read_slice(urb_size - ACTUAL_HEADER_SIZE)))?;
+        // `urb_size` is attacker-controlled (read off the wire); guard the cursor
+        // before slicing, or `read_slice` panics on a truncated PDU instead of
+        // returning a clean decode error.
+        let payload_size = urb_size - ACTUAL_HEADER_SIZE;
+        ensure_size!(in: src, size: payload_size);
+        let payload = TsUrbResultPayload::decode(&mut ReadCursor::new(src.read_slice(payload_size)))?;
         Ok(Self { header, payload })
     }
 }
@@ -426,6 +431,9 @@ impl Decode<'_> for TsUsbdInterfaceInfoResult {
                 "is less than min reqd value of 16"
             ));
         };
+        // `length` is attacker-controlled; guard before slicing (the `16..`
+        // pattern above rules out underflow, not over-read).
+        ensure_size!(in: src, size: usize::from(length) - 2);
         let mut src = ReadCursor::new(src.read_slice(usize::from(length) - 2));
         let interface_number = src.read_u8();
         let alternate_setting = src.read_u8();


### PR DESCRIPTION
Fuzzing the last piece of self-written network-facing parsing (the USB-redirection URBDRC PDU decoder) turned up three real panics.

## The bug
`UrbdrcClientPdu::decode` — what the macrdp **server** parses off the URBDRC dynamic channel — reached three decode sites that read a length field off the wire and passed it straight to `ReadCursor::read_slice(n)` **without an `ensure_size!` guard**. A truncated PDU therefore **panicked** (`range end index N out of range for slice of length M`) instead of returning a clean `DecodeError`:

| Site | Slice length |
|---|---|
| `TsUrbResult::decode` | `read_slice(urb_size - 8)` |
| `IoControlCompletion::decode` | `read_slice(information)` |
| `TsUsbdInterfaceInfoResult::decode` | `read_slice(length - 2)` |

Each now has an `ensure_size!(in: src, size: n)` before the slice — the exact idiom the sibling `UrbCompletion::decode` already uses for `cb_ts_urb_result` / `output_buffer_size`.

## Verification
- Both fuzz-found crash inputs now decode cleanly (return `Err`).
- **107M fuzz executions run clean** afterwards — 0 crashes / OOMs / hangs, RSS flat.
- `clippy -D warnings` + the 163-test macrdp suite green.

## Severity
Low — the URBDRC channel is **post-NLA**, **opt-in** (`--enable-usb-redirection`), and **inert without the entitled build** — but a decode path must never panic on malformed input. These are **upstream bugs** (not macrdp-specific), documented as divergence (4) in the vendored crate's `CLAUDE.md` and flagged to upstream alongside the existing interop divergences.

## Harness
Adds `vendor/ironrdp-rdpeusb/fuzz/` (cargo-fuzz, isolated workspace + own patch pins) as the regression guard — mirrors the `ironrdp-rdpeudp` harness. Needs nightly + cargo-fuzz; run on `rdpeusb` changes rather than in CI:
```
cd vendor/ironrdp-rdpeusb && cargo +nightly fuzz run client_pdu -- -max_total_time=N
```

Completes the pre-auth/local security audit's parser-fuzzing arm (the `rdpeudp` decoders were fuzzed clean earlier; this one found + fixed real bugs).