### PR TITLE
fix(capture): smooth live-resize on the headless path (debounce flap + auto-gather)

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -624,12 +624,40 @@ impl CaptureDisplay {
         match vd.resize(u32::from(width), u32::from(height)) {
             Ok(()) => {
                 self.screen_size_pts = vd.size_pts();
+                let vd_id = vd.display_id();
                 tracing::info!(
                     width,
                     height,
-                    display_id = vd.display_id(),
+                    display_id = vd_id,
                     "virtual display re-moded to the client-requested session size"
                 );
+                // A re-mode shifts the display's origin/bounds, so windows
+                // positioned in the old coordinate space are stranded off the
+                // new display and vanish from the client's view (the
+                // disappearing-apps report). In the HEADLESS modes
+                // (--capture-primary/--detach-primary — where the vd is the only
+                // visible display, and `session_tracker` is Some exactly then),
+                // sweep them back onto the new bounds — the same as an on-demand
+                // Ctrl+Alt+G, but automatic because a resize is when the user
+                // expects their windows to follow (an on-CONNECT auto-gather was
+                // rejected as surprising; a post-RESIZE one isn't). Skipped for
+                // plain --virtual-display, where a window off the vd may be
+                // intentionally on the still-active physical panel. Off-thread
+                // (AX), after a short settle for the WindowServer's own relayout.
+                #[cfg(target_os = "macos")]
+                if self.session_tracker.is_some() {
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_millis(400));
+                        let moved = crate::input::gather_windows_onto_display(vd_id);
+                        if moved > 0 {
+                            tracing::info!(
+                                moved,
+                                display_id = vd_id,
+                                "gathered stranded windows after live resize"
+                            );
+                        }
+                    });
+                }
                 (width, height)
             }
             Err(e) => {

--- a/src/input.rs
+++ b/src/input.rs
@@ -314,6 +314,13 @@ pub fn init_focus_observer() {}
 #[cfg(target_os = "macos")]
 mod scancodes;
 
+// Re-export the gather-windows sweep so the capture path can trigger it
+// automatically after a live virtual-display re-mode (see
+// `capture.rs::sync_virtual_display`), the same routine the Ctrl+Alt+G hotkey
+// runs on demand.
+#[cfg(target_os = "macos")]
+pub(crate) use macos::gather_windows_onto_display;
+
 #[cfg(target_os = "macos")]
 mod macos {
     use std::collections::HashSet;
@@ -2475,7 +2482,7 @@ mod macos {
     /// Accessibility grant (for `CGEventPost`), so no extra permission/prompt.
     /// Returns how many windows were moved. Triggered on demand by the
     /// Ctrl+Option+G hotkey (see `try_symbolic_hotkey`).
-    fn gather_windows_onto_display(display_id: u32) -> usize {
+    pub(crate) fn gather_windows_onto_display(display_id: u32) -> usize {
         // CFRelease + CGPoint are already in scope (the mod-level extern block /
         // `use` above); importing them here would shadow.
         use core_foundation::base::{CFTypeRef, TCFType};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1081,6 +1081,21 @@ fn spawn_primary_overlay_watcher<T: Send + 'static>(
         // don't kick off a 10-second blocking install for a session
         // that's already gone.
         const CONNECT_DEBOUNCE: Duration = Duration::from_millis(750);
+        // Disconnect-side flap absorber. A core deactivation–reactivation (a live
+        // resize on maximize, or blank recovery) briefly drops the session count
+        // to 0 and right back to 1 as the vendored server drops the old
+        // `CountedUpdates` and builds a new one — a flap, not a real disconnect.
+        // Without absorbing it, the headless `CapturedPrimary` drops (restore
+        // gamma) and re-engages (re-blank) on every resize — a visible flicker,
+        // and the session re-cycle restarts audio. The gap is VARIABLE (observed
+        // ~0.5–0.9 s) because it includes the virtual-display re-mode, which
+        // blocks a variable amount — so a single fixed sleep can't reliably cover
+        // it. Instead POLL for the session to come back, up to REACTIVATION_GRACE,
+        // and skip the teardown as soon as it does; only a count that STAYS 0 for
+        // the whole window is a real disconnect (then teardown is delayed by at
+        // most the grace — a couple seconds of extra gamma-blank, harmless).
+        const REACTIVATION_GRACE: Duration = Duration::from_millis(2500);
+        const REACTIVATION_POLL: Duration = Duration::from_millis(75);
         let mut was_zero = true;
         let mut installed_at: Option<Instant> = None;
         loop {
@@ -1116,6 +1131,33 @@ fn spawn_primary_overlay_watcher<T: Send + 'static>(
                     }
                 }
                 (false, true) => {
+                    // Absorb a transient count→0: a core deactivation–reactivation
+                    // (a live resize on maximize, or blank recovery) flaps 1→0→1
+                    // as the vendored server rebuilds `CountedUpdates`. Poll for
+                    // the session to come back (up to REACTIVATION_GRACE); if it
+                    // does, keep the headless overlay engaged so it doesn't drop +
+                    // re-capture (the visible flicker) and doesn't restart audio.
+                    // Only a count that STAYS 0 for the whole window is a real
+                    // disconnect. `was_zero` is left false on the skip (overlay
+                    // still engaged), so the paired count→1 `enter` notification
+                    // lands as a no-op (false, false).
+                    let deadline = Instant::now() + REACTIVATION_GRACE;
+                    let mut came_back = false;
+                    while Instant::now() < deadline {
+                        tokio::time::sleep(REACTIVATION_POLL).await;
+                        if tracker.count.load(Ordering::SeqCst) > 0 {
+                            came_back = true;
+                            break;
+                        }
+                    }
+                    if came_back {
+                        info!(
+                            label,
+                            "session flapped during grace (reactivation) — keeping \
+                             headless overlay engaged"
+                        );
+                        continue;
+                    }
                     if let Some(installed) = installed_at {
                         let elapsed = installed.elapsed();
                         if elapsed < ENGAGED_SETTLE {


### PR DESCRIPTION
## Problem

A live client resize (maximize, or drag between monitors of different resolutions) genuinely changes the session resolution, so it needs a core deactivation–reactivation — and on the `--virtual-display`/`--capture-primary` **headless** path that cascaded into a visible **session re-cycle**: the vendored server drops the old `CountedUpdates` (`SessionTracker` `leave`, count 1→0) and builds a new one (`enter`, 0→1), and the `spawn_primary_overlay_watcher` reacted to the transient `count→0` by dropping + re-engaging the headless `CapturedPrimary` (gamma flicker) and restarting the audio. Result: a ~1–2 s flicker + a sound cut on every resize, and windows stranded off the re-moded display (needing a manual `Ctrl+Alt+G`).

## Fixes

**1. Poll-based disconnect debounce** (`spawn_primary_overlay_watcher`). The reactivation's `leave→enter` gap is *variable* (~0.5–0.9 s — it includes the virtual-display re-mode, which blocks a variable amount), so a single fixed sleep can't reliably cover it (an initial fixed 750 ms caught the fast reactivations but dropped the ~880 ms ones). Instead poll for the session to come back for up to `REACTIVATION_GRACE` (2.5 s) and skip the teardown as soon as it does; only a count that **stays** 0 for the whole window is a real disconnect. Mirrors the existing `CONNECT_DEBOUNCE`. This kills the `CapturedPrimary` re-cycle (flicker) and the audio restart on resize — and helps blank-recovery and the `Ctrl+Alt+Shift+R` resync hotkey for free (same reactivation).

**2. Auto-gather stranded windows after a re-mode.** A re-mode shifts the vd's origin/bounds, so windows positioned in the old coordinate space are stranded off the new display and vanish. Sweep them onto the new bounds automatically — but **only in the headless modes** (`session_tracker.is_some()` is true exactly for `--capture-primary`/`--detach-primary`, where the vd is the only visible display); skipped for plain `--virtual-display`, where a window off the vd may be intentionally on the still-active physical panel. Runs ~400 ms after the re-mode (WindowServer relayout settle), off-thread. `gather_windows_onto_display` is now `pub(crate)`. Unlike an on-*connect* auto-gather (rejected as surprising), a post-*resize* gather is expected — your windows should follow the new size.

## Verification (real mstsc, capture-primary, 2026-07-17)

Maximize + drag-between-monitors-of-different-resolutions:
- Both fast (696 ms) and slow (809 ms) reactivations now hold: `session flapped during grace (reactivation) — keeping headless overlay engaged`, **no** `CapturedPrimary::drop`, **no** `SCK audio format` re-log (audio stream survived).
- `gathered stranded windows after live resize moved=7`.
- User-confirmed: **flicker much better, sound cut minimal, apps stay on screen.**

## Known follow-up (not in this PR)

The macOS **Dock can still disappear after a re-mode** — a separate main-display/Dock-anchoring issue (in capture-primary the vd is a *secondary* display, so the Dock is macOS's cursor-following per-display Dock, which doesn't re-anchor cleanly on a re-mode). Tracked separately; the proper fix is likely making the vd the actual main display (`--make-primary`) and re-asserting it on re-mode, which needs untangling an existing "capture subsumes make-primary" code comment first.
