### PR TITLE
config: bridge blank-recovery + auto-reconnect tunables into config.env; prune TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,22 +7,6 @@ then delete; promote a parked item to *In flight* when work actually starts.
 
 ## In flight (needs an action)
 
-- [x] **mstsc reconnect-blank SOLVED — in-place self-heal shipped (v0.8.27, #142 merged + released 2026-07-07; LIVE-VERIFIED real mstsc/WiFi 9/9 blanks healed, zero drops). (Remove this item next prune.)** The nine-pass "not server-fixable" saga is over. Root cause was mstsc retaining EGFX **surface id 0** across an in-process reconnect and compositing the stale surface (black). Every prior dislodge attempt bundled a surface delete or DVC/channel close (`resize_with_monitors` DeleteSurface, xrdp's DELETE_SURFACE+DYNVC_CLOSE) — all proven client-fatal. **Fix:** on a detected blank, send a **bare core Deactivation–Reactivation** (Server Deactivate All → new Demand Active) that touches NOTHING in the EGFX pipeline → mstsc re-maps surface 0 and presents again in place, ~1–2 s, no disconnect. Zero vendored-server change: `h264.rs` (`BlankAction::Reactivate` → `perform_blank_reactivate` stashes size in `Gfx::reactivate_request`) → `capture.rs::next_update` emits a no-op `DisplayUpdate::Resize(current)` → the server's existing `deactivate_all`+`new_deactivation_reactivation` preserves static channels so `setup_locked` skips (no resize_with_monitors/DeleteSurface). Now the **default** recovery action; the old connection-drop is only the fallback (`max_attempts` forced ≥2). Detection sped **~70 s → ~4 s** via a wall-clock fast-path (`MACRDP_BLANK_RECOVERY_MAX_WAIT_MS`/`MIN_WALL_REPORTS`); still RTT+QoE gated (FreeRDP/high-RTT untouched). `--fork-workers` no longer needed for reconnect reliability. Detail: [[project_h264_reconnect_blank]] TENTH PASS + the reconnect-blank quirk note. **DON'T re-add any surface-delete to the recovery path.**
-
-- [x] **Make blank-recovery RTT-aware — DONE, #135 merged + deployed + LIVE-VERIFIED 2026-07-05 (real mstsc over ZeroTier-on-MOBILE, link_rtt 142–161 ms: `seeding adaptive bitrate at ceiling/3` seed_bps=2000000 + `blank recovery DISARMED` both fired; session stable, user-confirmed working; config now clean — no plist override, --bitrate 6 restored). (Remove this item next prune.)** Original item: Found
-  live 2026-07-05 (real mstsc over ZeroTier). The detector (`src/h264.rs`
-  `should_blank_recover`) reads mstsc's QoE decode+render-time==0 as "not presenting" and
-  drops the connection, expecting nonzero EDR within ~200 ms (a LAN assumption). Over
-  ZeroTier a session that IS visibly rendering reports EDR=0 → it force-drops a WORKING
-  session every ~5 s, and the repeated drops poison mstsc's surface into a REAL permanent
-  black — i.e. the recovery *causes* the blank it's meant to fix. **Worked around** for the
-  ZeroTier user by `MACRDP_BLANK_RECOVERY=0` in the deployed LaunchAgent plist, but that
-  globally loses the LAN reconnect-blank protection. Proper fix (analogous to the #130
-  RTT-aware adaptive-bitrate signal): gate/scale the detector by link RTT, or require a
-  stronger signal (e.g. also-no-frame-acks, not just EDR==0) before dropping. Also worth
-  bridging `BLANK_RECOVERY` as a friendly `config.env` key (today it's env-only, not in the
-  `args_from_config` bridge list). Detail: [[project_zerotier_mstsc_tuning]].
-
 - [ ] **Tier 2.4 — multi-day soak (foundation core PASSED 31 h 2026-07-03; full 48–72 h on
   v0.8.24 still needed).** The last leg of the production-readiness trio (TLS ✓ #104, auth ✓
   #105). Tooling: `scripts/soak-monitor.sh monitor` samples a resource CSV; `… analyze`
@@ -71,57 +55,6 @@ then delete; promote a parked item to *In flight* when work actually starts.
   rect (`encoder/mod.rs:520,337`) — reuse a scratch buffer + one `spawn_blocking` per update;
   legacy-clients-only, clean upstream PRs. NOT worth doing: RDPEUDP per-datagram allocs
   (inherent to sans-I/O design), NFS readdir pagination cache, UDP idle tick suppression.
-- [x] **Softer UDP adaptive-bitrate signal over WiFi (retransmit tolerance).** SHIPPED
-  2026-06-29 (#100): `MACRDP_UDP_ADAPTIVE_RETX_TOLERANCE` (default 2) so sporadic wireless
-  retransmits don't ratchet the bitrate down. BUT the live mstsc/WiFi6 test disproved the
-  hypothesis for that link — the degradation was **ack-lag-driven** (tunnel wedging /
-  HOL-block, `retransmit_delta=0` on every decrease), not retransmit-driven, so the
-  tolerance never engaged and the watchdog de-migrated to TCP. Kept as a correct low-risk
-  improvement for links that *do* retransmit; the WiFi6 answer stays `UDP_MIGRATE_EGFX=0`.
-  The reliable-tunnel retransmit counter barely fires in practice — ack-lag is the dominant
-  signal. (Remove this line next prune.)
-
-- [x] **UDP-tunnel death detection + offer cooldown — SHIPPED (#133) + LIVE-VERIFIED
-  2026-07-04** (the fix for mstsc's ~60s dead-tunnel session reset; keepalives were
-  REJECTED — in the overlay case the UDP path itself is dead, so keepalives can't arrive
-  either). The listener declares a BOUND tunnel dead after `MACRDP_UDP_TUNNEL_DEAD_SECS`
-  (30s) of inbound silence → audio falls back to TCP immediately + multitransport offers
-  are suppressed for `MACRDP_UDP_MT_COOLDOWN_SECS` (600s). **Live verification (real
-  mstsc over ZeroTier, natural wedge):** 3× `UDP tunnel DEAD` at `idle_ms≈30s`, audio
-  kept playing through the fallback (user-confirmed), every reconnect logged
-  `multitransport offer SUPPRESSED` and ran plain TCP — cycle broken. Known limit: the
-  cooldown is in-process state, so a server crash/restart wipes it (observed once via the
-  NSPasteboard SIGSEGV below — one fresh offer followed). The verify run also surfaced the
-  oversized-cursor session-killer (PR #134) and that crash. Docs updated
-  (features.md/cli.md). Blockage tool for future re-tests: `scripts/udp-block.sh`
-  (pf-anchor UDP-only block on :3390). (Remove this item next prune.)
-
-- [x] **Oversized-cursor sprite kills the session — FIXED (#134, in v0.8.25, deployed; field-verified through hours of live use that previously crashed every ~45 s). (Remove next prune.)**
-  `TS_COLORPOINTERATTRIBUTE`'s XOR mask length is u16, so `w*h*4 > 65535` (e.g. macOS
-  shake-to-locate at Retina backing pixels, 128×128 = 65536) makes the encode error tear
-  down the whole client loop — killed 6 straight ZeroTier sessions at ~45 s during the
-  #133 verify (and fired at 00:43 that morning on the previous build). Fix:
-  `cursor/mod.rs::clamp_pointer_size` downscales aspect-preserving (hotspot-exact) via the
-  existing resampler; unit-tested.
-
-- [x] **NSPasteboard SIGSEGV crash — FIXED via a global pasteboard mutex (2026-07-07).**
-  2026-07-04 19:47:58 crash `macrdp-2026-07-04-194758.ips`: `objc_msgSend` under
-  `-[NSPasteboard _updateTypeCacheIfNeeded]` ← `_typesAtIndex:combinesItems:` during
-  connection churn (~13 s after a client-loop failure + a fresh accept). **Root cause
-  confirmed:** the process-global `NSPasteboard` (AppKit, NOT thread-safe) was accessed
-  from multiple threads with ZERO serialization — the advertise poller (a tokio worker)
-  walking `pasteboardItems()`/`types()` overlapped a concurrent writer
-  (`clearContents`/`writeObjects`/`setData` from the paste, download, or disconnect-Drop
-  paths, each on its own thread), which corrupts the pasteboard's internal type cache →
-  use-after-free → segfault. The disconnect-Drop clear racing the poller is the churn
-  window. **Fix:** `clipboard::pasteboard_guard()` — a process-global `Mutex<()>` that
-  every `pb::` accessor and every `file_promise*` pasteboard touch holds for the span of
-  its objc calls (poison-recovering, since the guarded data is `()`); the check-then-clear
-  cleanup paths hold it across the changeCount read + the clear so that's atomic too.
-  Serializes reader vs. writer and closes the race. Rare, so unproven-by-repro — keep the
-  `.ips` files and watch for a DIFFERENT signature (the 2026-06-28 `UNKNOWN_0x32` pthread
-  crash is a separate, still-open one-off).
-
 - [ ] **Congestion-responsive encoder rate control + frame dropping** (highest-value
   video-under-loss work — helps BOTH the default TCP path and UDP). **P1 (adaptive bitrate)
   SHIPPED as #94; P2a (IDR backoff + ack-lag signal switch) SHIPPED 2026-06-29;
@@ -421,6 +354,13 @@ then delete; promote a parked item to *In flight* when work actually starts.
   ceiling (NO-GO): multi-user concurrent GUI sessions (macOS limit).
 
 ## Parked — scoped, low priority
+
+- [ ] **Crash-report watch (post NSPasteboard-mutex fix).** The rare churn-time
+  NSPasteboard use-after-free SIGSEGV was fixed 2026-07-07 via a process-global
+  pasteboard mutex (`clipboard::pasteboard_guard()`, released in v0.8.29) — but it was
+  rare, so it's unproven-by-repro. Keep the `.ips` files and watch new crash reports for
+  a DIFFERENT signature. The 2026-06-28 `UNKNOWN_0x32` pthread crash is a separate,
+  still-open one-off.
 
 - [ ] **Auto-sized virtual display.** Resize the vdisplay to the client's resolution on
   connect (avoids the mirror-primary scaling lag). Risk: does `CGVirtualDisplay applySettings`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -345,7 +345,9 @@ each interval and waits `TIMEOUT_SECS` for it to run; a deadlocked runtime never
 runs it. A bounce logs `health-check watchdog: tokio runtime wedged …` before
 exiting.
 
-Blank recovery + auto-reconnect (env-only; on by default with `--enable-h264`).
+Blank recovery + auto-reconnect (env-tunable, **settable through `config.env`**
+— the matching keys are the same names minus the `MACRDP_` prefix, e.g.
+`BLANK_RECOVERY=0`; on by default with `--enable-h264`).
 The mstsc reconnect-blank auto-heal now **reactivates the RDP core in place** —
 on a detected blank the server sends a bare Deactivation–Reactivation (Server
 Deactivate All → new Demand Active) that preserves the EGFX channel/surface, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,29 @@ retry-after.
 (Log rotation is likewise env-tunable: `MACRDP_LOG_MAX_BYTES` (default 10 MiB) and
 `MACRDP_LOG_MAX_FILES` (default 5); see `--log-dir`.)
 
+### Blank recovery + auto-reconnect (on by default with `--enable-h264`)
+
+The mstsc reconnect-blank auto-heal: on a detected blank the server sends a bare
+core Deactivation–Reactivation that makes mstsc re-map its retained surface and
+present again **in place** (~1-2 s, no disconnect); a connection drop — healed by
+the client's auto-reconnect cookie — is only the fallback. Detection is
+**link-aware**: the server measures each connection's TCP RTT and, on slow links
+(≥ 80 ms) where the detection signal is unreliable, stands down instead of
+dropping a working session. The defaults are right for almost everyone; tune via
+`config.env` (keys shown) or the matching `MACRDP_*` env vars:
+
+```
+BLANK_RECOVERY=1              # master switch (0 = disable the detector entirely)   [env: MACRDP_BLANK_RECOVERY]
+BLANK_RECOVERY_REACTIVATE=1   # 1 = reactivate-in-place (heals mstsc); 0 = drop-only  [MACRDP_BLANK_RECOVERY_REACTIVATE]
+BLANK_RECOVERY_MAX_RTT_MS=80  # stand down at/above this link RTT (0 = always armed)  [MACRDP_BLANK_RECOVERY_MAX_RTT_MS]
+AUTO_RECONNECT=1              # 0 = don't provision the auto-reconnect cookie         [MACRDP_AUTO_RECONNECT]
+```
+
+Expert window tunables follow the same pattern (`BLANK_RECOVERY_{MIN_QOE,
+MAX_WAIT_MS,MIN_WALL_REPORTS,ARM_MS,RETRY_MS,MAX_ATTEMPTS,MAX_CONSECUTIVE_DROPS}`);
+QoE-less clients (FreeRDP) and high-RTT links are never touched. See the
+blank-recovery notes in `docs/known-quirks.md` for the full story.
+
 ## Headless mode
 
 `--virtual-display --width W --height H` allocates a headless display via undocumented `CGVirtualDisplay*` private API and serves it over RDP instead of mirroring the Mac's panel. Behaves like plugging in an external monitor — the remote session gets its own desktop at the requested resolution, and you keep using the Mac locally as normal. Add `--make-primary` to give the virtual display the menu bar so new app windows open there.

--- a/packaging/config.env.example
+++ b/packaging/config.env.example
@@ -231,17 +231,26 @@ FORK_WORKERS=0
 # LaunchAgent, stdout when interactive.
 # LOG_DIR="/Users/me/Library/Logs"
 
+# --- Blank recovery + auto-reconnect (on by default with ENABLE_H264=1) ------
+# The mstsc reconnect-blank auto-heal: on a detected blank the server sends a
+# bare core Deactivation–Reactivation that makes mstsc re-map its retained
+# surface and present again IN PLACE (~1-2 s, no disconnect); a connection drop
+# (healed by the client's auto-reconnect cookie) is only the fallback. LINK-AWARE
+# since v0.8.25 — the server measures each connection's TCP RTT and, on slow
+# links (>= 80 ms) where the detection signal is unreliable, automatically stands
+# down instead of dropping a working session. Rarely need changing.
+# BLANK_RECOVERY=1              # master switch (0 = disable the detector entirely)
+# BLANK_RECOVERY_REACTIVATE=1   # 1 = reactivate-in-place (heals mstsc); 0 = old drop-only
+# BLANK_RECOVERY_MAX_RTT_MS=80  # stand down at/above this link RTT (0 = always armed)
+# AUTO_RECONNECT=1              # 0 = don't provision the auto-reconnect cookie
+# Expert window tunables (same names minus the MACRDP_ prefix work here too):
+# BLANK_RECOVERY_{MIN_QOE,MAX_WAIT_MS,MIN_WALL_REPORTS,ARM_MS,RETRY_MS,
+# MAX_ATTEMPTS,MAX_CONSECUTIVE_DROPS} — see docs/cli.md for defaults.
+
 # --- Automatic behaviors with env-only tunables (not config.env keys) --------
 # These work out of the box; tune them only via the LaunchAgent plist's
 # EnvironmentVariables dict (see docs/cli.md + docs/known-quirks.md):
-#   Blank recovery (mstsc reconnect-blank auto-heal, needs ENABLE_H264=1): on by
-#   default and LINK-AWARE since v0.8.25 — the server measures each connection's
-#   TCP RTT and, on slow links (>= 80 ms) where the detection signal is
-#   unreliable, automatically stands down instead of dropping a working session.
-#   MACRDP_BLANK_RECOVERY=0 disables; MACRDP_BLANK_RECOVERY_MAX_RTT_MS moves the
-#   RTT gate (0 = always armed, the pre-v0.8.25 behavior).
 #   UDP tunnel death: MACRDP_UDP_TUNNEL_DEAD_SECS (30) / MACRDP_UDP_MT_COOLDOWN_SECS (600).
-#   Auto-reconnect cookie: MACRDP_AUTO_RECONNECT=0 disables.
 
 # Escape hatch: any other flags, space-separated, e.g.:
 #     EXTRA_FLAGS="--fps 60 --bitrate 8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1669,10 +1669,11 @@ fn args_from_config(path: &Path) -> Result<Args> {
             argv.push(path.clone());
         }
     }
-    // Auth-guard tunables are env-only (read at startup by auth_guard::*_from_env).
-    // Bridge the friendly config.env keys to their MACRDP_* env vars here so
-    // menu-bar / LaunchAgent users can tune them via config.env without editing
-    // the plist's EnvironmentVariables. Unset keys keep the on-by-default defaults.
+    // Env-only tunables (auth guard, health-check watchdog, blank recovery,
+    // auto-reconnect cookie — each read lazily after this point). Bridge the
+    // friendly config.env keys to their MACRDP_* env vars here so menu-bar /
+    // LaunchAgent users can tune them via config.env without editing the
+    // plist's EnvironmentVariables. Unset keys keep the on-by-default defaults.
     for (cfg_key, env_var) in [
         ("CONN_GUARD", "MACRDP_CONN_GUARD"),
         ("AUDIT_LOG", "MACRDP_AUDIT_LOG"),
@@ -1697,6 +1698,41 @@ fn args_from_config(path: &Path) -> Result<Args> {
             "MACRDP_HEALTHCHECK_TIMEOUT_SECS",
         ),
         ("HEALTHCHECK_FAILURES", "MACRDP_HEALTHCHECK_FAILURES"),
+        // Blank recovery (the mstsc reconnect-blank auto-heal, needs
+        // --enable-h264) + the auto-reconnect cookie. Env-driven like the
+        // guard (read in h264.rs per connection / main.rs at server build,
+        // both after this bridge runs). BLANK_RECOVERY=0 is the ask that
+        // motivated bridging: disabling the detector for an overlay-link
+        // profile used to need a plist EnvironmentVariables edit.
+        ("BLANK_RECOVERY", "MACRDP_BLANK_RECOVERY"),
+        (
+            "BLANK_RECOVERY_REACTIVATE",
+            "MACRDP_BLANK_RECOVERY_REACTIVATE",
+        ),
+        (
+            "BLANK_RECOVERY_MAX_RTT_MS",
+            "MACRDP_BLANK_RECOVERY_MAX_RTT_MS",
+        ),
+        ("BLANK_RECOVERY_MIN_QOE", "MACRDP_BLANK_RECOVERY_MIN_QOE"),
+        (
+            "BLANK_RECOVERY_MAX_WAIT_MS",
+            "MACRDP_BLANK_RECOVERY_MAX_WAIT_MS",
+        ),
+        (
+            "BLANK_RECOVERY_MIN_WALL_REPORTS",
+            "MACRDP_BLANK_RECOVERY_MIN_WALL_REPORTS",
+        ),
+        ("BLANK_RECOVERY_ARM_MS", "MACRDP_BLANK_RECOVERY_ARM_MS"),
+        ("BLANK_RECOVERY_RETRY_MS", "MACRDP_BLANK_RECOVERY_RETRY_MS"),
+        (
+            "BLANK_RECOVERY_MAX_ATTEMPTS",
+            "MACRDP_BLANK_RECOVERY_MAX_ATTEMPTS",
+        ),
+        (
+            "BLANK_RECOVERY_MAX_CONSECUTIVE_DROPS",
+            "MACRDP_BLANK_RECOVERY_MAX_CONSECUTIVE_DROPS",
+        ),
+        ("AUTO_RECONNECT", "MACRDP_AUTO_RECONNECT"),
     ] {
         if let Some(val) = cfg.get(cfg_key) {
             if !val.is_empty() {


### PR DESCRIPTION
Two quick wins from the TODO:

**1. `BLANK_RECOVERY` (+ family) as friendly `config.env` keys** — the sub-item left open in the RTT-aware blank-recovery entry. The `MACRDP_BLANK_RECOVERY_*` tunables and `MACRDP_AUTO_RECONNECT` join the existing `args_from_config` env-passthrough table (the auth-guard / health-check pattern), so disabling or tuning blank recovery — e.g. `BLANK_RECOVERY=0` for an overlay-link profile — no longer requires editing the LaunchAgent plist's `EnvironmentVariables`. All read sites verified lazy (per-connection in `h264.rs`, server-build in `main.rs`), i.e. after the bridge runs; each bridged name grep-verified against its read site. Docs: `config.env.example` ('env-only tunables' note converted to real keys), new user-facing subsection in `docs/configuration.md`, `docs/cli.md` header updated.

**2. TODO prune** — removes the five `[x]` items explicitly marked *remove next prune* (reconnect-blank saga, RTT-aware blank recovery, retransmit tolerance, tunnel-death detection, oversized cursor) and condenses the shipped NSPasteboard fix to its residual crash-report watch item under Parked.

Verified: `cargo fmt --check`, `clippy --all-targets -D warnings`, 163 tests pass; `--config` smoke run with the new keys parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)