### PR TITLE
feat(audit): client fingerprint — log which RDP client connects + SIEM event

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -37,11 +37,11 @@ The same event is written to both sinks, e.g. an accepted connection:
 {"timestamp":"2026-07-10T18:22:04.117Z","level":"INFO","target":"macrdp::audit","schema_version":1,"macrdp_version":"0.8.32","host":"mac-studio","event":"accept","src_ip":"203.0.113.5","src_port":54132}
 ```
 
-## The four events
+## The five events
 
-macrdp maps one TCP connection to (usually) three events in order —
-**`accept` → `auth` → `disconnect`** — plus **`reject`** for connections the guard
-blocks *before* they ever handshake.
+macrdp maps one TCP connection to (usually) four events in order —
+**`accept` → `auth` → `fingerprint` → `disconnect`** — plus **`reject`** for
+connections the guard blocks *before* they ever handshake.
 
 ### `accept` — the guard let the connection through *(INFO)*
 Emitted the moment a connection passes the pre-handshake auth guard (per-IP
@@ -85,6 +85,36 @@ itself the tell that it never reached authentication.
 > **Scope:** the `auth` event is emitted on the single-process server path. See
 > `configuration.md`.
 
+### `fingerprint` — which RDP client connected *(INFO)*
+Emitted **once per connection** when the capability exchange completes (after
+`auth`; not re-emitted on an in-session reactivation such as a live resize or
+blank recovery). Carries the identity the client announced during the handshake:
+
+- **`client_name`** — the client machine's hostname (client-controlled;
+  sanitized: control-chars stripped, length-bounded).
+- **`rdp_version`** — the announced RDP protocol version, hex (e.g. `0x80011` =
+  RDP 10.12).
+- **`client_build`** — the client's announced build number.
+- **`platform`** — the OS platform from the client's General capability set.
+
+**This is fingerprinting, not authentication** — a client can claim anything.
+Live-verified signatures for telling clients apart:
+
+| Client | `client_build` | `platform` |
+|---|---|---|
+| **mstsc** (real Windows) | the actual Windows build (e.g. `26100` = Win11 24H2, `22621` = 22H2) | `WINDOWS/WINDOWS_NT` |
+| **Thincast** | `18363` (a fixed, claimed value — not the host's real build) | `UNSPECIFIED/UNSPECIFIED` |
+| **FreeRDP** family | `2600` (hardcoded XP build) | `UNIX/...` |
+| **Windows App** (macOS/iOS/Android) | varies | its host platform |
+
+Reading it: mstsc reports the *machine's real* build and a Windows platform;
+everyone else reports a fixed/claimed build and (for the FreeRDP family, which
+Thincast derives from) a non-Windows or unspecified platform. Use it for "which
+client is this?" triage — never as a trust signal.
+
+> **Scope:** the `fingerprint` event is emitted on the single-process server
+> path (same as `auth`).
+
 ### `disconnect` — the connection ended *(INFO)*
 Emitted when the connection closes, with `duration_ms` (wall-clock lifetime) and a
 heuristic `outcome`:
@@ -112,13 +142,17 @@ heuristic `outcome`:
 | `schema_version` | int | all | audit contract version (`1`); bumps only on a breaking field change |
 | `macrdp_version` | string | all | server build, e.g. `0.8.32` |
 | `host` | string | all | server hostname (a collector usually adds its own too) |
-| `event` | string | all | `accept` \| `reject` \| `auth` \| `disconnect` |
+| `event` | string | all | `accept` \| `reject` \| `auth` \| `fingerprint` \| `disconnect` |
 | `src_ip` | string | all | client source IP — the primary correlation key |
-| `src_port` | int | accept, auth, disconnect | client source port — completes the per-connection tuple. **Absent on `reject`.** |
+| `src_port` | int | accept, auth, fingerprint, disconnect | client source port — completes the per-connection tuple. **Absent on `reject`.** |
 | `reason` | string | reject, auth (failure only) | reject: `rate_limit` \| `lockout`. auth: sanitized sspi error text |
 | `window_attempts` | int | reject (`rate_limit`) | attempts counted in the current window |
 | `retry_after_secs` | int | reject (`lockout`) | seconds until the cooldown expires |
 | `outcome` | string | auth, disconnect | auth: `success` \| `did_not_complete`. disconnect: `success` \| `failure` |
+| `client_name` | string | fingerprint | client's announced hostname (client-controlled; sanitized) |
+| `rdp_version` | string | fingerprint | announced RDP protocol version, hex |
+| `client_build` | int | fingerprint | client's announced build number |
+| `platform` | string | fingerprint | OS platform from the General capset (server-formatted) |
 | `duration_ms` | int | disconnect | connection wall-clock lifetime in milliseconds |
 
 **Correlation:** an `accept`, its `auth`, and its `disconnect` share
@@ -130,11 +164,13 @@ time window; a monotonic per-connection id is a possible future additive field.
 
 **Normal successful session**
 ```text
