### PR TITLE
docs: --alt-backtick-switch parity in configuration + architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,8 +25,9 @@ src/input.rs      RDP scancodes/mouse PDUs → CGEvent synthesis (US ANSI by
                   (Cmd+Tab app cycle, Cmd+` window cycle, Spotlight,
                   screencapture) since WindowServer's symbolic-hotkey
                   dispatcher won't fire for CGEventPost. The Cmd+Tab cycle
-                  (also Option+Tab with --alt-tab-switch) makes the landing
-                  app always surface — un-minimize / reopen-windowless
+                  (also Option+Tab with --alt-tab-switch), and the Cmd+`
+                  window cycle (also Option+` with --alt-backtick-switch),
+                  make the landing app always surface — un-minimize / reopen-windowless
                   (open -b) / unhide, gated to the committed app — and, with
                   --app-switcher-hud, drives the macrdphud overlay via
                   src/switcher_hud.rs. Also the optional Ctrl→Cmd

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,12 @@ packaging side, see [../packaging/README.md](../packaging/README.md).
                           gate Win+Tab (e.g. mstsc's "Apply Windows key
                           combinations" when windowed). Option+Shift+Tab cycles
                           backward. macOS-only.
+--alt-backtick-switch     Also accept Option+` (Alt+` from the client) as a
+                          window-cycle trigger for the current app, in addition
+                          to Cmd+`. Off by default. The Option+Tab analogue of
+                          --alt-tab-switch, for clients that forward Alt+` but
+                          gate Win-key combos. Option+Shift+` cycles backward.
+                          macOS-only.
 --app-switcher-hud        Show a visual app-switcher overlay (icon row, like
                           macOS's native Cmd+Tab) on the remote during Cmd+Tab /
                           Option+Tab. Off by default. macrdp spawns a small helper


### PR DESCRIPTION
Follow-up to #145. That PR added `--alt-backtick-switch` and documented it in `docs/features.md` + `packaging/config.env.example`, but not in `docs/configuration.md` (the user-facing flag reference) or `docs/architecture.md`, where its sibling `--alt-tab-switch` already appears. This adds the two parity entries. Docs-only.