-event="accept"     src_ip=203.0.113.5 src_port=54132
-event="auth"       src_ip=203.0.113.5 src_port=54132 outcome="success"
-event="disconnect" src_ip=203.0.113.5 src_port=54132 duration_ms=216913 outcome="success"
+event="accept"      src_ip=203.0.113.5 src_port=54132
+event="auth"        src_ip=203.0.113.5 src_port=54132 outcome="success"
+event="fingerprint" src_ip=203.0.113.5 src_port=54132 client_name="GENMACWIN" client_build=26100 platform="WINDOWS/WINDOWS_NT"
+event="disconnect"  src_ip=203.0.113.5 src_port=54132 duration_ms=216913 outcome="success"
 ```
-Allowed → authenticated → clean multi-minute session. The baseline.
+Allowed → authenticated → identified as real mstsc → clean multi-minute session.
+The baseline.
 
 **A single wrong password**
 ```text

--- a/docs/siem-forwarding.md
+++ b/docs/siem-forwarding.md
@@ -1,7 +1,7 @@
 # SIEM / SOC forwarding — the JSON audit stream
 
-macrdp emits its security-relevant events (connection **accept / reject / auth / disconnect**,
-with source IP+port, reason, and outcome) on a dedicated `macrdp::audit` tracing target. Point
+macrdp emits its security-relevant events (connection **accept / reject / auth / fingerprint /
+disconnect**, with source IP+port, reason, and outcome) on a dedicated `macrdp::audit` tracing target. Point
 `--audit-file` at a file and those events are additionally written as **one JSON object per
 line** — a stable, versioned contract a log collector can tail and forward to a SIEM.
 
@@ -70,7 +70,7 @@ Fields common to the events (all carry these except where the `src_port` row not
 | `schema_version` | int | `1` |
 | `macrdp_version` | string | e.g. `0.8.32` |
 | `host` | string | server hostname (a collector usually adds its own too) |
-| `event` | string | `accept` \| `reject` \| `auth` \| `disconnect` |
+| `event` | string | `accept` \| `reject` \| `auth` \| `fingerprint` \| `disconnect` |
 | `src_ip` | string | peer IP — correlation key |
 | `src_port` | int | peer source port — correlation key (present on `accept`/`auth`/`disconnect`; **absent on `reject`**, which is a per-IP decision) |
 
@@ -81,6 +81,7 @@ Event-specific:
 | `accept` | — |
 | `reject` | `reason` (`rate_limit` \| `lockout`), and `window_attempts` **or** `retry_after_secs` |
 | `auth` | `outcome` (`success` \| `did_not_complete`), and `reason` (only on `did_not_complete`) |
+| `fingerprint` | `client_name`, `rdp_version`, `client_build`, `platform` (which RDP client connected — informational, not a trust signal) |
 | `disconnect` | `duration_ms`, `outcome` (`success` \| `failure`) |
 
 The `auth` event is the explicit CredSSP/NLA login verdict, emitted once when the exchange
@@ -101,6 +102,7 @@ per-connection id is a possible future additive field.)
 ```json
 {"timestamp":"2026-07-10T18:22:04.117Z","level":"INFO","target":"macrdp::audit","schema_version":1,"macrdp_version":"0.8.32","host":"mac-studio","event":"accept","src_ip":"203.0.113.5","src_port":54132}
 {"timestamp":"2026-07-10T18:22:04.402Z","level":"INFO","target":"macrdp::audit","schema_version":1,"macrdp_version":"0.8.32","host":"mac-studio","event":"auth","src_ip":"203.0.113.5","src_port":54132,"outcome":"success"}
+{"timestamp":"2026-07-10T18:22:04.451Z","level":"INFO","target":"macrdp::audit","schema_version":1,"macrdp_version":"0.8.32","host":"mac-studio","event":"fingerprint","src_ip":"203.0.113.5","src_port":54132,"client_name":"GENMACWIN","rdp_version":"0x80011","client_build":26100,"platform":"WINDOWS/WINDOWS_NT"}
 {"timestamp":"2026-07-10T18:22:09.882Z","level":"WARN","target":"macrdp::audit","schema_version":1,"macrdp_version":"0.8.32","host":"mac-studio","event":"reject","reason":"lockout","src_ip":"203.0.113.9","retry_after_secs":240}
 {"timestamp":"2026-07-10T18:25:41.030Z","level":"INFO","target":"macrdp::audit","schema_version":1,"macrdp_version":"0.8.32","host":"mac-studio","event":"disconnect","src_ip":"203.0.113.5","src_port":54132,"duration_ms":216913,"outcome":"success"}
 ```

--- a/src/auth_guard.rs
+++ b/src/auth_guard.rs
@@ -555,6 +555,42 @@ pub fn audit_auth(ip: IpAddr, port: u16, success: bool, reason: Option<&str>) {
     }
 }
 
+/// Audit-log the client fingerprint for a connection, emitted once per
+/// connection when the capability exchange completes (after `auth`). The
+/// identity fields come from the client's GCC Client Core Data + General capset
+/// and are **informational fingerprinting only** — a client can claim anything.
+/// Known signatures (see `docs/audit-log.md`): mstsc = the real Windows build
+/// (e.g. 26100 = Win11 24H2) + platform `WINDOWS/WINDOWS_NT`; FreeRDP family =
+/// build 2600; Thincast = build 18363 + platform `UNSPECIFIED/UNSPECIFIED`.
+/// `client_name` is client-controlled → control-char-stripped + length-bounded
+/// (same log-injection defense as the auth `reason`). `platform` is
+/// server-formatted (safe).
+pub fn audit_fingerprint(
+    ip: IpAddr,
+    port: u16,
+    client_name: &str,
+    rdp_version: u32,
+    client_build: u32,
+    platform: &str,
+) {
+    if !audit_enabled() {
+        return;
+    }
+    tracing::info!(
+        target: "macrdp::audit",
+        schema_version = AUDIT_SCHEMA_VERSION,
+        macrdp_version = env!("CARGO_PKG_VERSION"),
+        host = host(),
+        event = "fingerprint",
+        src_ip = %ip,
+        src_port = port,
+        client_name = %bound_reason(Some(client_name)),
+        rdp_version = format_args!("{rdp_version:#x}"),
+        client_build,
+        platform = %platform,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Single-process ConnectionHandler adapter
 // ---------------------------------------------------------------------------
@@ -603,6 +639,25 @@ impl ironrdp_server::ConnectionHandler for AuthGuardHandler {
         // precedes the connection); guard defensively rather than assume it.
         if let Some(peer) = self.last_peer {
             audit_auth(peer.ip(), peer.port(), success, reason);
+        }
+    }
+
+    fn on_client_fingerprint(
+        &mut self,
+        client_name: &str,
+        rdp_version: u32,
+        client_build: u32,
+        platform: &str,
+    ) {
+        if let Some(peer) = self.last_peer {
+            audit_fingerprint(
+                peer.ip(),
+                peer.port(),
+                client_name,
+                rdp_version,
+                client_build,
+                platform,
+            );
         }
     }
 
@@ -1006,6 +1061,48 @@ mod tests {
         // Failure event carries the (bounded) reason.
         assert!(out.contains("outcome=\"did_not_complete\""), "{out}");
         assert!(out.contains("reason=logon denied"), "{out}");
+    }
+
+    #[test]
+    fn on_client_fingerprint_emits_fingerprint_event() {
+        use ironrdp_server::ConnectionHandler;
+
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .finish();
+
+        let peer = std::net::SocketAddr::from((Ipv4Addr::new(203, 0, 113, 5), 51000));
+        tracing::subscriber::with_default(subscriber, || {
+            let mut handler = AuthGuardHandler {
+                core: AuthGuardCore::with_config(test_cfg()),
+                last_peer: None,
+            };
+            assert!(handler.on_accept(peer));
+            // A hostile client name with a control char (log-injection attempt)
+            // must come out stripped.
+            handler.on_client_fingerprint("GENMACWIN\nevil", 0x80011, 26100, "WINDOWS/WINDOWS_NT");
+        });
+
+        let out = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            out.contains("event=\"fingerprint\""),
+            "no fingerprint event:\n{out}"
+        );
+        assert!(out.contains("src_ip=203.0.113.5"), "{out}");
+        assert!(out.contains("client_build=26100"), "{out}");
+        assert!(out.contains("rdp_version=0x80011"), "{out}");
+        assert!(out.contains("platform=WINDOWS/WINDOWS_NT"), "{out}");
+        // Control char stripped, name still present.
+        assert!(
+            out.contains("GENMACWIN evil"),
+            "control char not stripped:\n{out}"
+        );
+        assert!(
+            !out.contains("GENMACWIN\nevil"),
+            "raw control char leaked:\n{out}"
+        );
     }
 
     #[test]

--- a/vendor/ironrdp-acceptor/CLAUDE.md
+++ b/vendor/ironrdp-acceptor/CLAUDE.md
@@ -153,3 +153,15 @@ vendor dir until divergence (1) is upstreamed AND released.
     advertises `UDP_FECR|UDP_FECL|UDP_PREFERRED|SOFT_SYNC`, accepts the `UdpFecL`
     Initiate Request, opens a `SYN_LOSSY` flow, and starts a **DTLS 1.2**
     handshake. See docs/rdp-udp-multitransport-feasibility.md → "P2.0 Result".
+
+(4) Client-fingerprint identity fields from GCC Client Core Data (NOT upstreamed;
+    added 2026-07-18): `Acceptor` gains private `client_name: String` /
+    `client_version: u32` (raw `RdpVersion.0`) / `client_build: u32`, captured in
+    `BasicSettingsWaitInitial` alongside the KLID (divergence (2)) and surfaced as
+    `pub` fields on `AcceptorResult` (name cloned, not taken, so a
+    deactivation–reactivation's result still carries it). Consumed by the vendored
+    server's divergence (20) client-fingerprint log. Same additive GCC-surfacing
+    shape as (2) KLID/#1397 and the #1453 multitransport flags → cleanly
+    upstreamable later. Heuristics: mstsc sends the real Windows build (e.g.
+    22621) + its hostname; FreeRDP hardcodes build 2600. Informational
+    fingerprinting only — a client can claim anything.

--- a/vendor/ironrdp-acceptor/src/connection.rs
+++ b/vendor/ironrdp-acceptor/src/connection.rs
@@ -62,6 +62,16 @@ pub struct Acceptor {
     /// `BasicSettingsWaitInitial` and surfaced on `AcceptorResult` so the
     /// server can serve the client's keyboard layout. 0 = unknown / not sent.
     client_keyboard_layout: u32,
+    /// (vendored) Client-fingerprint identity fields from the GCC Client Core
+    /// Data (divergence (4)): the client machine's hostname, its announced RDP
+    /// version (raw u32; e.g. mstsc 0x80005 = V5_PLUS), and its build number
+    /// (mstsc = the real Windows build like 22621; FreeRDP hardcodes 2600).
+    /// Captured in `BasicSettingsWaitInitial` alongside the KLID and surfaced
+    /// on `AcceptorResult` for logging/audit. Informational fingerprinting —
+    /// a client can claim anything.
+    client_name: String,
+    client_version: u32,
+    client_build: u32,
     /// (vendored) The client's announced multitransport support flags
     /// (MS-RDPEMT) from its GCC MultiTransportChannelData block, captured in
     /// `BasicSettingsWaitInitial` and surfaced on `AcceptorResult` so the
@@ -125,6 +135,12 @@ pub struct AcceptorResult {
     /// (vendored) The client's announced keyboard-layout identifier (KLID)
     /// from its GCC Client Core Data; 0 if the client didn't send one.
     pub keyboard_layout: u32,
+    /// (vendored) Client-fingerprint identity from the GCC Client Core Data
+    /// (divergence (4)): hostname, raw RDP version, and build number. Empty /
+    /// 0 when not sent. Informational — a client can claim anything.
+    pub client_name: String,
+    pub client_version: u32,
+    pub client_build: u32,
     /// (vendored) The client's announced multitransport (MS-RDPEMT) support
     /// flags from its GCC MultiTransportChannelData block; empty if the client
     /// sent no multitransport block.
@@ -167,6 +183,9 @@ impl Acceptor {
             honor_client_desktop_size: false,
             honor_client_desktop_size_max: None,
             client_keyboard_layout: 0,
+            client_name: String::new(),
+            client_version: 0,
+            client_build: 0,
             client_multitransport: gcc::MultiTransportFlags::empty(),
             advertise_extended_client_data: false,
             multitransport_offer: None,
@@ -247,6 +266,9 @@ impl Acceptor {
             honor_client_desktop_size: consumed.honor_client_desktop_size,
             honor_client_desktop_size_max: consumed.honor_client_desktop_size_max,
             client_keyboard_layout: consumed.client_keyboard_layout,
+            client_name: consumed.client_name,
+            client_version: consumed.client_version,
+            client_build: consumed.client_build,
             client_multitransport: consumed.client_multitransport,
             advertise_extended_client_data: consumed.advertise_extended_client_data,
             // Reactivation skips LicensingExchange, so nothing is re-emitted;
@@ -309,6 +331,11 @@ impl Acceptor {
                 reactivation: self.reactivation,
                 credentials: self.received_credentials.take(),
                 keyboard_layout: self.client_keyboard_layout,
+                // Cloned (not mem::take'n) so a later deactivation–reactivation's
+                // result still carries the fingerprint.
+                client_name: self.client_name.clone(),
+                client_version: self.client_version,
+                client_build: self.client_build,
                 multitransport_flags: self.client_multitransport,
                 multitransport_offered: self.multitransport_offered,
             }),
@@ -574,6 +601,12 @@ impl Sequence for Acceptor {
                 // the server can serve a non-US layout. Always recorded (it's
                 // free); whether to act on it is the server's choice.
                 self.client_keyboard_layout = gcc_blocks.core.keyboard_layout;
+
+                // (vendored, divergence (4)) Capture the client-fingerprint
+                // identity fields for the server's connect log / audit.
+                self.client_name = gcc_blocks.core.client_name.clone();
+                self.client_version = gcc_blocks.core.version.0;
+                self.client_build = gcc_blocks.core.client_build;
 
                 // (vendored) Capture the client's multitransport (MS-RDPEMT)
                 // support flags so the server can decide whether to offer a UDP

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -1408,3 +1408,14 @@ AND released — #1276 landing is NOT sufficient.
     Cleanly upstreamable as the server counterpart to a (nonexistent-upstream)
     client MS-RDPECAM — but it's a gate, so hold until Phase 1 shapes the real API.
     Reference: FreeRDP `channels/rdpecam/server/` implements this server side.
+
+(20) Client-fingerprint connect log (NOT upstreamed; added 2026-07-18; pairs with
+    acceptor divergence (4)): `client_accepted` logs one `info!` line per initial
+    connection (skipped on reactivation) — `client fingerprint` with
+    `client_name` / `rdp_version` (hex) / `client_build` (from the acceptor's new
+    `AcceptorResult` fields) + `platform` (`major/minor_platform_type` scanned by
+    reference from the General capset in `result.capabilities`, before the
+    consuming loop). Answers "which RDP client connected": mstsc = real Windows
+    build + WINDOWS platform; FreeRDP family = build 2600; Windows Apps = their
+    host platform. Lands in macrdp.log next to the `macrdp::audit` lines.
+    Informational fingerprinting only. Additive; upstreamable with (4).

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -29,7 +29,7 @@ use tokio::net::TcpSocket;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task;
 use tokio_rustls::TlsAcceptor;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use {ironrdp_dvc as dvc, ironrdp_rdpsnd as rdpsnd};
 
 use crate::autodetect::{AutoDetectManager, RttSnapshot};
@@ -96,6 +96,22 @@ pub trait ConnectionHandler: Send {
     /// which runs immediately before, for the peer. Default: no-op.
     fn on_authenticated(&mut self, success: bool, reason: Option<&str>) {
         let _ = (success, reason);
+    }
+
+    /// (vendored, divergence (20)) Called once per connection when the
+    /// capability exchange completes (not on a deactivation–reactivation),
+    /// carrying the client-fingerprint identity: the GCC Client Core Data
+    /// hostname / raw RDP version / build number plus the General-capset
+    /// platform (formatted). Informational fingerprinting — a client can
+    /// claim anything. Default: no-op.
+    fn on_client_fingerprint(
+        &mut self,
+        client_name: &str,
+        rdp_version: u32,
+        client_build: u32,
+        platform: &str,
+    ) {
+        let _ = (client_name, rdp_version, client_build, platform);
     }
 }
 
@@ -2470,6 +2486,45 @@ impl RdpServer {
         if let Some(handle) = &self.keyboard_layout {
             handle.store(result.keyboard_layout, Ordering::Relaxed);
             debug!(klid = result.keyboard_layout, "client keyboard layout announced");
+        }
+
+        // (vendored, divergence (20)) Client-fingerprint log: the identity
+        // fields the acceptor captured from the GCC Client Core Data
+        // (acceptor divergence (4)) + the platform from the General capset.
+        // Heuristics for "which client is this": mstsc sends the real Windows
+        // build (e.g. 22621) + platform WINDOWS; FreeRDP hardcodes build 2600;
+        // the Windows Apps announce their host platform. Informational
+        // fingerprinting only — a client can claim anything. Skipped on
+        // reactivation (same connection, already logged).
+        if !result.reactivation {
+            let platform = result
+                .capabilities
+                .iter()
+                .find_map(|c| match c {
+                    CapabilitySet::General(g) => {
+                        Some(format!("{:?}/{:?}", g.major_platform_type, g.minor_platform_type))
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| "unknown".to_owned());
+            info!(
+                client_name = %result.client_name,
+                rdp_version = format_args!("{:#x}", result.client_version),
+                client_build = result.client_build,
+                platform = %platform,
+                "client fingerprint"
+            );
+            // Surface it to the application's ConnectionHandler (macrdp's
+            // AuthGuardHandler emits an `event="fingerprint"` audit record for
+            // the SIEM JSON stream).
+            if let Some(handler) = self.connection_handler.as_mut() {
+                handler.on_client_fingerprint(
+                    &result.client_name,
+                    result.client_version,
+                    result.client_build,
+                    &platform,
+                );
+            }
         }
 
         if !result.input_events.is_empty() {


### PR DESCRIPTION
## What

Surface the client's self-reported identity from the RDP handshake so the operator can tell at a glance **which RDP client connected** — mstsc vs FreeRDP vs Thincast vs a Windows App — both as a connect-log line and as a new event on the SIEM JSON audit stream.

Grew out of a research thread on why mstsc audio is smoother than FreeRDP/Thincast (per-client behavior differs a lot), where "who is this client?" turned out to be a genuinely useful thing to log.

## How

- **Vendored acceptor (divergence (4)):** capture `client_name` (hostname), `client_version` (raw `RdpVersion`), and `client_build` from the GCC Client Core Data — the same additive surfacing pattern as the KLID (#1397) — onto `AcceptorResult`. Name is cloned (not taken) so a deactivation–reactivation's result still carries it.
- **Vendored server (divergence (20)):** one `client fingerprint` `info!` line per **initial** connection (skipped on reactivation), with the platform pulled from the General capset (`major/minor_platform_type`). Adds a default-no-op `on_client_fingerprint` hook to `ConnectionHandler` so the application can consume it.
- **macrdp (`src/auth_guard.rs`):** `AuthGuardHandler::on_client_fingerprint` emits an `event="fingerprint"` `macrdp::audit` record (`client_name` / `rdp_version` / `client_build` / `platform`), so it also lands in the `--audit-file` JSON stream for a SIEM. `client_name` is client-controlled → control-char-stripped + length-bounded (same log-injection defense as the auth `reason`). Schema stays **v1** (additive event + fields, non-breaking).

## Live-verified signatures

| Client | `client_build` | `platform` |
|---|---|---|
| **mstsc** (Win11 24H2) | `26100` (real build) | `WINDOWS/WINDOWS_NT` |
| **Thincast** | `18363` (claimed) | `UNSPECIFIED/UNSPECIFIED` |
| **FreeRDP** family | `2600` | `UNIX/...` |

Verified live on real mstsc and Thincast against the running server. **Fingerprinting only — a client can claim anything; it is not a trust signal.**

## Tests

- `on_client_fingerprint_emits_fingerprint_event` (incl. a control-char / log-injection strip assertion). `cargo fmt` + `clippy -D warnings` clean.
- `docs/audit-log.md` + `docs/siem-forwarding.md` updated (new event, field reference, known-signature table, example lines).