### PR TITLE
fix(server): a second client hangs instead of taking over the live session

### DIFF
--- a/src/conn_test.rs
+++ b/src/conn_test.rs
@@ -649,23 +649,76 @@ async fn second_client_preempts_the_live_session() -> anyhow::Result<()> {
                 "second client should complete its own handshake"
             );
 
-            // ...and the first session is gone: its socket is closed, so the
-            // next read fails rather than blocking forever.
-            let dropped =
-                tokio::time::timeout(std::time::Duration::from_secs(10), framed_a.read_pdu())
-                    .await
-                    .map_err(|_| {
-                        anyhow::anyhow!("first session was left alive after being preempted")
-                    })?;
+            // ...and the first session is told WHY it's going away, then torn
+            // down. The reason matters as much as the teardown: macrdp
+            // provisions the auto-reconnect cookie by default, so a client
+            // dropped with no explanation just reconnects a second later and
+            // preempts back — an infinite ping-pong (observed live before this
+            // was added). ERRINFO_DISCONNECTED_BY_OTHERCONNECTION is what tells
+            // it to stay away.
+            let mut saw_eviction_reason = false;
+            let closed = loop {
+                let read =
+                    tokio::time::timeout(std::time::Duration::from_secs(10), framed_a.read_pdu())
+                        .await
+                        .map_err(|_| {
+                            anyhow::anyhow!("first session was left alive after being preempted")
+                        })?;
+                match read {
+                    Ok((_action, bytes)) => {
+                        if is_disconnected_by_other_connection(&bytes) {
+                            saw_eviction_reason = true;
+                        }
+                    }
+                    // Socket closed — the session is gone.
+                    Err(e) => break e,
+                }
+            };
             assert!(
-                dropped.is_err(),
-                "preempted session should be torn down, got {dropped:?}"
+                saw_eviction_reason,
+                "the preempted session must be told it was replaced \
+                 (ERRINFO_DISCONNECTED_BY_OTHERCONNECTION) so it doesn't auto-reconnect and \
+                 preempt straight back; instead the connection just closed with {closed:?}"
             );
 
             server_task.abort();
             anyhow::Ok(())
         })
         .await
+}
+
+/// Is this raw server PDU a Server Set Error Info carrying
+/// `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION` (MS-RDPBCGR 2.2.5.1.1) — i.e. the
+/// "another connection took your session" notice? Anything that isn't that
+/// exact PDU (including anything that fails to decode — the session is full of
+/// unrelated traffic) is simply `false`.
+fn is_disconnected_by_other_connection(bytes: &[u8]) -> bool {
+    use ironrdp_core::decode;
+    use ironrdp_pdu::mcs::McsMessage;
+    use ironrdp_pdu::rdp::headers::{ShareControlPdu, ShareDataPdu};
+    use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode};
+    use ironrdp_pdu::x224::X224;
+
+    let Ok(x224) = decode::<X224<McsMessage<'_>>>(bytes) else {
+        return false;
+    };
+    let McsMessage::SendDataIndication(data) = x224.0 else {
+        return false;
+    };
+    let Ok(ctrl) = decode::<ironrdp_pdu::rdp::headers::ShareControlHeader>(&data.user_data) else {
+        return false;
+    };
+    let ShareControlPdu::Data(share_data) = ctrl.share_control_pdu else {
+        return false;
+    };
+    matches!(
+        share_data.share_data_pdu,
+        ShareDataPdu::ServerSetErrorInfo(pdu)
+            if pdu.0
+                == ErrorInfo::ProtocolIndependentCode(
+                    ProtocolIndependentCode::DisconnectedByOtherconnection
+                )
+    )
 }
 
 /// A `ConnectionHandler` that accepts exactly the first connection it sees
@@ -852,6 +905,87 @@ async fn a_preempting_candidate_clears_on_accept_exactly_once() -> anyhow::Resul
                 2,
                 "on_accept should have fired exactly once for the winning candidate \
                  (once during the race, not again when served from `pending`)"
+            );
+
+            server_task.abort();
+            anyhow::Ok(())
+        })
+        .await
+}
+
+/// The safety net under the eviction-reason fix: a peer that was JUST evicted
+/// must not be able to immediately preempt its way back in.
+///
+/// This reproduces the live failure that motivated it. macrdp provisions the
+/// auto-reconnect cookie by default, so an evicted client reconnects ~1 s
+/// later; before this, that reconnect simply preempted the client that had
+/// replaced it, which then reconnected and preempted back — an endless
+/// ping-pong at ~1-2 s per cycle. `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION`
+/// (asserted in `second_client_preempts_the_live_session`) is the real fix,
+/// but it depends on the client honoring it; this bounds the damage if one
+/// doesn't.
+///
+/// Note every peer here is `127.0.0.1`, which is precisely the case the net
+/// keys on (source IP — the source PORT changes on every reconnect, so it
+/// can't be part of the key).
+#[tokio::test]
+async fn a_just_evicted_peer_cannot_immediately_preempt_back() -> anyhow::Result<()> {
+    init_tracing();
+
+    let probe = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+    let addr = probe.local_addr()?;
+    drop(probe);
+
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            let mut server = build_test_server_full(
+                addr.port(),
+                1024,
+                768,
+                true,
+                None,
+                crate::bitmap_codecs(),
+                true,
+            );
+            let server_task = tokio::task::spawn_local(async move {
+                let _ = server.run().await;
+            });
+
+            // A connects, then B preempts it — the normal takeover.
+            let a = connect_with_retry(addr).await?;
+            let (_size_a, _framed_a) = connect_client(a, 1280, 800).await?;
+
+            let b = connect_with_retry(addr).await?;
+            let (_size_b, mut framed_b) = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                connect_client(b, 1920, 1080),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("B hung instead of preempting A"))??;
+
+            // Now A "auto-reconnects" immediately, exactly as it did live.
+            // It must NOT be allowed to take the session back from B.
+            let a2 = connect_with_retry(addr).await?;
+            let bounced = tokio::time::timeout(
+                std::time::Duration::from_secs(3),
+                connect_client(a2, 1280, 800),
+            )
+            .await;
+            assert!(
+                matches!(bounced, Ok(Err(_)) | Err(_)),
+                "a just-evicted peer must not complete a handshake and retake the session, got a \
+                 successful connect back"
+            );
+
+            // ...and B is still alive: reading times out (nothing to say)
+            // rather than reporting the session was torn down under it.
+            let b_still_alive =
+                tokio::time::timeout(std::time::Duration::from_millis(500), framed_b.read_pdu())
+                    .await;
+            assert!(
+                b_still_alive.is_err(),
+                "B's session must survive the evicted peer's reconnect, got {b_still_alive:?}"
             );
 
             server_task.abort();

--- a/src/conn_test.rs
+++ b/src/conn_test.rs
@@ -31,8 +31,8 @@ use ironrdp_connector::sspi::generator::NetworkRequest;
 use ironrdp_connector::{ClientConnector, Config, ConnectorResult, Credentials, DesktopSize};
 use ironrdp_pdu::rdp::capability_sets::{BitmapCodecs, Codec, CodecProperty, NsCodec};
 use ironrdp_server::{
-    DesktopSize as ServerDesktopSize, DisplayUpdate, KeyboardEvent, MouseEvent, RdpServer,
-    RdpServerDisplay, RdpServerDisplayUpdates, RdpServerInputHandler,
+    ConnectionHandler, DesktopSize as ServerDesktopSize, DisplayUpdate, KeyboardEvent, MouseEvent,
+    RdpServer, RdpServerDisplay, RdpServerDisplayUpdates, RdpServerInputHandler,
 };
 use ironrdp_tokio::TokioFramed;
 use tokio_rustls::{rustls, TlsConnector};
@@ -67,6 +67,49 @@ impl RdpServerDisplay for TestDisplay {
     }
     async fn updates(&mut self) -> Result<Box<dyn RdpServerDisplayUpdates>> {
         Ok(Box::new(TestUpdates))
+    }
+}
+
+/// A do-nothing sound factory whose only job is to KEEP THE SESSION ALIVE in
+/// the preemption test. With no sound factory the server drops the audio
+/// sender, so `dispatch_audio`'s channel closes and the client loop ends
+/// immediately with `Disconnect` — a client would never actually stay
+/// connected. Holding the `audio_sender` here (and never sending) makes the
+/// audio arm park forever, so the session lives until it's torn down for real.
+struct KeepAliveSound {
+    audio_sender: Option<tokio::sync::mpsc::Sender<ironrdp_server::AudioWave>>,
+}
+impl ironrdp_server::ServerEventSender for KeepAliveSound {
+    fn set_sender(
+        &mut self,
+        _sender: tokio::sync::mpsc::UnboundedSender<ironrdp_server::ServerEvent>,
+    ) {
+    }
+}
+impl ironrdp_server::SoundServerFactory for KeepAliveSound {
+    fn build_backend(&self) -> Box<dyn ironrdp_server::RdpsndServerHandler> {
+        #[derive(Debug)]
+        struct NoAudio;
+        impl ironrdp_server::RdpsndServerHandler for NoAudio {
+            fn get_formats(&self) -> &[ironrdp_rdpsnd::pdu::AudioFormat] {
+                &[]
+            }
+            fn start(
+                &mut self,
+                _client_format: &ironrdp_rdpsnd::pdu::ClientAudioFormatPdu,
+            ) -> Option<u16> {
+                None
+            }
+            fn stop(&mut self) {}
+        }
+        Box::new(NoAudio)
+    }
+    fn set_audio_sender(
+        &mut self,
+        audio_sender: tokio::sync::mpsc::Sender<ironrdp_server::AudioWave>,
+    ) {
+        // Hold it so the receiver stays open (never sends).
+        self.audio_sender = Some(audio_sender);
     }
 }
 
@@ -213,17 +256,53 @@ fn build_test_server(
     max: Option<(u16, u16)>,
     codecs: BitmapCodecs,
 ) -> RdpServer {
+    build_test_server_on(3389, server_w, server_h, honor, max, codecs)
+}
+
+/// As [`build_test_server`], but bound to `port` — only meaningful for a test
+/// that drives the real TCP accept loop (`RdpServer::run`) rather than calling
+/// `run_connection` over an in-memory duplex.
+fn build_test_server_on(
+    port: u16,
+    server_w: u16,
+    server_h: u16,
+    honor: bool,
+    max: Option<(u16, u16)>,
+    codecs: BitmapCodecs,
+) -> RdpServer {
+    build_test_server_full(port, server_w, server_h, honor, max, codecs, false)
+}
+
+/// As above, with `keep_alive` opting into a `KeepAliveSound` factory so a
+/// served connection stays up (the preemption test needs a live session to
+/// take over). Without it the client loop ends immediately (closed audio
+/// channel), which is fine for the negotiate-and-drop tests.
+fn build_test_server_full(
+    port: u16,
+    server_w: u16,
+    server_h: u16,
+    honor: bool,
+    max: Option<(u16, u16)>,
+    codecs: BitmapCodecs,
+    keep_alive: bool,
+) -> RdpServer {
     let display = TestDisplay {
         size: ServerDesktopSize {
             width: server_w,
             height: server_h,
         },
     };
+    let sound: Option<Box<dyn ironrdp_server::SoundServerFactory>> = if keep_alive {
+        Some(Box::new(KeepAliveSound { audio_sender: None }))
+    } else {
+        None
+    };
     let mut server = RdpServer::builder()
-        .with_addr((Ipv4Addr::LOCALHOST, 3389))
+        .with_addr((Ipv4Addr::LOCALHOST, port))
         .with_tls(server_tls_acceptor())
         .with_input_handler(TestInput)
         .with_display_handler(display)
+        .with_sound_factory(sound)
         .with_bitmap_codecs(codecs)
         .build();
     server.set_honor_client_desktop_size(honor);
@@ -243,6 +322,22 @@ async fn drive_client(
     client_w: u16,
     client_h: u16,
 ) -> anyhow::Result<(u16, u16)> {
+    let (size, _framed) = connect_client(client_io, client_w, client_h).await?;
+    Ok(size)
+}
+
+/// Same handshake as [`drive_client`], but generic over the transport and
+/// returning the still-open framed TLS stream so a caller can keep the session
+/// alive (and observe it being torn down). Used by the preemption test, which
+/// needs a real TCP connection that outlives the handshake.
+async fn connect_client<S>(
+    client_io: S,
+    client_w: u16,
+    client_h: u16,
+) -> anyhow::Result<((u16, u16), TokioFramed<tokio_rustls::client::TlsStream<S>>)>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync + 'static,
+{
     // pre-TLS negotiation
     let mut connector = ClientConnector::new(
         client_config(client_w, client_h),
@@ -278,7 +373,10 @@ async fn drive_client(
         None,
     )
     .await?;
-    Ok((result.desktop_size.width, result.desktop_size.height))
+    Ok((
+        (result.desktop_size.width, result.desktop_size.height),
+        tls_framed,
+    ))
 }
 
 /// Run one full client→server connect over an in-memory duplex with the given
@@ -487,4 +585,289 @@ async fn server_survives_many_reconnects() -> anyhow::Result<()> {
             Ok(())
         })
         .await
+}
+
+/// A second client connecting while a session is live must TAKE OVER: the old
+/// session is dropped and the newcomer completes its handshake. Before the
+/// accept loop learned to preempt, it `await`ed the whole connection, so the
+/// second client sat unserved in the TCP backlog — from the user's side, a
+/// silent hang until the first client left.
+///
+/// This is the one test that drives the real `RdpServer::run` accept loop over
+/// real TCP (every other test here calls `run_connection` over a duplex), since
+/// preemption lives in that loop.
+#[tokio::test]
+async fn second_client_preempts_the_live_session() -> anyhow::Result<()> {
+    init_tracing();
+
+    // Claim an ephemeral port, then release it for the server to bind.
+    let probe = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+    let addr = probe.local_addr()?;
+    drop(probe);
+
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            // A live session (see `KeepAliveSound`) — otherwise the client loop
+            // ends the moment it starts and there's nothing to preempt.
+            let mut server = build_test_server_full(
+                addr.port(),
+                1024,
+                768,
+                true,
+                None,
+                crate::bitmap_codecs(),
+                true,
+            );
+            let server_task = tokio::task::spawn_local(async move {
+                let _ = server.run().await;
+            });
+
+            // First client: connect and keep the session open.
+            let a = connect_with_retry(addr).await?;
+            let (size_a, mut framed_a) = connect_client(a, 1280, 800).await?;
+            assert_eq!(
+                size_a,
+                (1280, 800),
+                "first client should be served normally"
+            );
+
+            // Second client, while the first is still connected: it must be
+            // served, not queued behind the live session.
+            let b = connect_with_retry(addr).await?;
+            let (size_b, _framed_b) = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                connect_client(b, 1920, 1080),
+            )
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!("second client hung — the accept loop did not preempt the session")
+            })??;
+            assert_eq!(
+                size_b,
+                (1920, 1080),
+                "second client should complete its own handshake"
+            );
+
+            // ...and the first session is gone: its socket is closed, so the
+            // next read fails rather than blocking forever.
+            let dropped =
+                tokio::time::timeout(std::time::Duration::from_secs(10), framed_a.read_pdu())
+                    .await
+                    .map_err(|_| {
+                        anyhow::anyhow!("first session was left alive after being preempted")
+                    })?;
+            assert!(
+                dropped.is_err(),
+                "preempted session should be torn down, got {dropped:?}"
+            );
+
+            server_task.abort();
+            anyhow::Ok(())
+        })
+        .await
+}
+
+/// A `ConnectionHandler` that accepts exactly the first connection it sees
+/// and rejects every one after — standing in for macrdp's own
+/// `AuthGuardHandler` (per-source-IP rate-limit/lockout) rejecting a
+/// preempting candidate.
+struct RejectAfterFirst {
+    accepted_once: bool,
+}
+
+impl ConnectionHandler for RejectAfterFirst {
+    fn on_accept(&mut self, _peer: SocketAddr) -> bool {
+        !core::mem::replace(&mut self.accepted_once, true)
+    }
+}
+
+/// A candidate that speaks RDP (passes the TPKT probe) but that `on_accept`
+/// would reject — e.g. an IP the auth guard has already locked out — must
+/// NOT be allowed to preempt the live session. `on_accept` has to run, and be
+/// honored, before the preemption is committed, or the guard's rejection
+/// would only be observed after the damage (evicting a real session) is
+/// already done. Regression guard for the ordering bug caught in review on
+/// the upstreamed shape of this fix, Devolutions/IronRDP#1476.
+#[tokio::test]
+async fn preemption_does_not_evict_a_session_the_handler_would_reject() -> anyhow::Result<()> {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    init_tracing();
+
+    let probe = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+    let addr = probe.local_addr()?;
+    drop(probe);
+
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            let display = TestDisplay {
+                size: ServerDesktopSize {
+                    width: 1024,
+                    height: 768,
+                },
+            };
+            let sound: Box<dyn ironrdp_server::SoundServerFactory> =
+                Box::new(KeepAliveSound { audio_sender: None });
+            let mut server = RdpServer::builder()
+                .with_addr((Ipv4Addr::LOCALHOST, addr.port()))
+                .with_tls(server_tls_acceptor())
+                .with_input_handler(TestInput)
+                .with_display_handler(display)
+                .with_sound_factory(Some(sound))
+                .with_bitmap_codecs(crate::bitmap_codecs())
+                .with_connection_handler(Some(Box::new(RejectAfterFirst {
+                    accepted_once: false,
+                })))
+                .build();
+            server.set_honor_client_desktop_size(true);
+
+            let server_task = tokio::task::spawn_local(async move {
+                let _ = server.run().await;
+            });
+
+            // Client A: the live session under test — a real, completed
+            // handshake kept open via `KeepAliveSound`, same as the sibling
+            // preemption test.
+            let a = connect_with_retry(addr).await?;
+            let (_size_a, mut framed_a) = connect_client(a, 1280, 800).await?;
+
+            // Client B: the preempting candidate. It DOES speak RDP (a valid
+            // TPKT header), but `RejectAfterFirst` rejects every accept after
+            // the first, so it must never be allowed to preempt client A.
+            let mut client_b = connect_with_retry(addr).await?;
+            client_b.write_all(&[0x03, 0x00]).await?;
+
+            // Client B should be dropped by the server (on_accept rejected
+            // it): its read side observes the connection closing. The
+            // server's TPKT probe `peek()`s those 2 bytes without consuming
+            // them, so a close with unread data queued can surface as a
+            // reset instead of a clean EOF, platform-dependently — either is
+            // "the server dropped this connection."
+            let mut buf = [0u8; 1];
+            let client_b_read =
+                tokio::time::timeout(std::time::Duration::from_secs(5), client_b.read(&mut buf)).await;
+            assert!(
+                matches!(client_b_read, Ok(Ok(0)) | Ok(Err(_))),
+                "the rejected candidate's connection should be closed by the server, got {client_b_read:?}"
+            );
+
+            // Client A must still be alive: reading a PDU TIMES OUT (no
+            // disconnect) rather than observing the server having dropped it
+            // to serve the (rejected) client B.
+            let client_a_still_alive =
+                tokio::time::timeout(std::time::Duration::from_millis(500), framed_a.read_pdu()).await;
+            assert!(
+                client_a_still_alive.is_err(),
+                "the live session must survive a preemption attempt the handler rejected, got {client_a_still_alive:?}"
+            );
+
+            server_task.abort();
+            anyhow::Ok(())
+        })
+        .await
+}
+
+/// A `ConnectionHandler` that always accepts, but counts how many times
+/// `on_accept` fires — via a shared counter, since the handler itself is
+/// moved into the server and the test can't reach back into it directly.
+struct CountingAccepts {
+    count: Arc<core::sync::atomic::AtomicU32>,
+}
+
+impl ConnectionHandler for CountingAccepts {
+    fn on_accept(&mut self, _peer: SocketAddr) -> bool {
+        self.count
+            .fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+        true
+    }
+}
+
+/// A winning preemption candidate must clear `on_accept` exactly ONCE for the
+/// one physical connection it is — not once as a candidate during the race
+/// and again when it's served from the `pending` slot on the next loop
+/// iteration. `on_accept` is stateful for macrdp's real handler
+/// (`AuthGuardHandler` records the accept toward its per-source-IP
+/// rate-limit window and writes an audit line), so a double call would
+/// silently inflate both for a single real connection attempt.
+#[tokio::test]
+async fn a_preempting_candidate_clears_on_accept_exactly_once() -> anyhow::Result<()> {
+    init_tracing();
+
+    let probe = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+    let addr = probe.local_addr()?;
+    drop(probe);
+
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            let accept_count = Arc::new(core::sync::atomic::AtomicU32::new(0));
+
+            let display = TestDisplay {
+                size: ServerDesktopSize {
+                    width: 1024,
+                    height: 768,
+                },
+            };
+            let sound: Box<dyn ironrdp_server::SoundServerFactory> =
+                Box::new(KeepAliveSound { audio_sender: None });
+            let mut server = RdpServer::builder()
+                .with_addr((Ipv4Addr::LOCALHOST, addr.port()))
+                .with_tls(server_tls_acceptor())
+                .with_input_handler(TestInput)
+                .with_display_handler(display)
+                .with_sound_factory(Some(sound))
+                .with_bitmap_codecs(crate::bitmap_codecs())
+                .with_connection_handler(Some(Box::new(CountingAccepts {
+                    count: Arc::clone(&accept_count),
+                })))
+                .build();
+            server.set_honor_client_desktop_size(true);
+
+            let server_task = tokio::task::spawn_local(async move {
+                let _ = server.run().await;
+            });
+
+            // Client A: the live session.
+            let a = connect_with_retry(addr).await?;
+            let (_size_a, _framed_a) = connect_client(a, 1280, 800).await?;
+            assert_eq!(
+                accept_count.load(core::sync::atomic::Ordering::SeqCst),
+                1,
+                "on_accept should have fired exactly once for client A"
+            );
+
+            // Client B: preempts client A.
+            let b = connect_with_retry(addr).await?;
+            let (_size_b, _framed_b) = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                connect_client(b, 1920, 1080),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("second client hung"))??;
+
+            assert_eq!(
+                accept_count.load(core::sync::atomic::Ordering::SeqCst),
+                2,
+                "on_accept should have fired exactly once for the winning candidate \
+                 (once during the race, not again when served from `pending`)"
+            );
+
+            server_task.abort();
+            anyhow::Ok(())
+        })
+        .await
+}
+
+/// The listener needs a moment to bind after `run()` is spawned; retry briefly
+/// so the test isn't racy on a loaded machine.
+async fn connect_with_retry(addr: SocketAddr) -> anyhow::Result<tokio::net::TcpStream> {
+    for _ in 0..100 {
+        match tokio::net::TcpStream::connect(addr).await {
+            Ok(stream) => return Ok(stream),
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(20)).await,
+        }
+    }
+    anyhow::bail!("server never started listening on {addr}")
 }

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -3,7 +3,7 @@
 Local fork of ironrdp-server 0.10.0, pulled in via `[patch.crates-io]` in
 `Cargo.toml`. The audio-lag control in the dedicated `dispatch_audio` task
 (carved out of `dispatch_server_events`) is the live divergence. Keep this
-vendor dir until (2)/(3)/(4)/(5)/(6)/(7)/(8)/(9)/(10)/(11)/(12)/(13)/(14)/(15)/(16)/(17)/(18)/(19)/(20)/(21) below are upstreamed
+vendor dir until (2)/(3)/(4)/(5)/(6)/(7)/(8)/(9)/(10)/(11)/(12)/(13)/(14)/(15)/(16)/(17)/(18)/(19)/(20)/(21)/(22) below are upstreamed
 AND released — #1276 landing is NOT sufficient.
 
 (1) The original "keep newest queued waves on per-batch overflow"
@@ -1458,3 +1458,62 @@ AND released — #1276 landing is NOT sufficient.
     maintainer, since the same gap is reachable through `MousePdu`/`MouseXPdu`/
     `MouseRelPdu` and a uniform fix touches the public `MouseEvent` API). Delete
     this divergence once the upstream fix lands and the pin moves past it.
+
+(22) Second-client PREEMPTS the live session in the accept loop (NOT
+    upstreamed; added 2026-07-23). Upstream `RdpServer::run` `await`s the whole
+    `run_connection(stream)` inline, so while one client is connected a SECOND
+    client's TCP connect sits unserved in the listen backlog — the server never
+    calls `accept()` again until the first session ends. From the second user's
+    side that is a silent HANG (the connection is established at the TCP layer,
+    but no RDP handshake response ever comes). macrdp is single-console-session
+    by design (it mirrors/serves ONE desktop), so the right behavior is for a
+    new client to TAKE OVER: drop the existing session and serve the newcomer.
+    Reshaped `run()` so the in-flight connection races `listener.accept()`: a
+    new connection that passes `probe_preempting_client` (a `recv(MSG_PEEK)` for
+    a TPKT header — version 3 + reserved 0 — within `PREEMPT_PROBE_TIMEOUT` = 5 s,
+    so a bare TCP connect / port scan can't kill a live desktop; the peeked bytes
+    stay queued for the real handshake) causes the in-flight `run_connection`
+    future to be DROPPED (cancellation = the same per-connection teardown a
+    client-side disconnect takes: socket closes, every Drop runs), and the
+    winner is carried in a `pending` slot and served on the next loop iteration
+    — so it still flows through the RTT sample + the multitransport reset
+    exactly like any accepted connection. A candidate mid-probe when the OLD
+    session ends on its own is NOT dropped (it's handed to `pending`, not a
+    preemption). Preemption is only a cheap TPKT filter, not auth — a peer that
+    speaks RDP but fails NLA still takes the slot once it clears `on_accept`
+    (below); that's bounded by the existing `ConnectionHandler` rate-limit/
+    lockout gate (`AuthGuardHandler`).
+    New helpers `probe_preempting_client` + the `PreemptRace` enum (the select
+    must only yield, never mutate the probe slot its futures borrow). Covered by
+    `src/conn_test.rs::second_client_preempts_the_live_session` (the one test
+    that drives the real `RdpServer::run` accept loop over real TCP — every other
+    conn_test uses `run_connection` over a duplex; it needs a `KeepAliveSound`
+    factory to hold the audio channel open, or the client loop ends instantly and
+    there's nothing to preempt). Additive to `run()` only; `run_connection` and
+    the per-connection path are untouched. Upstreamable as an opt-in policy (e.g.
+    a `ConnectionHandler`/builder switch: reject-new vs preempt-existing), since
+    a multi-session server would want the current queue-behind behavior — offer
+    it that way rather than as an unconditional change. **Filed upstream as
+    Devolutions/IronRDP#1476** (an opt-in `preempt_existing_session` builder
+    option, since a general-purpose server needs to keep the queue-behind
+    default) — drop this divergence once it's released and the pin can adopt it.
+
+    **on_accept-ordering fix (2026-07-26, from the #1476 review):** the initial
+    cut only ran `ConnectionHandler::on_accept` on the candidate on the NEXT
+    outer-loop iteration — by which point the live session had already been
+    cancelled to make room for it. A candidate `on_accept` (the auth guard's
+    per-source-IP rate-limit/lockout) would reject could therefore still evict
+    the active session; it would just get rejected immediately afterward, after
+    the damage was done. Fixed by gating the candidate through `on_accept` as
+    soon as it's accepted, BEFORE it's allowed to start the TPKT probe (and so
+    before it can ever preempt anything). This needs `connection_handler`
+    pulled out of `self` into a local `handler` before the live connection's
+    `conn` future is created — `conn` captures `&mut self` for the whole race,
+    and `on_accept` must stay callable alongside it — restored into `self` once
+    the race ends (`conn`'s scope must close BEFORE the restore, or the
+    borrow checker rejects it — hence the extra `{ }` block around `conn`).
+    Covered by `src/conn_test.rs::
+    preemption_does_not_evict_a_session_the_handler_would_reject` (a real
+    `RdpServer::run()` with a handler that accepts only the first connection);
+    verified it fails without this fix (the live session gets evicted) and
+    passes with it.

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -3,7 +3,7 @@
 Local fork of ironrdp-server 0.10.0, pulled in via `[patch.crates-io]` in
 `Cargo.toml`. The audio-lag control in the dedicated `dispatch_audio` task
 (carved out of `dispatch_server_events`) is the live divergence. Keep this
-vendor dir until (2)/(3)/(4)/(5)/(6)/(7)/(8)/(9)/(10)/(11)/(12)/(13)/(14)/(15)/(16)/(17)/(18)/(19)/(20)/(21)/(22) below are upstreamed
+vendor dir until (2)/(3)/(4)/(5)/(6)/(7)/(8)/(9)/(10)/(11)/(12)/(13)/(14)/(15)/(16)/(17)/(18)/(19)/(20)/(21)/(22)/(23) below are upstreamed
 AND released — #1276 landing is NOT sufficient.
 
 (1) The original "keep newest queued waves on per-batch overflow"
@@ -1459,61 +1459,151 @@ AND released — #1276 landing is NOT sufficient.
     `MouseRelPdu` and a uniform fix touches the public `MouseEvent` API). Delete
     this divergence once the upstream fix lands and the pin moves past it.
 
-(22) Second-client PREEMPTS the live session in the accept loop (NOT
-    upstreamed; added 2026-07-23). Upstream `RdpServer::run` `await`s the whole
-    `run_connection(stream)` inline, so while one client is connected a SECOND
-    client's TCP connect sits unserved in the listen backlog — the server never
-    calls `accept()` again until the first session ends. From the second user's
-    side that is a silent HANG (the connection is established at the TCP layer,
-    but no RDP handshake response ever comes). macrdp is single-console-session
-    by design (it mirrors/serves ONE desktop), so the right behavior is for a
-    new client to TAKE OVER: drop the existing session and serve the newcomer.
-    Reshaped `run()` so the in-flight connection races `listener.accept()`: a
-    new connection that passes `probe_preempting_client` (a `recv(MSG_PEEK)` for
-    a TPKT header — version 3 + reserved 0 — within `PREEMPT_PROBE_TIMEOUT` = 5 s,
-    so a bare TCP connect / port scan can't kill a live desktop; the peeked bytes
-    stay queued for the real handshake) causes the in-flight `run_connection`
-    future to be DROPPED (cancellation = the same per-connection teardown a
-    client-side disconnect takes: socket closes, every Drop runs), and the
-    winner is carried in a `pending` slot and served on the next loop iteration
-    — so it still flows through the RTT sample + the multitransport reset
-    exactly like any accepted connection. A candidate mid-probe when the OLD
-    session ends on its own is NOT dropped (it's handed to `pending`, not a
-    preemption). Preemption is only a cheap TPKT filter, not auth — a peer that
-    speaks RDP but fails NLA still takes the slot once it clears `on_accept`
-    (below); that's bounded by the existing `ConnectionHandler` rate-limit/
-    lockout gate (`AuthGuardHandler`).
-    New helpers `probe_preempting_client` + the `PreemptRace` enum (the select
-    must only yield, never mutate the probe slot its futures borrow). Covered by
-    `src/conn_test.rs::second_client_preempts_the_live_session` (the one test
-    that drives the real `RdpServer::run` accept loop over real TCP — every other
-    conn_test uses `run_connection` over a duplex; it needs a `KeepAliveSound`
-    factory to hold the audio channel open, or the client loop ends instantly and
-    there's nothing to preempt). Additive to `run()` only; `run_connection` and
-    the per-connection path are untouched. Upstreamable as an opt-in policy (e.g.
-    a `ConnectionHandler`/builder switch: reject-new vs preempt-existing), since
-    a multi-session server would want the current queue-behind behavior — offer
-    it that way rather than as an unconditional change. **Filed upstream as
-    Devolutions/IronRDP#1476** (an opt-in `preempt_existing_session` builder
-    option, since a general-purpose server needs to keep the queue-behind
-    default) — drop this divergence once it's released and the pin can adopt it.
+(22) Second-client PREEMPTS the live session in the accept loop — SUPERSEDED
+    by (23) below; kept for history (added 2026-07-23, superseded 2026-07-27).
+    Upstream `RdpServer::run` `await`s the whole `run_connection(stream)`
+    inline, so while one client is connected a SECOND client's TCP connect
+    sits unserved in the listen backlog — the server never calls `accept()`
+    again until the first session ends: a silent HANG for the second client.
+    macrdp is single-console-session by design, so the right behavior is for a
+    new client to TAKE OVER. The original mechanism reshaped `run()` so the
+    in-flight connection raced `listener.accept()`, and a candidate won by
+    passing `probe_preempting_client` — a cheap `recv(MSG_PEEK)` check for a
+    TPKT header (version 3 + reserved 0), just enough to prove "this looks
+    like the start of an RDP handshake." Two narrower bugs in that mechanism
+    were fixed in place (on_accept had to run on the candidate BEFORE it could
+    start probing, not after it already won; and exactly once per physical
+    connection, not twice) before the mechanism itself was found to have a
+    structural problem — see (23).
 
-    **on_accept-ordering fix (2026-07-26, from the #1476 review):** the initial
-    cut only ran `ConnectionHandler::on_accept` on the candidate on the NEXT
-    outer-loop iteration — by which point the live session had already been
-    cancelled to make room for it. A candidate `on_accept` (the auth guard's
-    per-source-IP rate-limit/lockout) would reject could therefore still evict
-    the active session; it would just get rejected immediately afterward, after
-    the damage was done. Fixed by gating the candidate through `on_accept` as
-    soon as it's accepted, BEFORE it's allowed to start the TPKT probe (and so
-    before it can ever preempt anything). This needs `connection_handler`
-    pulled out of `self` into a local `handler` before the live connection's
-    `conn` future is created — `conn` captures `&mut self` for the whole race,
-    and `on_accept` must stay callable alongside it — restored into `self` once
-    the race ends (`conn`'s scope must close BEFORE the restore, or the
-    borrow checker rejects it — hence the extra `{ }` block around `conn`).
-    Covered by `src/conn_test.rs::
-    preemption_does_not_evict_a_session_the_handler_would_reject` (a real
-    `RdpServer::run()` with a handler that accepts only the first connection);
-    verified it fails without this fix (the live session gets evicted) and
-    passes with it.
+(23) Second-client preemption is gated on FULL AUTHENTICATION, not a TPKT peek
+    (NOT upstreamed; added 2026-07-27, replacing divergence (22)'s mechanism).
+    **The bug that forced this redesign, found via a real CI failure:**
+    `scripts/test-audit-log.sh` (two sequential connections — correct password,
+    then wrong password) started failing after (22) shipped: the FIRST
+    connection's `event="auth" outcome="success"` never appeared in the audit
+    log at all. Root cause: (22)'s `probing = false` from the moment a
+    connection started being served meant the accept loop raced
+    `listener.accept()` through the live connection's OWN negotiation, not just
+    once it was fully active. The test's second `sdl-freerdp` process could
+    connect and win the TPKT-peek race (2 bytes, near-instant) BEFORE the
+    first connection's TLS+CredSSP handshake (real crypto, genuinely slower)
+    completed — cancelling a connection that was about to authenticate
+    successfully, based on nothing more than "some other socket also sent 2
+    plausible bytes." This is not just a benign-overlap edge case: it means
+    ANY connection attempt — including a failed/malicious one that never
+    authenticates — could evict the live session purely by winning a race
+    against a TPKT peek, which is exactly backwards from what preemption
+    should guarantee ("unauthenticated connection shouldn't disconnect the
+    session," confirmed as the hard requirement rather than a nice-to-have).
+
+    **The fix: a candidate must complete REAL negotiation — TLS, then CredSSP
+    where applicable — before it's allowed to preempt anything.** This is
+    architecturally harder than the TPKT peek because `RdpServer` serves one
+    connection at a time by design (single `static_channels`, single
+    `gfx_handle`, factories that build real per-connection backends against
+    shared hardware — SCK capture, camera, USB, RDPDR/NFS); the live
+    connection's `run_connection` holds `&mut self` for its whole lifetime, so
+    a candidate's negotiation has to run WITHOUT touching `self` mutably at
+    all, or it can't run concurrently with the live connection's own
+    `&mut self` borrow. The fix is a Phase 1 (negotiate + authenticate,
+    concurrency-safe) / Phase 2 (exclusive, resource-driving) split:
+
+    - **`NegotiationContext`** (new struct): a cheap `Rc`/`Arc`-cloned snapshot
+      of everything Phase 1 needs — `self.opts`/`self.creds` (both `Clone`),
+      `self.display`/`self.handler` (already `Arc`), `self.echo_handle`/
+      `self.ev_sender` (already `Clone`), the channel factories, and
+      `self.connection_handler` (already `Rc<RefCell<..>>` from the (22)
+      on_accept-ordering fix). Built once per race via
+      `RdpServer::negotiation_context(&self)`.
+    - **Factory storage changed `Box<dyn X>` → `Rc<dyn X>`** (cliprdr, sound,
+      rdpdr, usb, camera, gfx) so `NegotiationContext` can hold cheap clones
+      instead of needing exclusive access through `self`. Public builder API
+      unchanged (still takes `Box<dyn X>`; wrapped via `Rc::from` at
+      construction, after the one-time `set_sender` setup that needs `&mut`
+      on the still-owned `Box`).
+    - **`attach_channels_impl`** (new free function): the channel-attaching
+      body of the old `attach_channels`, factored out to take explicit
+      factory/handle references instead of reading `self`. `RdpServer::
+      attach_channels` (the normal path) now just calls it with `self`'s own
+      fields; `negotiate_candidate` calls it with a `NegotiationContext`'s.
+      Returns the GFX handle instead of writing `self.gfx_handle` directly —
+      only the actual WINNER should claim it, so installation is deferred to
+      `serve_negotiated` (Phase 2 entry).
+    - **`negotiate_candidate`** (new free function, `TcpStream`-specific):
+      duplicates the pre-`accept_finalize` portion of `run_connection` —
+      build `Acceptor` → `attach_channels_impl` → `accept_begin` → TLS upgrade
+      → CredSSP (when the security mode is Hybrid; fires
+      `on_authenticated` on the candidate's outcome too, so a rejected
+      preemption attempt still shows up in the audit log) — against a
+      `NegotiationContext` instead of `&mut self`. Returns `Some(
+      NegotiatedCandidate)` (the negotiated `Acceptor` + framed TLS stream +
+      GFX handle) ONLY on full success; any failure at any step — malformed
+      negotiation, TLS rejected, CredSSP rejected — returns `None` and the
+      live session is left completely untouched. Duplicates rather than
+      shares code with `run_connection` because that function is generic over
+      any stream type and needs `&mut self`; this needs neither. Keep the two
+      in sync by hand if the negotiation sequence changes upstream.
+    - **Multitransport is a normal-path-only feature for a candidate.** Both
+      the UDP transport OFFER (in `run_connection`, before `attach_channels`)
+      and the lossy-audio DVC (inside `attach_channels_impl`, only useful
+      paired with that offer) are skipped entirely for a candidate — those
+      fields (`multitransport_cookies`, `current_offer_cookie`,
+      `udp_tunnel_bound`, …) are process-wide, per-connection-mutated
+      bookkeeping shared with the live connection's own multitransport state,
+      not safe to touch concurrently. A candidate that wins via preemption
+      always negotiates plain TCP; a normal (non-racing) connection is
+      unaffected. Same reasoning extends to RTT sampling (`link_rtt_ms`) —
+      not sampled for a preemption winner, since by the time it's confirmed
+      the winner its raw `TcpStream` is already wrapped in TLS.
+    - **`serve_negotiated`** (new method): Phase 2 for a winning candidate —
+      installs the deferred GFX handle, resets `auto_reconnect_sent`
+      (mirroring the top of `run_connection`), then hands off to the SAME
+      `accept_finalize` the normal path uses. From here a preemption-won
+      connection is indistinguishable from a normally-accepted one.
+    - **`run()`'s race loop**: `pending` now carries a `NegotiatedCandidate`
+      (not a raw stream) — by construction, nothing reaches `pending` without
+      having already passed `on_accept` AND fully authenticated. The `probe`
+      future's output changed from `Option<(TcpStream, SocketAddr)>` to
+      `Option<NegotiatedCandidate>`; since that no longer carries the peer
+      address, a `probing_peer: Option<SocketAddr>` local tracks it alongside
+      `probing`. `conn` (the live connection's future) changed from
+      `core::pin::pin!` (stack-pinned, single concrete type) to `Box::pin`
+      (heap-allocated, `dyn Future`), because it's now EITHER
+      `self.run_connection(stream)` (a fresh `Entry::Fresh`) OR
+      `self.serve_negotiated(candidate)` (an `Entry::Negotiated` — a
+      previously-preempting candidate that itself is now the live connection,
+      and must be just as preemptible by a THIRD candidate) — two different
+      concrete future types unified behind one `dyn Future` so the same race
+      loop serves both without duplicating it.
+
+    Covered by the existing `src/conn_test.rs::
+    second_client_preempts_the_live_session` (a well-behaved candidate still
+    wins end-to-end — proves the positive path through the new
+    `negotiate_candidate` machinery) and `::
+    preemption_does_not_evict_a_session_the_handler_would_reject` (the
+    `on_accept` gate still blocks a bad actor before negotiation even starts).
+    **Not covered locally: a candidate that reaches CredSSP but fails it**
+    (wrong password) — `ironrdp-server` isn't a workspace member here (a
+    `[patch.crates-io]` path override), so `#[cfg(test)]` code inside the
+    vendor crate itself can never run via any `cargo test` invocation from
+    macrdp (confirmed empirically: `cargo test -p ironrdp-server` refuses,
+    "requires dev-dependencies and is not a member of the workspace" — the
+    same reason other vendored crates' tests live in macrdp's own `src/*.rs`
+    testing public APIs instead). Building a full NTLM-capable test client in
+    `conn_test.rs` to drive real CredSSP failure was judged more risk/effort
+    than the remaining gap warranted, given `scripts/test-audit-log.sh` (real
+    sdl-freerdp, correct AND wrong password) is exactly this scenario and runs
+    in CI — that's the authoritative check for this path. The property does
+    follow directly from the code structure, though: a candidate cannot reach
+    `pending` without `negotiate_candidate` returning `Some`, and that can
+    only happen after `accept_credssp` returns `Ok`.
+
+    Upstreamable, same shape as (22): an opt-in policy (a `ConnectionHandler`/
+    builder switch: reject-new vs preempt-existing-once-authenticated), since
+    a general-purpose multi-session server would want to keep the existing
+    queue-behind behavior. Filed as Devolutions/IronRDP#1476 (still the
+    TPKT-peek shape as of this writing — the auth-gating redesign is
+    macrdp-specific for now, since it needed the `Box`→`Rc` factory change
+    which isn't obviously desirable upstream). Revisit upstreaming once (22)'s
+    design has had more real-world runway.

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -1607,3 +1607,61 @@ AND released — #1276 landing is NOT sufficient.
     macrdp-specific for now, since it needed the `Box`→`Rc` factory change
     which isn't obviously desirable upstream). Revisit upstreaming once (22)'s
     design has had more real-world runway.
+
+    **Eviction must tell the loser WHY, or the two clients ping-pong forever
+    (2026-07-27, found in live testing of the above — the failure that made
+    this a two-part fix).** With auth-gating in place, preemption worked
+    exactly as designed and was still unusable: two real clients on a LAN
+    (.44 and .46) traded the session back and forth every ~1-2 s,
+    indefinitely. The loop is entirely self-inflicted and obvious in
+    hindsight: macrdp provisions the **Server Auto-Reconnect Cookie** by
+    default (divergence 13, so a blank-recovery drop heals seamlessly), so a
+    client dropped for ANY reason silently auto-reconnects about a second
+    later. A preemption drop was indistinguishable from a blank-recovery drop,
+    so the evicted client came straight back, authenticated (legitimately —
+    it's a real client with real credentials, so the auth gate is no defense
+    here), and preempted the client that had just replaced it. Repeat forever.
+    Note this is a case where each individual component behaved *correctly*
+    and the composition was broken; nothing was going to catch it short of
+    running two real clients.
+
+    Two layers now:
+
+    1. **`ServerEvent::EvictedByOtherConnection` (the real fix).** A new event
+       distinct from `Quit`: `dispatch_server_events` (which has the writer +
+       channel ids) sends a Server Set Error Info PDU carrying
+       `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION` (0x05, MS-RDPBCGR 2.2.5.1.1 —
+       the exact code real Windows RDS uses for a session takeover) before
+       returning `Disconnect`. A client that receives an administrative
+       disconnect reason shows it ("another user connected…") and does NOT
+       auto-reconnect. `run()`'s preemption path sends this and then keeps
+       polling the incumbent for `EVICTION_GRACE` (750 ms) so the PDU actually
+       reaches the wire, instead of cancelling the future outright; on timeout
+       it degrades to exactly the hard cancellation it replaced, so a
+       wedged/half-dead peer can't stall the takeover. Uses the same
+       `encode_share_data_pdu` helper the ARC cookie does.
+    2. **`recently_evicted` + `REPREEMPT_COOLDOWN` (the net).** Whether a
+       given client honors the error info is client-dependent and unverified
+       across the field, and an *infinite* flap is a bad enough failure to be
+       worth a structural bound. So a peer evicted moments ago may not
+       immediately preempt back: keyed on source IP (the source PORT changes
+       on every reconnect, so it can't be part of the key), 5 s, and — the
+       load-bearing detail — **each refused attempt RE-ARMS the window**. An
+       auto-reconnect storm at ~1 s cadence therefore can never win the
+       session back no matter how long it runs, while a human who closes the
+       client and reconnects (a gap well over 5 s) still can. Cleared when a
+       session ends on its own rather than being replaced. **Known
+       limitation:** IP-keyed, so two distinct clients behind one NAT/public
+       IP will briefly (≤5 s, re-armed) block each other's takeover right
+       after an eviction. Accepted — it's a net under the real fix, not the
+       mechanism itself, and the alternative (no bound at all) is worse.
+
+    Covered by `src/conn_test.rs::second_client_preempts_the_live_session`
+    (extended: now asserts the evicted session actually RECEIVES
+    `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION`, decoding the PDU rather than
+    just checking the socket closed) and `::
+    a_just_evicted_peer_cannot_immediately_preempt_back` (reproduces the live
+    ping-pong: A connects, B preempts, A immediately reconnects → refused, B
+    survives; note every loopback peer is 127.0.0.1, which is exactly the
+    source-IP key the net uses). Both verified to fail without their
+    respective fix and pass with it.

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -26,7 +26,7 @@ use ironrdp_svc::{ChannelFlags, StaticChannelId, StaticChannelSet, SvcProcessor,
 use ironrdp_tokio::{FramedRead, FramedWrite, TokioFramed, split_tokio_framed, unsplit_tokio_framed};
 use rdpsnd::server::{RdpsndServer, RdpsndServerMessage};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
-use tokio::net::TcpSocket;
+use tokio::net::{TcpSocket, TcpStream};
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task;
 use tokio_rustls::TlsAcceptor;
@@ -46,11 +46,6 @@ use crate::{SoundServerFactory, builder, capabilities};
 /// TCP listen backlog size for the RDP server socket.
 const LISTENER_BACKLOG: u32 = 1024;
 
-/// (vendored, divergence 22) How long a connection accepted while a session is
-/// live may take to start speaking RDP before it is dropped instead of being
-/// allowed to preempt that session.
-const PREEMPT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
-
 /// (vendored, divergence 22) What resolved first while a session was live: the
 /// session itself ending, a new inbound connection, or the verdict on a
 /// previously accepted candidate. The `select!` yields one of these and does
@@ -59,57 +54,10 @@ const PREEMPT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 enum PreemptRace {
     Ended(Result<()>),
     Accepted(std::io::Result<(tokio::net::TcpStream, SocketAddr)>),
-    Probed(Option<(tokio::net::TcpStream, SocketAddr)>),
-}
-
-/// (vendored, divergence 22) Decide whether a connection accepted while another
-/// session is live may PREEMPT it, without consuming anything the RDP handshake
-/// needs.
-///
-/// Preemption is destructive to the connected user, so a bare TCP connect must
-/// not be enough to trigger it — otherwise any port scan (or a half-open probe)
-/// would kill a live desktop session. This peeks — `recv(MSG_PEEK)`, so the
-/// bytes stay queued for `run_connection` — at the first two bytes and requires
-/// them to be a TPKT header (version 3, reserved 0), i.e. the start of an X.224
-/// Connection Request. A scanner that connects and closes, or that never sends
-/// anything, resolves to `None` and the live session is left alone.
-///
-/// This is a cheap filter, not authentication: a peer that speaks RDP but fails
-/// NLA still takes over the session slot. That case is bounded by the
-/// [`ConnectionHandler`] gate (rate limiting / lockout), which the caller runs
-/// on the winner before serving it.
-async fn probe_preempting_client(
-    stream: tokio::net::TcpStream,
-    peer: SocketAddr,
-) -> Option<(tokio::net::TcpStream, SocketAddr)> {
-    const TPKT_VERSION: u8 = 0x03;
-
-    let speaks_rdp = tokio::time::timeout(PREEMPT_PROBE_TIMEOUT, async {
-        let mut head = [0u8; 2];
-        loop {
-            match stream.peek(&mut head).await {
-                // Peer closed without sending — a connect-scan, not a client.
-                Ok(0) => return false,
-                // Only the first byte has landed; wait for its partner.
-                Ok(1) => tokio::time::sleep(Duration::from_millis(20)).await,
-                Ok(_) => return head[0] == TPKT_VERSION && head[1] == 0x00,
-                Err(_) => return false,
-            }
-        }
-    })
-    .await
-    .unwrap_or(false);
-
-    if speaks_rdp {
-        Some((stream, peer))
-    } else {
-        debug!(
-            ?peer,
-            "connection did not start an RDP handshake while a session was live — \
-             dropping it rather than preempting the live session"
-        );
-        None
-    }
+    /// The outcome of `negotiate_candidate` for whichever peer is currently
+    /// being probed — see `probing_peer` at the call site for why the peer
+    /// itself isn't carried here.
+    Probed(Option<NegotiatedCandidate>),
 }
 
 /// Action to take after a client disconnects.
@@ -471,19 +419,26 @@ pub struct RdpServer {
     handler: Arc<Mutex<Box<dyn RdpServerInputHandler>>>,
     display: Arc<Mutex<Box<dyn RdpServerDisplay>>>,
     static_channels: StaticChannelSet,
-    sound_factory: Option<Box<dyn SoundServerFactory>>,
-    cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
-    rdpdr_factory: Option<Box<dyn crate::RdpdrServerFactory>>,
+    // (vendored, divergence 23) `Rc`, not `Box`: a preempting candidate's
+    // trial negotiation (see `negotiate_and_authenticate`) needs to build its
+    // own real static/dynamic channels concurrently with the live
+    // connection's `run_connection`, which holds `&mut self` for the whole
+    // race — so it works from a cheaply-cloned snapshot of these factories
+    // instead of going through `self`. They're set once at construction and
+    // never reassigned, so sharing via `Rc` costs nothing at steady state.
+    sound_factory: Option<Rc<dyn SoundServerFactory>>,
+    cliprdr_factory: Option<Rc<dyn CliprdrServerFactory>>,
+    rdpdr_factory: Option<Rc<dyn crate::RdpdrServerFactory>>,
     // (divergence 16) server-direction MS-RDPEUSB (URBDRC) USB redirection.
     // Ships inert: the URBDRC DVC is advertised only when this is `Some`.
-    usb_factory: Option<Box<dyn crate::UrbdrcServerFactory>>,
+    usb_factory: Option<Rc<dyn crate::UrbdrcServerFactory>>,
     // (divergence 19) server-direction MS-RDPECAM camera redirection — Phase-0
     // protocol gate. The `RDCamera_Device_Enumerator` DVC is advertised only when
     // this is `Some`; byte-identical when None.
-    camera_factory: Option<Box<dyn crate::RdCameraServerFactory>>,
+    camera_factory: Option<Rc<dyn crate::RdCameraServerFactory>>,
     echo_handle: EchoServerHandle,
     #[cfg(feature = "egfx")]
-    gfx_factory: Option<Box<dyn GfxServerFactory>>,
+    gfx_factory: Option<Rc<dyn GfxServerFactory>>,
     #[cfg(feature = "egfx")]
     gfx_handle: Option<crate::gfx::GfxServerHandle>,
     ev_sender: mpsc::UnboundedSender<ServerEvent>,
@@ -717,6 +672,340 @@ enum RunState {
     DeactivationReactivation { desktop_size: DesktopSize },
 }
 
+/// (vendored, divergence 23) The GFX server handle `attach_channels_impl`
+/// hands back, so its caller can decide whether/when to install it on
+/// `self.gfx_handle` — a type alias so the function signature doesn't need
+/// its own `#[cfg(feature = "egfx")]` variant.
+#[cfg(feature = "egfx")]
+type AttachedGfxHandle = Option<crate::gfx::GfxServerHandle>;
+#[cfg(not(feature = "egfx"))]
+type AttachedGfxHandle = ();
+
+/// (vendored, divergence 23) The channel-attaching half of connection setup,
+/// factored out of `RdpServer::attach_channels` so it can also run for a
+/// preempting candidate's trial negotiation (`negotiate_candidate`), which
+/// races concurrently against the live connection's `&mut self` borrow and so
+/// can't call a `&mut self` method. Takes borrowed/cloned factory references
+/// instead of reading `self` directly; the normal path
+/// (`RdpServer::attach_channels`) passes `self`'s own fields, the candidate
+/// path passes a cloned `NegotiationContext`'s.
+///
+/// Returns the GFX handle instead of writing it to a field — the normal path
+/// installs it on `self.gfx_handle` immediately (nothing else is racing);
+/// the candidate path holds it in the `NegotiatedCandidate` and only installs
+/// it on `self.gfx_handle` if/when that candidate actually wins (see
+/// `serve_negotiated`), since only the winner should claim it.
+///
+/// **Multitransport is a normal-path-only channel here.** The lossy-audio DVC
+/// (added when `multitransport_lossy_audio_formats` is `Some`) is
+/// deliberately NOT offered to a preempting candidate: it's only useful when
+/// paired with the UDP transport OFFER, which candidates also skip (see
+/// `negotiate_candidate`) because that offer registers process-wide cookie/
+/// tunnel state on `self` that isn't safe to touch concurrently with the live
+/// connection's own multitransport bookkeeping. A candidate that wins via
+/// preemption always runs plain TCP with no lossy-audio channel; a normal
+/// (non-racing) connection is unaffected.
+#[expect(clippy::too_many_arguments, reason = "internal helper, one call site per caller shape")]
+fn attach_channels_impl(
+    acceptor: &mut Acceptor,
+    cliprdr_factory: Option<&dyn CliprdrServerFactory>,
+    sound_factory: Option<&dyn SoundServerFactory>,
+    rdpdr_factory: Option<&dyn crate::RdpdrServerFactory>,
+    usb_factory: Option<&dyn crate::UrbdrcServerFactory>,
+    camera_factory: Option<&dyn crate::RdCameraServerFactory>,
+    #[cfg(feature = "egfx")] gfx_factory: Option<&dyn GfxServerFactory>,
+    #[cfg(feature = "multitransport")] multitransport_lossy_audio_formats: Option<Vec<ironrdp_rdpsnd::pdu::AudioFormat>>,
+    #[cfg(feature = "multitransport")] lossy_audio_format: crate::multitransport::audio_dvc::NegotiatedAudioFormat,
+    display: &Arc<Mutex<Box<dyn RdpServerDisplay>>>,
+    handler: &Arc<Mutex<Box<dyn RdpServerInputHandler>>>,
+    echo_handle: &EchoServerHandle,
+    ev_sender: &mpsc::UnboundedSender<ServerEvent>,
+) -> AttachedGfxHandle {
+    if let Some(cliprdr_factory) = cliprdr_factory {
+        let backend = cliprdr_factory.build_cliprdr_backend();
+
+        let cliprdr = CliprdrServer::new(backend);
+
+        acceptor.attach_static_channel(cliprdr);
+    }
+
+    if let Some(factory) = sound_factory {
+        let backend = factory.build_backend();
+
+        acceptor.attach_static_channel(RdpsndServer::new(backend));
+    }
+
+    // RDPDR (drive redirection). MS-RDPEFS requires it be co-advertised with
+    // rdpsnd, so it's attached right after the sound channel. build_rdpdr
+    // wires the backend's RdpdrHandle to this connection's event sender so it
+    // can issue device-I/O requests.
+    if let Some(factory) = rdpdr_factory {
+        let rdpdr = crate::rdpdr::build_rdpdr(factory, ev_sender.clone());
+        acceptor.attach_static_channel(rdpdr);
+    }
+
+    let dcs_backend = DisplayControlBackend::new(Arc::clone(display));
+    let dvc = dvc::DrdynvcServer::new()
+        .with_dynamic_channel(AInputHandler {
+            handler: Arc::clone(handler),
+        })
+        .with_dynamic_channel(DisplayControlServer::new(Box::new(dcs_backend)));
+
+    let dvc = {
+        let echo_handle = echo_handle.clone();
+        dvc.with_dynamic_channel(EchoDvcBridge::new(echo_handle))
+    };
+
+    #[cfg(feature = "egfx")]
+    let (dvc, gfx_handle) = {
+        let mut dvc = dvc;
+        let mut gfx_handle = None;
+        if let Some(gfx_factory) = gfx_factory {
+            if let Some((bridge, handle)) = gfx_factory.build_server_with_handle() {
+                gfx_handle = Some(handle);
+                dvc = dvc.with_dynamic_channel(bridge);
+            } else {
+                let handler = gfx_factory.build_gfx_handler();
+                let gfx_server = ironrdp_egfx::server::GraphicsPipelineServer::new(handler);
+                dvc = dvc.with_dynamic_channel(gfx_server);
+            }
+        }
+        (dvc, gfx_handle)
+    };
+    #[cfg(not(feature = "egfx"))]
+    let gfx_handle = ();
+
+    // (vendored, feature=multitransport, P2.4b) Dual audio output DVC for lossy
+    // UDP audio. Registered only when the application supplied a format list
+    // (macrdp does so when `--enable-aac` + the lossy UDP offer are both on).
+    // mstsc tears down if it receives Server Audio Formats on the `_LOSSY_`
+    // channel (over TCP *or* the tunnel — verified), so we open BOTH: the
+    // reliable `AUDIO_PLAYBACK_DVC` runs the format/quality/training handshake
+    // over TCP and publishes the negotiated format index; the lossy
+    // `AUDIO_PLAYBACK_LOSSY_DVC` is Soft-Synced onto the lossy/DTLS tunnel and
+    // carries only Wave2 data stamped with that index. See the "Multitransport
+    // is a normal-path-only channel" note on this function's doc comment.
+    #[cfg(feature = "multitransport")]
+    let dvc = {
+        use crate::multitransport::audio_dvc::AudioLossyDvc;
+        let mut dvc = dvc;
+        if let Some(formats) = multitransport_lossy_audio_formats {
+            dvc = dvc.with_dynamic_channel(AudioLossyDvc::reliable(formats, lossy_audio_format.clone()));
+            dvc = dvc.with_dynamic_channel(AudioLossyDvc::lossy());
+        }
+        dvc
+    };
+
+    // (divergence 16) server-direction MS-RDPEUSB (URBDRC) USB redirection.
+    // Advertised only when a factory is installed; byte-identical when None.
+    let dvc = {
+        let mut dvc = dvc;
+        if let Some(usb_factory) = usb_factory {
+            dvc = dvc.with_dynamic_channel(usb_factory.build_processor());
+        }
+        dvc
+    };
+
+    // (divergence 19) server-direction MS-RDPECAM camera redirection (Phase-0
+    // gate). Advertised only when a factory is installed; byte-identical when None.
+    let dvc = {
+        let mut dvc = dvc;
+        if let Some(camera_factory) = camera_factory {
+            dvc = dvc.with_dynamic_channel(camera_factory.build_processor());
+        }
+        dvc
+    };
+
+    acceptor.attach_static_channel(dvc);
+
+    gfx_handle
+}
+
+/// (vendored, divergence 23) A cheap, `Rc`/`Arc`-cloned snapshot of everything
+/// [`negotiate_candidate`] needs to run a preempting candidate's TLS+CredSSP
+/// negotiation concurrently with the live connection's `run_connection`
+/// (which holds `&mut self` for the whole race — see `RdpServer::run`'s
+/// preemption branch). Built once per race via `RdpServer::negotiation_context`.
+///
+/// Deliberately does NOT carry multitransport state (`self.multitransport*`,
+/// `self.link_rtt_ms`, `self.current_offer_cookie`): those fields are
+/// process-wide, per-connection-mutated bookkeeping shared with the live
+/// connection's own negotiation, so a candidate touching them concurrently
+/// would corrupt whichever runs second. A candidate that wins via preemption
+/// always negotiates plain TCP (no UDP multitransport offer, no lossy-audio
+/// DVC) — see the doc comment on `attach_channels_impl`.
+struct NegotiationContext {
+    opts: RdpServerOptions,
+    creds: Option<Credentials>,
+    honor_client_desktop_size: bool,
+    honor_client_desktop_size_max: Option<DesktopSize>,
+    display: Arc<Mutex<Box<dyn RdpServerDisplay>>>,
+    handler: Arc<Mutex<Box<dyn RdpServerInputHandler>>>,
+    echo_handle: EchoServerHandle,
+    ev_sender: mpsc::UnboundedSender<ServerEvent>,
+    cliprdr_factory: Option<Rc<dyn CliprdrServerFactory>>,
+    sound_factory: Option<Rc<dyn SoundServerFactory>>,
+    rdpdr_factory: Option<Rc<dyn crate::RdpdrServerFactory>>,
+    usb_factory: Option<Rc<dyn crate::UrbdrcServerFactory>>,
+    camera_factory: Option<Rc<dyn crate::RdCameraServerFactory>>,
+    #[cfg(feature = "egfx")]
+    gfx_factory: Option<Rc<dyn GfxServerFactory>>,
+    connection_handler: Option<Rc<RefCell<Box<dyn ConnectionHandler>>>>,
+}
+
+/// (vendored, divergence 23) The result of a successful [`negotiate_candidate`]
+/// call: TLS is up, CredSSP authenticated (or the security mode doesn't use
+/// CredSSP at all — see that function's doc comment), and static/dynamic
+/// channels are attached. Everything needed to jump straight into
+/// `RdpServer::accept_finalize` — [`RdpServer::serve_negotiated`] does exactly
+/// that for the winner of a preemption race, skipping the negotiation this
+/// struct already completed.
+struct NegotiatedCandidate {
+    framed: TokioFramed<tokio_rustls::server::TlsStream<TcpStream>>,
+    acceptor: Acceptor,
+    gfx_handle: AttachedGfxHandle,
+}
+
+/// (vendored, divergence 23) Negotiate and authenticate `stream` from `peer`
+/// against a cloned `ctx`, WITHOUT touching the live connection's `self` at
+/// all — this is what lets it run concurrently, inside `RdpServer::run`'s
+/// preemption race, against the live connection's own `run_connection` (which
+/// holds `&mut self`).
+///
+/// Returns `Some` only once the candidate has genuinely proven itself: TLS
+/// established AND (for macrdp's always-Hybrid security — see
+/// [`RdpServerSecurity`]) CredSSP/NLA authentication succeeded. On any
+/// failure — TLS rejected, CredSSP rejected, a malformed/non-RDP negotiation,
+/// or a security mode this fast path doesn't know how to authenticate for
+/// (defensive; macrdp always configures Hybrid) — returns `None` and the live
+/// connection is left completely undisturbed. This is the fix for
+/// "an unauthenticated connection shouldn't be able to disconnect the live
+/// session": the old TPKT-header-only probe proved a candidate was
+/// *attempting* an RDP handshake, not that it would succeed, so a connection
+/// that failed authentication entirely — or even one that was simply still
+/// negotiating when a second, unrelated connection arrived — could still
+/// evict the active session before either side finished.
+///
+/// This duplicates the pre-`accept_finalize` portion of `run_connection`
+/// (X.224 negotiate → attach real channels → TLS → CredSSP) rather than
+/// sharing code with it, because `run_connection` is generic over any
+/// `AsyncRead + AsyncWrite` stream and takes `&mut self`; this is
+/// `TcpStream`-specific (the only stream type `RdpServer::run`'s accept loop
+/// ever sees) and takes `&NegotiationContext` instead, precisely so it can
+/// run alongside a live `&mut self` borrow. Keep the two in sync by hand if
+/// the negotiation sequence ever changes upstream.
+async fn negotiate_candidate(ctx: &NegotiationContext, stream: TcpStream, peer: SocketAddr) -> Option<NegotiatedCandidate> {
+    let framed = TokioFramed::new(stream);
+
+    let size = ctx.display.lock().await.size().await;
+    let capabilities = capabilities::capabilities(&ctx.opts, size);
+    let mut acceptor = Acceptor::new(ctx.opts.security.flag(), size, capabilities, ctx.creds.clone());
+    acceptor.set_honor_client_desktop_size(ctx.honor_client_desktop_size);
+    acceptor.set_honor_client_desktop_size_max(ctx.honor_client_desktop_size_max);
+
+    let gfx_handle = attach_channels_impl(
+        &mut acceptor,
+        ctx.cliprdr_factory.as_deref(),
+        ctx.sound_factory.as_deref(),
+        ctx.rdpdr_factory.as_deref(),
+        ctx.usb_factory.as_deref(),
+        ctx.camera_factory.as_deref(),
+        #[cfg(feature = "egfx")]
+        ctx.gfx_factory.as_deref(),
+        // No multitransport offer for a candidate (see the struct doc on
+        // `NegotiationContext`), so the lossy-audio DVC — which is only
+        // useful paired with that offer — is never attached here either.
+        #[cfg(feature = "multitransport")]
+        None,
+        #[cfg(feature = "multitransport")]
+        crate::multitransport::audio_dvc::NegotiatedAudioFormat::new(),
+        &ctx.display,
+        &ctx.handler,
+        &ctx.echo_handle,
+        &ctx.ev_sender,
+    );
+
+    let res = match ironrdp_acceptor::accept_begin(framed, &mut acceptor).await {
+        Ok(res) => res,
+        Err(error) => {
+            debug!(?peer, ?error, "candidate accept_begin failed — not eligible to preempt");
+            return None;
+        }
+    };
+
+    let stream = match res {
+        BeginResult::ShouldUpgrade(stream) => stream,
+        BeginResult::Continue(_) => {
+            // No TLS in this security mode, so there's nothing to
+            // authenticate against — matches `RdpServerSecurity::None`,
+            // which macrdp never configures. Conservatively not eligible to
+            // preempt rather than guessing at a meaning for "authenticated"
+            // that doesn't apply here.
+            debug!(?peer, "candidate connection did not upgrade to TLS — not eligible to preempt");
+            return None;
+        }
+    };
+
+    let tls_acceptor = match &ctx.opts.security {
+        RdpServerSecurity::Tls(acceptor) => acceptor,
+        RdpServerSecurity::Hybrid((acceptor, _)) => acceptor,
+        RdpServerSecurity::None => unreachable!("ShouldUpgrade implies a TLS-capable security mode"),
+    };
+    let accept = match tls_acceptor.accept(stream).await {
+        Ok(accept) => accept,
+        Err(error) => {
+            debug!(?peer, ?error, "candidate TLS accept failed — not eligible to preempt");
+            return None;
+        }
+    };
+    let mut framed = TokioFramed::new(accept);
+
+    acceptor.mark_security_upgrade_as_done();
+
+    let hybrid_pub_key = match &ctx.opts.security {
+        RdpServerSecurity::Hybrid((_, pub_key)) => Some(pub_key.clone()),
+        _ => None,
+    };
+    if let Some(pub_key) = hybrid_pub_key {
+        let client_name = "rdp-client".to_owned();
+
+        let auth_result = ironrdp_acceptor::accept_credssp(
+            &mut framed,
+            &mut acceptor,
+            &mut ironrdp_tokio::reqwest::ReqwestNetworkClient::new(),
+            client_name.into(),
+            pub_key,
+            None,
+        )
+        .await;
+
+        // (vendored, divergence 18) Same audit hook `run_connection` uses for
+        // the live connection — reachable here via the `Rc<RefCell<..>>`
+        // clone in `ctx`. Fires for a REJECTED candidate too (unlike the old
+        // TPKT probe, which had no auth outcome to report at all), so a
+        // failed preemption attempt against a real macrdp deployment still
+        // shows up in the audit log / AuthGuardHandler lockout accounting.
+        if let Some(handler) = ctx.connection_handler.as_ref() {
+            match &auth_result {
+                Ok(()) => handler.borrow_mut().on_authenticated(true, None),
+                Err(e) => handler.borrow_mut().on_authenticated(false, Some(&e.to_string())),
+            }
+        }
+
+        if let Err(error) = auth_result {
+            debug!(?peer, ?error, "candidate CredSSP authentication failed — not preempting the live session");
+            return None;
+        }
+    }
+
+    debug!(?peer, "candidate authenticated — eligible to preempt the live session");
+    Some(NegotiatedCandidate {
+        framed,
+        acceptor,
+        gfx_handle,
+    })
+}
+
 impl RdpServer {
     pub fn new(
         opts: RdpServerOptions,
@@ -762,14 +1051,18 @@ impl RdpServer {
             handler: Arc::new(Mutex::new(handler)),
             display: Arc::new(Mutex::new(display)),
             static_channels: StaticChannelSet::new(),
-            sound_factory,
-            cliprdr_factory,
-            rdpdr_factory,
-            usb_factory,
-            camera_factory,
+            // Wrapped into `Rc` here (after the one-time `set_sender` setup
+            // above, which needs `&mut` on the still-owned `Box`) so a
+            // preempting candidate's trial negotiation can hold its own
+            // cheap clone — see the field doc comment.
+            sound_factory: sound_factory.map(Rc::from),
+            cliprdr_factory: cliprdr_factory.map(Rc::from),
+            rdpdr_factory: rdpdr_factory.map(Rc::from),
+            usb_factory: usb_factory.map(Rc::from),
+            camera_factory: camera_factory.map(Rc::from),
             echo_handle: EchoServerHandle::new(ev_sender.clone()),
             #[cfg(feature = "egfx")]
-            gfx_factory,
+            gfx_factory: gfx_factory.map(Rc::from),
             #[cfg(feature = "egfx")]
             gfx_handle: None,
             ev_sender,
@@ -1023,98 +1316,80 @@ impl RdpServer {
     }
 
     fn attach_channels(&mut self, acceptor: &mut Acceptor) {
-        if let Some(cliprdr_factory) = self.cliprdr_factory.as_deref() {
-            let backend = cliprdr_factory.build_cliprdr_backend();
-
-            let cliprdr = CliprdrServer::new(backend);
-
-            acceptor.attach_static_channel(cliprdr);
-        }
-
-        if let Some(factory) = self.sound_factory.as_deref() {
-            let backend = factory.build_backend();
-
-            acceptor.attach_static_channel(RdpsndServer::new(backend));
-        }
-
-        // RDPDR (drive redirection). MS-RDPEFS requires it be co-advertised with
-        // rdpsnd, so it's attached right after the sound channel. build_rdpdr
-        // wires the backend's RdpdrHandle to this connection's event sender so it
-        // can issue device-I/O requests.
-        if let Some(factory) = self.rdpdr_factory.as_deref() {
-            let rdpdr = crate::rdpdr::build_rdpdr(factory, self.ev_sender.clone());
-            acceptor.attach_static_channel(rdpdr);
-        }
-
-        let dcs_backend = DisplayControlBackend::new(Arc::clone(&self.display));
-        let dvc = dvc::DrdynvcServer::new()
-            .with_dynamic_channel(AInputHandler {
-                handler: Arc::clone(&self.handler),
-            })
-            .with_dynamic_channel(DisplayControlServer::new(Box::new(dcs_backend)));
-
-        let dvc = {
-            let echo_handle = self.echo_handle.clone();
-            dvc.with_dynamic_channel(EchoDvcBridge::new(echo_handle))
-        };
-
+        let gfx_handle = attach_channels_impl(
+            acceptor,
+            self.cliprdr_factory.as_deref(),
+            self.sound_factory.as_deref(),
+            self.rdpdr_factory.as_deref(),
+            self.usb_factory.as_deref(),
+            self.camera_factory.as_deref(),
+            #[cfg(feature = "egfx")]
+            self.gfx_factory.as_deref(),
+            #[cfg(feature = "multitransport")]
+            self.multitransport_lossy_audio_formats.clone(),
+            #[cfg(feature = "multitransport")]
+            self.lossy_audio_format.clone(),
+            &self.display,
+            &self.handler,
+            &self.echo_handle,
+            &self.ev_sender,
+        );
         #[cfg(feature = "egfx")]
-        let dvc = {
-            let mut dvc = dvc;
-            if let Some(gfx_factory) = self.gfx_factory.as_deref() {
-                if let Some((bridge, handle)) = gfx_factory.build_server_with_handle() {
-                    self.gfx_handle = Some(handle);
-                    dvc = dvc.with_dynamic_channel(bridge);
-                } else {
-                    let handler = gfx_factory.build_gfx_handler();
-                    let gfx_server = ironrdp_egfx::server::GraphicsPipelineServer::new(handler);
-                    dvc = dvc.with_dynamic_channel(gfx_server);
-                }
-            }
-            dvc
-        };
+        {
+            self.gfx_handle = gfx_handle;
+        }
+        #[cfg(not(feature = "egfx"))]
+        let _ = gfx_handle;
+    }
 
-        // (vendored, feature=multitransport, P2.4b) Dual audio output DVC for lossy
-        // UDP audio. Registered only when the application supplied a format list
-        // (macrdp does so when `--enable-aac` + the lossy UDP offer are both on).
-        // mstsc tears down if it receives Server Audio Formats on the `_LOSSY_`
-        // channel (over TCP *or* the tunnel — verified), so we open BOTH: the
-        // reliable `AUDIO_PLAYBACK_DVC` runs the format/quality/training handshake
-        // over TCP and publishes the negotiated format index; the lossy
-        // `AUDIO_PLAYBACK_LOSSY_DVC` is Soft-Synced onto the lossy/DTLS tunnel and
-        // carries only Wave2 data stamped with that index.
-        #[cfg(feature = "multitransport")]
-        let dvc = {
-            use crate::multitransport::audio_dvc::AudioLossyDvc;
-            let mut dvc = dvc;
-            if let Some(formats) = self.multitransport_lossy_audio_formats.clone() {
-                dvc = dvc.with_dynamic_channel(AudioLossyDvc::reliable(formats, self.lossy_audio_format.clone()));
-                dvc = dvc.with_dynamic_channel(AudioLossyDvc::lossy());
-            }
-            dvc
-        };
+    /// (vendored, divergence 23) Build a cheap, `Rc`/`Arc`-cloned snapshot for
+    /// a candidate's concurrent negotiation — see [`NegotiationContext`].
+    fn negotiation_context(&self) -> NegotiationContext {
+        NegotiationContext {
+            opts: self.opts.clone(),
+            creds: self.creds.clone(),
+            honor_client_desktop_size: self.honor_client_desktop_size,
+            honor_client_desktop_size_max: self.honor_client_desktop_size_max,
+            display: Arc::clone(&self.display),
+            handler: Arc::clone(&self.handler),
+            echo_handle: self.echo_handle.clone(),
+            ev_sender: self.ev_sender.clone(),
+            cliprdr_factory: self.cliprdr_factory.clone(),
+            sound_factory: self.sound_factory.clone(),
+            rdpdr_factory: self.rdpdr_factory.clone(),
+            usb_factory: self.usb_factory.clone(),
+            camera_factory: self.camera_factory.clone(),
+            #[cfg(feature = "egfx")]
+            gfx_factory: self.gfx_factory.clone(),
+            connection_handler: self.connection_handler.clone(),
+        }
+    }
 
-        // (divergence 16) server-direction MS-RDPEUSB (URBDRC) USB redirection.
-        // Advertised only when a factory is installed; byte-identical when None.
-        let dvc = {
-            let mut dvc = dvc;
-            if let Some(usb_factory) = self.usb_factory.as_deref() {
-                dvc = dvc.with_dynamic_channel(usb_factory.build_processor());
-            }
-            dvc
-        };
+    /// (vendored, divergence 23) Phase 2 for a candidate that already won the
+    /// preemption race in [`negotiate_candidate`] — TLS and CredSSP are
+    /// already done. Installs the winner's GFX handle (deferred until now:
+    /// only the actual winner should claim it, see `attach_channels_impl`'s
+    /// doc comment) and resets the auto-reconnect-cookie guard (mirroring the
+    /// top of `run_connection`), then hands off to the same `accept_finalize`
+    /// the normal path uses — from here on a preemption-won connection is
+    /// indistinguishable from a normally-accepted one.
+    async fn serve_negotiated(&mut self, candidate: NegotiatedCandidate) -> Result<()> {
+        self.auto_reconnect_sent = false;
+        #[cfg(feature = "egfx")]
+        {
+            self.gfx_handle = candidate.gfx_handle;
+        }
+        #[cfg(not(feature = "egfx"))]
+        let _ = candidate.gfx_handle;
 
-        // (divergence 19) server-direction MS-RDPECAM camera redirection (Phase-0
-        // gate). Advertised only when a factory is installed; byte-identical when None.
-        let dvc = {
-            let mut dvc = dvc;
-            if let Some(camera_factory) = self.camera_factory.as_deref() {
-                dvc = dvc.with_dynamic_channel(camera_factory.build_processor());
-            }
-            dvc
-        };
+        let framed = self.accept_finalize(candidate.framed, candidate.acceptor).await?;
+        debug!("Shutting down TLS connection");
+        let (mut tls_stream, _) = framed.into_inner();
+        if let Err(e) = tls_stream.shutdown().await {
+            debug!(?e, "TLS shutdown error");
+        }
 
-        acceptor.attach_static_channel(dvc);
+        Ok(())
     }
 
     pub async fn run_connection<S>(&mut self, stream: S) -> Result<()>
@@ -1354,17 +1629,26 @@ impl RdpServer {
         debug!("Listening for connections on {local_addr}");
         self.local_addr = Some(local_addr);
 
-        // (vendored, divergence 22) A connection that arrives while a session is
-        // live PREEMPTS it (see `probe_preempting_client`). The preempting stream
-        // is carried here so the next iteration serves it instead of accepting a
-        // fresh one — it still goes through the RTT sample below, exactly like
-        // any other connection, but NOT `on_accept` again (see `from_pending`):
-        // it already cleared that gate once, as a candidate, during the race.
-        let mut pending: Option<(tokio::net::TcpStream, SocketAddr)> = None;
+        // (vendored, divergence 23) A candidate that wins a preemption race
+        // (see `negotiate_candidate`) has ALREADY cleared `on_accept` and
+        // fully authenticated (TLS + CredSSP) by the time it lands here — the
+        // whole point of the auth-gated redesign is that nothing gets to
+        // preempt the live session without proving itself first. So `pending`
+        // carries a `NegotiatedCandidate`, not a raw stream: the next
+        // iteration skips straight to `serve_negotiated` (Phase 2), with no
+        // second `on_accept` call (would double-count a stateful handler like
+        // `AuthGuardHandler`, see `NegotiationContext`'s doc comment) and no
+        // renegotiation (already done).
+        let mut pending: Option<(NegotiatedCandidate, SocketAddr)> = None;
 
         loop {
-            let (stream, peer, from_pending) = match pending.take() {
-                Some((stream, peer)) => (stream, peer, true),
+            enum Entry {
+                Fresh(TcpStream, SocketAddr),
+                Negotiated(NegotiatedCandidate, SocketAddr),
+            }
+
+            let entry = match pending.take() {
+                Some((candidate, peer)) => Entry::Negotiated(candidate, peer),
                 None => {
                     let ev_receiver = Arc::clone(&self.ev_receiver);
                     let mut ev_receiver = ev_receiver.lock().await;
@@ -1393,20 +1677,25 @@ impl RdpServer {
                         },
                         else => break,
                     };
-                    (stream, peer, false)
+                    Entry::Fresh(stream, peer)
                 }
             };
 
+            let peer = match &entry {
+                Entry::Fresh(_, peer) | Entry::Negotiated(_, peer) => *peer,
+            };
             debug!(?peer, "Received connection");
 
-            // A `pending` winner already ran (and passed) `on_accept` once,
-            // as a candidate, inside the preemption race below. Re-running it
-            // here would be a silent double-count for a STATEFUL handler —
-            // macrdp's own `AuthGuardHandler::on_accept` records the accept
-            // toward its per-source-IP rate-limit window and writes an audit
-            // line, so calling it twice for the one physical connection would
-            // inflate both without a second real attempt behind it.
-            let accepted = from_pending
+            // A `Negotiated` winner already ran (and passed) `on_accept` once,
+            // as a candidate, inside the preemption race below — its
+            // negotiation wouldn't even have started otherwise (see
+            // `negotiate_candidate`'s caller). Re-running it here would be a
+            // silent double-count for a STATEFUL handler — macrdp's own
+            // `AuthGuardHandler::on_accept` records the accept toward its
+            // per-source-IP rate-limit window and writes an audit line, so
+            // calling it twice for the one physical connection would inflate
+            // both without a second real attempt behind it.
+            let accepted = matches!(entry, Entry::Negotiated(..))
                 || self
                     .connection_handler
                     .as_ref()
@@ -1414,7 +1703,9 @@ impl RdpServer {
 
             if !accepted {
                 debug!(?peer, "Connection rejected by handler");
-                drop(stream);
+                if let Entry::Fresh(stream, _) = entry {
+                    drop(stream);
+                }
             } else {
                 // (vendored, divergence 15) Sample the kernel's smoothed TCP
                 // RTT here — the accept loop is the only point the concrete
@@ -1422,45 +1713,67 @@ impl RdpServer {
                 // takes a generic stream and wraps it immediately. The
                 // handshake-seeded srtt is available right away and is what
                 // link-adaptive consumers key on. 0 = unknown (kept on error).
-                if let Some(cell) = &self.link_rtt_ms {
-                    let rtt = tcp_srtt_ms(&stream).unwrap_or(0);
-                    cell.store(rtt, Ordering::Relaxed);
-                    debug!(?peer, rtt_ms = rtt, "sampled TCP link RTT at accept");
+                //
+                // Not sampled for a `Negotiated` winner: its raw `TcpStream`
+                // is already wrapped in TLS by the time it gets here (and its
+                // negotiation ran against a `NegotiationContext` snapshot that
+                // deliberately excludes `link_rtt_ms` — see that struct's doc
+                // comment on why candidates don't touch shared connection
+                // state). Accepted limitation, same shape as candidates
+                // skipping the multitransport offer: a preemption-won
+                // connection's RTT-dependent behavior (blank-recovery gating,
+                // adaptive-bitrate seeding) falls back to whatever was last
+                // observed rather than a fresh sample.
+                if let Entry::Fresh(stream, _) = &entry {
+                    if let Some(cell) = &self.link_rtt_ms {
+                        let rtt = tcp_srtt_ms(stream).unwrap_or(0);
+                        cell.store(rtt, Ordering::Relaxed);
+                        debug!(?peer, rtt_ms = rtt, "sampled TCP link RTT at accept");
+                    }
                 }
                 let started = tokio::time::Instant::now();
 
-                // (vendored, divergence 22) Serve this connection, but keep
-                // accepting meanwhile: a NEW client must be able to take over
-                // an existing session instead of hanging in the backlog behind
-                // it (the accept loop used to `await` the whole connection, so
-                // a second client saw a silent hang until the first left).
-                // A candidate that clears `on_accept` (the auth guard's
-                // rate-limit/lockout — see below) AND passes
-                // `probe_preempting_client` wins: the in-flight connection
+                // (vendored, divergence 22/23) Serve this connection, but
+                // keep accepting meanwhile: a NEW client must be able to take
+                // over an existing session instead of hanging in the backlog
+                // behind it (the accept loop used to `await` the whole
+                // connection, so a second client saw a silent hang until the
+                // first left). A candidate wins only once it clears
+                // `on_accept` (the auth guard's rate-limit/lockout — checked
+                // before it's even allowed to start negotiating, see the next
+                // comment) AND fully authenticates via `negotiate_candidate`
+                // (TLS + CredSSP) — an unauthenticated connection, or one that
+                // merely started a handshake, can never preempt the live
+                // session (Devolutions/IronRDP#1476 review + a real
+                // regression this exact gap caused, see divergence 23's log
+                // entry). Once a candidate wins, the in-flight connection
                 // future is dropped (cancelled — its socket closes and every
                 // per-connection resource unwinds via Drop, the same teardown
                 // a client-side disconnect takes) and the newcomer is served
-                // on the next iteration.
+                // on the next iteration via `serve_negotiated`, which resumes
+                // straight from its already-completed negotiation.
                 //
                 // Clone the shared `connection_handler` handle first (a cheap
-                // `Rc` bump): `conn` below captures `&mut self` for the whole
-                // race, so the candidate's `on_accept` — which needs to run
-                // concurrently with `conn`, see the next comment — can't go
-                // through `self.connection_handler` directly. It's `Rc<RefCell<..>>`
-                // rather than a bare `Option<Box<..>>` for exactly this reason:
-                // a `self.connection_handler.take()` here (the first cut of
-                // this fix) would have made it inaccessible to `conn` too —
-                // silently breaking `on_authenticated`/`on_client_fingerprint`,
-                // which `run_connection` calls through this same field
-                // mid-connection, for the WHOLE race, not just an instant.
+                // `Rc` bump) and snapshot a `NegotiationContext`: `conn` below
+                // captures `&mut self` for the whole race, so a candidate's
+                // `on_accept` + negotiation — which needs to run concurrently
+                // with `conn` — can't go through `self` directly.
                 let handler = self.connection_handler.clone();
+                let ctx = self.negotiation_context();
 
                 let outcome = {
-                    let mut conn = core::pin::pin!(self.run_connection(stream));
-                    let mut probe: core::pin::Pin<
-                        Box<dyn core::future::Future<Output = Option<(tokio::net::TcpStream, SocketAddr)>>>,
-                    > = Box::pin(core::future::pending());
+                    let mut conn: core::pin::Pin<Box<dyn Future<Output = Result<()>> + '_>> = match entry {
+                        Entry::Fresh(stream, _) => Box::pin(self.run_connection(stream)),
+                        Entry::Negotiated(candidate, _) => Box::pin(self.serve_negotiated(candidate)),
+                    };
+                    let mut probe: core::pin::Pin<Box<dyn Future<Output = Option<NegotiatedCandidate>>>> =
+                        Box::pin(core::future::pending());
                     let mut probing = false;
+                    // The peer being probed — `negotiate_candidate`'s Output
+                    // doesn't carry it (it's already known to the caller), so
+                    // it's tracked alongside `probing` and reattached to
+                    // whatever `probe` resolves to.
+                    let mut probing_peer: Option<SocketAddr> = None;
 
                     loop {
                         // The select must only YIELD here, never mutate
@@ -1474,16 +1787,18 @@ impl RdpServer {
 
                         match race {
                             // The session ended on its own. A candidate still
-                            // being probed is NOT dropped on the floor — that
-                            // would silently reset a legitimate client that
-                            // happened to connect right as the old session
-                            // left; finish the probe and serve it next.
+                            // being negotiated is NOT dropped on the floor —
+                            // that would silently reset a legitimate client
+                            // that happened to connect right as the old
+                            // session left; finish its negotiation and serve
+                            // it next if it authenticates.
                             PreemptRace::Ended(res) => {
                                 if probing {
                                     // Not a preemption (nothing was taken from
                                     // anyone) — hand it straight to the next
                                     // iteration.
-                                    pending = probe.await;
+                                    let peer = probing_peer.expect("probing implies probing_peer is set");
+                                    pending = probe.await.map(|candidate| (candidate, peer));
                                 }
                                 break (res, None);
                             }
@@ -1491,20 +1806,19 @@ impl RdpServer {
                                 // Gate the candidate through `on_accept`
                                 // (the AuthGuardHandler's per-source-IP
                                 // rate-limit/lockout) BEFORE it's allowed to
-                                // start probing — and so before it can ever
-                                // preempt anything. Without this, a candidate
-                                // the guard would reject could still evict the
-                                // live session just by winning the TPKT
-                                // probe, since `on_accept` would only run
-                                // afterward once it became the next
-                                // iteration's connection — the exact ordering
-                                // bug Devolutions/IronRDP#1476 review caught
-                                // in the upstreamed shape of this fix.
+                                // start negotiating — and so before it can
+                                // ever preempt anything. Without this, a
+                                // candidate the guard would reject could
+                                // still evict the live session just by
+                                // authenticating, since `on_accept` would
+                                // only run afterward once it became the next
+                                // iteration's connection.
                                 let candidate_accepted =
                                     handler.as_ref().is_none_or(|h| h.borrow_mut().on_accept(next_peer));
                                 if candidate_accepted {
                                     probing = true;
-                                    probe = Box::pin(probe_preempting_client(next_stream, next_peer));
+                                    probing_peer = Some(next_peer);
+                                    probe = Box::pin(negotiate_candidate(&ctx, next_stream, next_peer));
                                 } else {
                                     debug!(
                                         ?next_peer,
@@ -1519,8 +1833,12 @@ impl RdpServer {
                             PreemptRace::Probed(candidate) => {
                                 probing = false;
                                 probe = Box::pin(core::future::pending());
-                                if let Some(next) = candidate {
-                                    break (Ok(()), Some(next));
+                                let peer = probing_peer.take().expect("probing_peer set alongside probing");
+                                match candidate {
+                                    Some(candidate) => break (Ok(()), Some((candidate, peer))),
+                                    None => {
+                                        debug!(?peer, "candidate did not authenticate — live session unaffected");
+                                    }
                                 }
                             }
                         }
@@ -1530,13 +1848,13 @@ impl RdpServer {
                 let (result, preempted_by) = outcome;
                 let duration = started.elapsed();
 
-                if let Some((next_stream, next_peer)) = preempted_by {
+                if let Some((candidate, new_peer)) = preempted_by {
                     info!(
                         old_peer = ?peer,
-                        new_peer = ?next_peer,
-                        "another client connected — dropping the existing session in its favor"
+                        new_peer = ?new_peer,
+                        "an authenticated candidate connected — dropping the existing session in its favor"
                     );
-                    pending = Some((next_stream, next_peer));
+                    pending = Some((candidate, new_peer));
                 }
 
                 if let Err(ref error) = result {

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -1,3 +1,4 @@
+use core::cell::RefCell;
 use core::net::SocketAddr;
 use core::time::Duration;
 use std::rc::Rc;
@@ -500,7 +501,19 @@ pub struct RdpServer {
     creds: Option<Credentials>,
     local_addr: Option<SocketAddr>,
     autodetect: Option<AutoDetectManager>,
-    connection_handler: Option<Box<dyn ConnectionHandler>>,
+    // (vendored, divergence 22) `Rc<RefCell<..>>`, not a bare `Option<Box<..>>`:
+    // the preemption race in `run()` needs to call `on_accept` on a candidate
+    // while `self` is ALSO mutably borrowed for the whole race by the live
+    // connection's `run_connection` future (which itself calls
+    // `on_authenticated`/`on_client_fingerprint` through this same field
+    // mid-connection). A bare `.take()` of the field for the race's duration
+    // — the first cut of this fix — silently broke those two hooks for
+    // EVERY connection (not just preempted ones), since macrdp's preemption
+    // is unconditional: caught by the audit-log CI integration test showing
+    // zero `event="auth"` records. Sharing via `Rc<RefCell<..>>` lets a
+    // cheap clone reach the handler for the candidate's `on_accept` without
+    // taking it away from the connection that's using it concurrently.
+    connection_handler: Option<Rc<RefCell<Box<dyn ConnectionHandler>>>>,
     /// True when the client has sent `SuppressOutput { desktop_rect: None }`
     /// — the standard RDP "I am minimized / don't need display updates"
     /// signal (e.g., mstsc on window-minimize). Cleared on
@@ -765,7 +778,7 @@ impl RdpServer {
             creds: None,
             local_addr: None,
             autodetect: None,
-            connection_handler,
+            connection_handler: connection_handler.map(|h| Rc::new(RefCell::new(h))),
             display_suppressed: Arc::new(AtomicBool::new(false)),
             keyboard_layout: None,
             link_rtt_ms: None,
@@ -1283,10 +1296,10 @@ impl RdpServer {
                     // validated, Err = auth did not complete (dominated by bad
                     // credentials). Reactivation reuses the connection and does not
                     // re-run accept_credssp, so this fires exactly once per login.
-                    if let Some(handler) = self.connection_handler.as_mut() {
+                    if let Some(handler) = self.connection_handler.as_ref() {
                         match &auth_result {
-                            Ok(()) => handler.on_authenticated(true, None),
-                            Err(e) => handler.on_authenticated(false, Some(&e.to_string())),
+                            Ok(()) => handler.borrow_mut().on_authenticated(true, None),
+                            Err(e) => handler.borrow_mut().on_authenticated(false, Some(&e.to_string())),
                         }
                     }
 
@@ -1393,8 +1406,11 @@ impl RdpServer {
             // toward its per-source-IP rate-limit window and writes an audit
             // line, so calling it twice for the one physical connection would
             // inflate both without a second real attempt behind it.
-            let accepted =
-                from_pending || self.connection_handler.as_mut().is_none_or(|h| h.on_accept(peer));
+            let accepted = from_pending
+                || self
+                    .connection_handler
+                    .as_ref()
+                    .is_none_or(|h| h.borrow_mut().on_accept(peer));
 
             if !accepted {
                 debug!(?peer, "Connection rejected by handler");
@@ -1426,12 +1442,18 @@ impl RdpServer {
                 // a client-side disconnect takes) and the newcomer is served
                 // on the next iteration.
                 //
-                // Take `connection_handler` out of `self` first: `conn` below
-                // captures `&mut self` for the whole race, and the candidate's
-                // `on_accept` must still be callable alongside it — see the
-                // next comment for why that ordering matters. Restored into
-                // `self` once the race ends (`conn`'s scope closes here).
-                let mut handler = self.connection_handler.take();
+                // Clone the shared `connection_handler` handle first (a cheap
+                // `Rc` bump): `conn` below captures `&mut self` for the whole
+                // race, so the candidate's `on_accept` — which needs to run
+                // concurrently with `conn`, see the next comment — can't go
+                // through `self.connection_handler` directly. It's `Rc<RefCell<..>>`
+                // rather than a bare `Option<Box<..>>` for exactly this reason:
+                // a `self.connection_handler.take()` here (the first cut of
+                // this fix) would have made it inaccessible to `conn` too —
+                // silently breaking `on_authenticated`/`on_client_fingerprint`,
+                // which `run_connection` calls through this same field
+                // mid-connection, for the WHOLE race, not just an instant.
+                let handler = self.connection_handler.clone();
 
                 let outcome = {
                     let mut conn = core::pin::pin!(self.run_connection(stream));
@@ -1478,7 +1500,8 @@ impl RdpServer {
                                 // iteration's connection — the exact ordering
                                 // bug Devolutions/IronRDP#1476 review caught
                                 // in the upstreamed shape of this fix.
-                                let candidate_accepted = handler.as_mut().is_none_or(|h| h.on_accept(next_peer));
+                                let candidate_accepted =
+                                    handler.as_ref().is_none_or(|h| h.borrow_mut().on_accept(next_peer));
                                 if candidate_accepted {
                                     probing = true;
                                     probe = Box::pin(probe_preempting_client(next_stream, next_peer));
@@ -1504,7 +1527,6 @@ impl RdpServer {
                     }
                 };
 
-                self.connection_handler = handler;
                 let (result, preempted_by) = outcome;
                 let duration = started.elapsed();
 
@@ -1585,8 +1607,8 @@ impl RdpServer {
                     }
                 }
 
-                if let Some(ref mut handler) = self.connection_handler {
-                    let action = handler.on_disconnected(
+                if let Some(handler) = self.connection_handler.as_ref() {
+                    let action = handler.borrow_mut().on_disconnected(
                         peer,
                         duration,
                         result.as_ref().err(),
@@ -2747,8 +2769,8 @@ impl RdpServer {
             // Surface it to the application's ConnectionHandler (macrdp's
             // AuthGuardHandler emits an `event="fingerprint"` audit record for
             // the SIEM JSON stream).
-            if let Some(handler) = self.connection_handler.as_mut() {
-                handler.on_client_fingerprint(
+            if let Some(handler) = self.connection_handler.as_ref() {
+                handler.borrow_mut().on_client_fingerprint(
                     &result.client_name,
                     result.client_version,
                     result.client_build,

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -1,5 +1,5 @@
 use core::cell::RefCell;
-use core::net::SocketAddr;
+use core::net::{IpAddr, SocketAddr};
 use core::time::Duration;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -45,6 +45,21 @@ use crate::{SoundServerFactory, builder, capabilities};
 
 /// TCP listen backlog size for the RDP server socket.
 const LISTENER_BACKLOG: u32 = 1024;
+
+/// (vendored, divergence 23) How long an evicted session gets to send its
+/// `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION` and wind down on its own before
+/// it's cancelled outright. Short: the preempting client is already
+/// authenticated and waiting, and a half-dead peer must not stall the
+/// takeover. Exceeding it is not an error — it just degrades to the hard
+/// cancellation this grace period replaced.
+const EVICTION_GRACE: Duration = Duration::from_millis(750);
+
+/// (vendored, divergence 23) How long a just-evicted peer is barred from
+/// preempting its way back in — see [`RdpServer::recently_evicted`]. Sized to
+/// sit comfortably above a client's automatic reconnect cadence (~1 s) and
+/// comfortably below the time a human takes to close a window and reconnect,
+/// so it filters retry storms without blocking a deliberate retake.
+const REPREEMPT_COOLDOWN: Duration = Duration::from_secs(5);
 
 /// (vendored, divergence 22) What resolved first while a session was live: the
 /// session itself ending, a new inbound connection, or the verdict on a
@@ -456,6 +471,19 @@ pub struct RdpServer {
     creds: Option<Credentials>,
     local_addr: Option<SocketAddr>,
     autodetect: Option<AutoDetectManager>,
+    /// (vendored, divergence 23) Anti-ping-pong net for session preemption:
+    /// the peer most recently EVICTED by a takeover, and when it last tried to
+    /// come back.
+    ///
+    /// `EvictedByOtherConnection` is the real fix for the eviction loop (it
+    /// tells the loser not to auto-reconnect), but whether a given client
+    /// honors it is client-dependent. This bounds the damage if one doesn't:
+    /// a peer that was just evicted may not immediately re-preempt, and each
+    /// refused attempt RE-ARMS the window. An auto-reconnect storm (~1 s
+    /// cadence) therefore can never win the session back, while a human who
+    /// closes and reconnects — a gap far longer than
+    /// [`REPREEMPT_COOLDOWN`] — still can. Cleared once a takeover sticks.
+    recently_evicted: Option<(IpAddr, Instant)>,
     // (vendored, divergence 22) `Rc<RefCell<..>>`, not a bare `Option<Box<..>>`:
     // the preemption race in `run()` needs to call `on_accept` on a candidate
     // while `self` is ALSO mutably borrowed for the whole race by the live
@@ -628,6 +656,21 @@ pub struct RdpServer {
 #[derive(Debug)]
 pub enum ServerEvent {
     Quit(String),
+    /// (vendored, divergence 23) End this connection because an authenticated
+    /// candidate is taking the session over — a preemption, not a plain quit.
+    ///
+    /// Unlike [`Self::Quit`], this sends a Server Set Error Info PDU
+    /// (`ERRINFO_DISCONNECTED_BY_OTHERCONNECTION`, MS-RDPBCGR 2.2.5.1.1 — the
+    /// same code real Windows RDS uses for a session takeover) before
+    /// disconnecting. That distinction is LOAD-BEARING, not cosmetic: macrdp
+    /// provisions the Server Auto-Reconnect Cookie by default (divergence 13,
+    /// for blank-recovery), so a client dropped with no explanation silently
+    /// auto-reconnects a second later. With preemption in play that produced
+    /// an infinite ping-pong — each evicted client bounced straight back,
+    /// authenticated, and preempted the other, forever (observed live at
+    /// ~1-2 s per cycle). Telling the loser WHY it was disconnected is what
+    /// makes it stay away.
+    EvictedByOtherConnection,
     Clipboard(ClipboardMessage),
     /// File-copy initiation that bypasses `ClipboardMessage::SendInitiateCopy`
     /// and reaches `CliprdrServer::initiate_file_copy` directly. The only
@@ -1071,6 +1114,7 @@ impl RdpServer {
             creds: None,
             local_addr: None,
             autodetect: None,
+            recently_evicted: None,
             connection_handler: connection_handler.map(|h| Rc::new(RefCell::new(h))),
             display_suppressed: Arc::new(AtomicBool::new(false)),
             keyboard_layout: None,
@@ -1760,6 +1804,13 @@ impl RdpServer {
                 // with `conn` — can't go through `self` directly.
                 let handler = self.connection_handler.clone();
                 let ctx = self.negotiation_context();
+                // Same reason as `handler`/`ctx`: `conn` borrows `self` for the
+                // whole race, so the eviction event has to be sent through a
+                // clone of the sender rather than `self.ev_sender`.
+                let self_ev_sender = self.ev_sender.clone();
+                // Likewise moved out of `self` for the race, and written back
+                // after it (the loop below both reads and re-arms it).
+                let mut recently_evicted = self.recently_evicted.take();
 
                 let outcome = {
                     let mut conn: core::pin::Pin<Box<dyn Future<Output = Result<()>> + '_>> = match entry {
@@ -1813,12 +1864,37 @@ impl RdpServer {
                                 // authenticating, since `on_accept` would
                                 // only run afterward once it became the next
                                 // iteration's connection.
-                                let candidate_accepted =
-                                    handler.as_ref().is_none_or(|h| h.borrow_mut().on_accept(next_peer));
+                                //
+                                // Ahead of even that: a peer evicted moments
+                                // ago may not bounce straight back and take
+                                // the session again. Each attempt re-arms the
+                                // window, so an auto-reconnect storm can never
+                                // win — see `recently_evicted`. This is the
+                                // net under `EvictedByOtherConnection`, which
+                                // is what should normally stop the loop.
+                                let bounced_back = match &mut recently_evicted {
+                                    Some((ip, last_try)) if *ip == next_peer.ip() => {
+                                        let within = last_try.elapsed() < REPREEMPT_COOLDOWN;
+                                        if within {
+                                            *last_try = Instant::now();
+                                        }
+                                        within
+                                    }
+                                    _ => false,
+                                };
+                                let candidate_accepted = !bounced_back
+                                    && handler.as_ref().is_none_or(|h| h.borrow_mut().on_accept(next_peer));
                                 if candidate_accepted {
                                     probing = true;
                                     probing_peer = Some(next_peer);
                                     probe = Box::pin(negotiate_candidate(&ctx, next_stream, next_peer));
+                                } else if bounced_back {
+                                    info!(
+                                        ?next_peer,
+                                        "ignoring a reconnect from the peer just evicted — it is auto-reconnecting \
+                                         into the session that replaced it; not letting it bounce back"
+                                    );
+                                    drop(next_stream);
                                 } else {
                                     debug!(
                                         ?next_peer,
@@ -1833,11 +1909,47 @@ impl RdpServer {
                             PreemptRace::Probed(candidate) => {
                                 probing = false;
                                 probe = Box::pin(core::future::pending());
-                                let peer = probing_peer.take().expect("probing_peer set alongside probing");
+                                let new_peer = probing_peer.take().expect("probing_peer set alongside probing");
                                 match candidate {
-                                    Some(candidate) => break (Ok(()), Some((candidate, peer))),
+                                    Some(candidate) => {
+                                        // The candidate has authenticated and is
+                                        // taking over. Tell the incumbent WHY
+                                        // it's going away, and give it a moment
+                                        // to actually send that + shut down,
+                                        // instead of cancelling it outright: a
+                                        // client dropped with no reason
+                                        // auto-reconnects off the ARC cookie
+                                        // and preempts straight back, forever
+                                        // (see `EvictedByOtherConnection`).
+                                        info!(
+                                            old_peer = ?peer,
+                                            ?new_peer,
+                                            "an authenticated candidate connected — evicting the existing session in its favor"
+                                        );
+                                        let _ = self_ev_sender.send(ServerEvent::EvictedByOtherConnection);
+                                        // Arm the net against this peer
+                                        // bouncing straight back in.
+                                        recently_evicted = Some((peer.ip(), Instant::now()));
+                                        // Keep polling the incumbent so it can
+                                        // observe the event, write the PDU and
+                                        // return on its own. Bounded, because a
+                                        // wedged/half-dead peer must not stall
+                                        // the takeover — on timeout `conn` is
+                                        // simply dropped, i.e. exactly the hard
+                                        // cancellation this replaces.
+                                        match tokio::time::timeout(EVICTION_GRACE, &mut conn).await {
+                                            Ok(res) => break (res, Some((candidate, new_peer))),
+                                            Err(_) => {
+                                                debug!(
+                                                    old_peer = ?peer,
+                                                    "evicted session did not wind down in time — cancelling it"
+                                                );
+                                                break (Ok(()), Some((candidate, new_peer)));
+                                            }
+                                        }
+                                    }
                                     None => {
-                                        debug!(?peer, "candidate did not authenticate — live session unaffected");
+                                        debug!(?new_peer, "candidate did not authenticate — live session unaffected");
                                     }
                                 }
                             }
@@ -1847,14 +1959,18 @@ impl RdpServer {
 
                 let (result, preempted_by) = outcome;
                 let duration = started.elapsed();
+                self.recently_evicted = recently_evicted;
 
+                // The eviction itself is logged inside the race, where the
+                // decision is made; here it's just carried to the next
+                // iteration.
                 if let Some((candidate, new_peer)) = preempted_by {
-                    info!(
-                        old_peer = ?peer,
-                        new_peer = ?new_peer,
-                        "an authenticated candidate connected — dropping the existing session in its favor"
-                    );
                     pending = Some((candidate, new_peer));
+                } else {
+                    // This session ended on its own terms rather than being
+                    // replaced, so nobody is mid-eviction any more — let a
+                    // previously-evicted peer connect again freely.
+                    self.recently_evicted = None;
                 }
 
                 if let Err(ref error) = result {
@@ -2106,6 +2222,35 @@ impl RdpServer {
             match event {
                 ServerEvent::Quit(reason) => {
                     debug!("Got quit event: {reason}");
+                    return Ok(RunState::Disconnect);
+                }
+                // (vendored, divergence 23) Session takeover: tell the client
+                // WHY it's being disconnected before dropping it, so it does
+                // not treat this as an unexpected drop and auto-reconnect off
+                // the ARC cookie (which ping-pongs forever against the
+                // preempting client — see the variant's doc comment).
+                ServerEvent::EvictedByOtherConnection => {
+                    debug!("evicting this connection — another client took the session over");
+                    let pdu = rdp::headers::ShareDataPdu::ServerSetErrorInfo(
+                        rdp::server_error_info::ServerSetErrorInfoPdu(
+                            rdp::server_error_info::ErrorInfo::ProtocolIndependentCode(
+                                rdp::server_error_info::ProtocolIndependentCode::DisconnectedByOtherconnection,
+                            ),
+                        ),
+                    );
+                    // Best-effort: if the evicted peer's socket is already
+                    // half-dead the write fails, which is fine — it's leaving
+                    // either way, and the caller falls back to cancelling it.
+                    match encode_share_data_pdu(pdu, io_channel_id, user_channel_id) {
+                        Ok(bytes) => {
+                            if let Err(error) = writer.write_all(&bytes).await {
+                                debug!(?error, "could not send the eviction reason; disconnecting anyway");
+                            }
+                        }
+                        Err(error) => {
+                            warn!(?error, "could not encode the eviction reason; disconnecting anyway");
+                        }
+                    }
                     return Ok(RunState::Disconnect);
                 }
                 ServerEvent::GetLocalAddr(tx) => {

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -45,6 +45,72 @@ use crate::{SoundServerFactory, builder, capabilities};
 /// TCP listen backlog size for the RDP server socket.
 const LISTENER_BACKLOG: u32 = 1024;
 
+/// (vendored, divergence 22) How long a connection accepted while a session is
+/// live may take to start speaking RDP before it is dropped instead of being
+/// allowed to preempt that session.
+const PREEMPT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// (vendored, divergence 22) What resolved first while a session was live: the
+/// session itself ending, a new inbound connection, or the verdict on a
+/// previously accepted candidate. The `select!` yields one of these and does
+/// NOT mutate the probe slot — its futures still borrow it inside the select
+/// expression.
+enum PreemptRace {
+    Ended(Result<()>),
+    Accepted(std::io::Result<(tokio::net::TcpStream, SocketAddr)>),
+    Probed(Option<(tokio::net::TcpStream, SocketAddr)>),
+}
+
+/// (vendored, divergence 22) Decide whether a connection accepted while another
+/// session is live may PREEMPT it, without consuming anything the RDP handshake
+/// needs.
+///
+/// Preemption is destructive to the connected user, so a bare TCP connect must
+/// not be enough to trigger it — otherwise any port scan (or a half-open probe)
+/// would kill a live desktop session. This peeks — `recv(MSG_PEEK)`, so the
+/// bytes stay queued for `run_connection` — at the first two bytes and requires
+/// them to be a TPKT header (version 3, reserved 0), i.e. the start of an X.224
+/// Connection Request. A scanner that connects and closes, or that never sends
+/// anything, resolves to `None` and the live session is left alone.
+///
+/// This is a cheap filter, not authentication: a peer that speaks RDP but fails
+/// NLA still takes over the session slot. That case is bounded by the
+/// [`ConnectionHandler`] gate (rate limiting / lockout), which the caller runs
+/// on the winner before serving it.
+async fn probe_preempting_client(
+    stream: tokio::net::TcpStream,
+    peer: SocketAddr,
+) -> Option<(tokio::net::TcpStream, SocketAddr)> {
+    const TPKT_VERSION: u8 = 0x03;
+
+    let speaks_rdp = tokio::time::timeout(PREEMPT_PROBE_TIMEOUT, async {
+        let mut head = [0u8; 2];
+        loop {
+            match stream.peek(&mut head).await {
+                // Peer closed without sending — a connect-scan, not a client.
+                Ok(0) => return false,
+                // Only the first byte has landed; wait for its partner.
+                Ok(1) => tokio::time::sleep(Duration::from_millis(20)).await,
+                Ok(_) => return head[0] == TPKT_VERSION && head[1] == 0x00,
+                Err(_) => return false,
+            }
+        }
+    })
+    .await
+    .unwrap_or(false);
+
+    if speaks_rdp {
+        Some((stream, peer))
+    } else {
+        debug!(
+            ?peer,
+            "connection did not start an RDP handshake while a session was live — \
+             dropping it rather than preempting the live session"
+        );
+        None
+    }
+}
+
 /// Action to take after a client disconnects.
 ///
 /// Returned by [`ConnectionHandler::on_disconnected`] to control whether
@@ -1275,136 +1341,261 @@ impl RdpServer {
         debug!("Listening for connections on {local_addr}");
         self.local_addr = Some(local_addr);
 
+        // (vendored, divergence 22) A connection that arrives while a session is
+        // live PREEMPTS it (see `probe_preempting_client`). The preempting stream
+        // is carried here so the next iteration serves it instead of accepting a
+        // fresh one — it still goes through the RTT sample below, exactly like
+        // any other connection, but NOT `on_accept` again (see `from_pending`):
+        // it already cleared that gate once, as a candidate, during the race.
+        let mut pending: Option<(tokio::net::TcpStream, SocketAddr)> = None;
+
         loop {
-            let ev_receiver = Arc::clone(&self.ev_receiver);
-            let mut ev_receiver = ev_receiver.lock().await;
-            tokio::select! {
-                Some(event) = ev_receiver.recv() => {
-                    match event {
-                        ServerEvent::Quit(reason) => {
-                            debug!("Got quit event {reason}");
-                            break;
-                        }
-                        ServerEvent::GetLocalAddr(tx) => {
-                            let _ = tx.send(self.local_addr);
-                        }
-                        ServerEvent::SetCredentials(creds) => {
-                            self.set_credentials(Some(creds));
-                        }
-                        ev => {
-                            debug!("Unexpected event {:?}", ev);
-                        }
-                    }
-                },
-                Ok((stream, peer)) = listener.accept() => {
-                    debug!(?peer, "Received connection");
-                    drop(ev_receiver);
-
-                    let accepted = self.connection_handler
-                        .as_mut()
-                        .is_none_or(|h| h.on_accept(peer));
-
-                    if !accepted {
-                        debug!(?peer, "Connection rejected by handler");
-                        drop(stream);
-                    } else {
-                        // (vendored, divergence 15) Sample the kernel's smoothed TCP
-                        // RTT here — the accept loop is the only point the concrete
-                        // TcpStream (hence the raw fd) is reachable; run_connection
-                        // takes a generic stream and wraps it immediately. The
-                        // handshake-seeded srtt is available right away and is what
-                        // link-adaptive consumers key on. 0 = unknown (kept on error).
-                        if let Some(cell) = &self.link_rtt_ms {
-                            let rtt = tcp_srtt_ms(&stream).unwrap_or(0);
-                            cell.store(rtt, Ordering::Relaxed);
-                            debug!(?peer, rtt_ms = rtt, "sampled TCP link RTT at accept");
-                        }
-                        let started = tokio::time::Instant::now();
-                        let result = self.run_connection(stream).await;
-                        let duration = started.elapsed();
-
-                        if let Err(ref error) = result {
-                            error!(?error, "Connection error");
-                        }
-
-                        self.static_channels = StaticChannelSet::new();
-
-                        // (M3c) Reset per-connection UDP-multitransport state that is
-                        // otherwise only ever SET, never cleared — so a reconnect to
-                        // this same persistent RdpServer starts clean. Critically
-                        // `egfx_on_udp`: left true from the previous connection, the
-                        // next connection routes EGFX over a UDP tunnel that its OWN
-                        // Soft-Sync hasn't bound yet → frames are dropped and the
-                        // client sees a blank/black desktop on reconnect. Resetting it
-                        // keeps EGFX on TCP until the new connection's tunnel binds and
-                        // re-fires Soft-Sync (clean migration; and a correct TCP
-                        // fallback if the new tunnel never binds). The lossy-audio
-                        // counters + the on-lossy handle must likewise restart.
-                        // (`multitransport_migration`, `udp_tunnel_bound`, and the
-                        // inbound rx ARE refreshed per connection at the offer site, so
-                        // only these only-set-never-reset flags need clearing here.)
-                        #[cfg(feature = "multitransport")]
-                        {
-                            self.egfx_on_udp = false;
-                            self.lossy_audio_block_no = 0;
-                            self.lossy_audio_streaming = false;
-                            if let Some(handle) = &self.egfx_on_lossy_handle {
-                                handle.store(false, std::sync::atomic::Ordering::Relaxed);
+            let (stream, peer, from_pending) = match pending.take() {
+                Some((stream, peer)) => (stream, peer, true),
+                None => {
+                    let ev_receiver = Arc::clone(&self.ev_receiver);
+                    let mut ev_receiver = ev_receiver.lock().await;
+                    let (stream, peer) = tokio::select! {
+                        Some(event) = ev_receiver.recv() => {
+                            match event {
+                                ServerEvent::Quit(reason) => {
+                                    debug!("Got quit event {reason}");
+                                    break;
+                                }
+                                ServerEvent::GetLocalAddr(tx) => {
+                                    let _ = tx.send(self.local_addr);
+                                }
+                                ServerEvent::SetCredentials(creds) => {
+                                    self.set_credentials(Some(creds));
+                                }
+                                ev => {
+                                    debug!("Unexpected event {:?}", ev);
+                                }
                             }
-                            if let Some(handle) = &self.egfx_on_udp_handle {
-                                handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                            continue;
+                        },
+                        Ok((stream, peer)) = listener.accept() => {
+                            drop(ev_receiver);
+                            (stream, peer)
+                        },
+                        else => break,
+                    };
+                    (stream, peer, false)
+                }
+            };
+
+            debug!(?peer, "Received connection");
+
+            // A `pending` winner already ran (and passed) `on_accept` once,
+            // as a candidate, inside the preemption race below. Re-running it
+            // here would be a silent double-count for a STATEFUL handler —
+            // macrdp's own `AuthGuardHandler::on_accept` records the accept
+            // toward its per-source-IP rate-limit window and writes an audit
+            // line, so calling it twice for the one physical connection would
+            // inflate both without a second real attempt behind it.
+            let accepted =
+                from_pending || self.connection_handler.as_mut().is_none_or(|h| h.on_accept(peer));
+
+            if !accepted {
+                debug!(?peer, "Connection rejected by handler");
+                drop(stream);
+            } else {
+                // (vendored, divergence 15) Sample the kernel's smoothed TCP
+                // RTT here — the accept loop is the only point the concrete
+                // TcpStream (hence the raw fd) is reachable; run_connection
+                // takes a generic stream and wraps it immediately. The
+                // handshake-seeded srtt is available right away and is what
+                // link-adaptive consumers key on. 0 = unknown (kept on error).
+                if let Some(cell) = &self.link_rtt_ms {
+                    let rtt = tcp_srtt_ms(&stream).unwrap_or(0);
+                    cell.store(rtt, Ordering::Relaxed);
+                    debug!(?peer, rtt_ms = rtt, "sampled TCP link RTT at accept");
+                }
+                let started = tokio::time::Instant::now();
+
+                // (vendored, divergence 22) Serve this connection, but keep
+                // accepting meanwhile: a NEW client must be able to take over
+                // an existing session instead of hanging in the backlog behind
+                // it (the accept loop used to `await` the whole connection, so
+                // a second client saw a silent hang until the first left).
+                // A candidate that clears `on_accept` (the auth guard's
+                // rate-limit/lockout — see below) AND passes
+                // `probe_preempting_client` wins: the in-flight connection
+                // future is dropped (cancelled — its socket closes and every
+                // per-connection resource unwinds via Drop, the same teardown
+                // a client-side disconnect takes) and the newcomer is served
+                // on the next iteration.
+                //
+                // Take `connection_handler` out of `self` first: `conn` below
+                // captures `&mut self` for the whole race, and the candidate's
+                // `on_accept` must still be callable alongside it — see the
+                // next comment for why that ordering matters. Restored into
+                // `self` once the race ends (`conn`'s scope closes here).
+                let mut handler = self.connection_handler.take();
+
+                let outcome = {
+                    let mut conn = core::pin::pin!(self.run_connection(stream));
+                    let mut probe: core::pin::Pin<
+                        Box<dyn core::future::Future<Output = Option<(tokio::net::TcpStream, SocketAddr)>>>,
+                    > = Box::pin(core::future::pending());
+                    let mut probing = false;
+
+                    loop {
+                        // The select must only YIELD here, never mutate
+                        // `probe`: its futures still borrow it inside the
+                        // select expression.
+                        let race = tokio::select! {
+                            res = &mut conn => PreemptRace::Ended(res),
+                            accepted = listener.accept(), if !probing => PreemptRace::Accepted(accepted),
+                            candidate = &mut probe => PreemptRace::Probed(candidate),
+                        };
+
+                        match race {
+                            // The session ended on its own. A candidate still
+                            // being probed is NOT dropped on the floor — that
+                            // would silently reset a legitimate client that
+                            // happened to connect right as the old session
+                            // left; finish the probe and serve it next.
+                            PreemptRace::Ended(res) => {
+                                if probing {
+                                    // Not a preemption (nothing was taken from
+                                    // anyone) — hand it straight to the next
+                                    // iteration.
+                                    pending = probe.await;
+                                }
+                                break (res, None);
                             }
-                            // Clear the watchdog's de-migrate request so a fresh
-                            // connection retries UDP instead of instantly routing the
-                            // newly-migrated EGFX straight back to TCP.
-                            if let Some(handle) = &self.demigrate_request {
-                                handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                            PreemptRace::Accepted(Ok((next_stream, next_peer))) => {
+                                // Gate the candidate through `on_accept`
+                                // (the AuthGuardHandler's per-source-IP
+                                // rate-limit/lockout) BEFORE it's allowed to
+                                // start probing — and so before it can ever
+                                // preempt anything. Without this, a candidate
+                                // the guard would reject could still evict the
+                                // live session just by winning the TPKT
+                                // probe, since `on_accept` would only run
+                                // afterward once it became the next
+                                // iteration's connection — the exact ordering
+                                // bug Devolutions/IronRDP#1476 review caught
+                                // in the upstreamed shape of this fix.
+                                let candidate_accepted = handler.as_mut().is_none_or(|h| h.on_accept(next_peer));
+                                if candidate_accepted {
+                                    probing = true;
+                                    probe = Box::pin(probe_preempting_client(next_stream, next_peer));
+                                } else {
+                                    debug!(
+                                        ?next_peer,
+                                        "candidate connection rejected by handler while a session was live"
+                                    );
+                                    drop(next_stream);
+                                }
                             }
-                            // Retire this connection's tunnel: lower the shared bound
-                            // flag so the listener's tunnel-death check (which skips
-                            // lowered flags) treats the now-abandoned tunnel as benign
-                            // teardown — it just ages out via the idle GC. Without
-                            // this, every ended session's tunnel "dies" ~30 s later
-                            // and starts the multitransport-offer COOLDOWN, silently
-                            // downgrading the next 10 min of healthy-LAN connections
-                            // to plain TCP (observed live 2026-07-06 after a
-                            // blank-recovery drop). A tunnel that wedges while its
-                            // session is ALIVE still declares death + cooldown exactly
-                            // as before (its flag is still up when the check runs).
-                            if let Some(flag) = &self.udp_tunnel_bound {
-                                flag.store(false, std::sync::atomic::Ordering::Relaxed);
+                            PreemptRace::Accepted(Err(error)) => {
+                                warn!(?error, "accept failed while a session was live");
                             }
-                            // Evict the connection's offer cookie no matter how it
-                            // ended. Eviction used to be keyed off `MigrationState`
-                            // (set only at activation), so a connection dying
-                            // earlier — mstsc's cert-prompt broken pipe, CredSSP
-                            // failures, probes — leaked one registry entry per
-                            // attempt forever, and a LATE tunnel bind (the client's
-                            // UDP handshake outliving a fast session end) could
-                            // still consume the stale cookie and re-raise the
-                            // retired flag → zombie peer → spurious death + a
-                            // 10-min offer cooldown on a healthy setup.
-                            if let Some(cookie) = self.current_offer_cookie.take() {
-                                if let Some(registry) = self.multitransport_cookies.as_ref() {
-                                    registry.remove(&cookie);
+                            PreemptRace::Probed(candidate) => {
+                                probing = false;
+                                probe = Box::pin(core::future::pending());
+                                if let Some(next) = candidate {
+                                    break (Ok(()), Some(next));
                                 }
                             }
                         }
+                    }
+                };
 
-                        if let Some(ref mut handler) = self.connection_handler {
-                            let action = handler.on_disconnected(
-                                peer,
-                                duration,
-                                result.as_ref().err(),
-                            );
-                            if action == PostConnectionAction::Stop {
-                                debug!(?peer, "Handler requested stop after disconnect");
-                                break;
-                            }
+                self.connection_handler = handler;
+                let (result, preempted_by) = outcome;
+                let duration = started.elapsed();
+
+                if let Some((next_stream, next_peer)) = preempted_by {
+                    info!(
+                        old_peer = ?peer,
+                        new_peer = ?next_peer,
+                        "another client connected — dropping the existing session in its favor"
+                    );
+                    pending = Some((next_stream, next_peer));
+                }
+
+                if let Err(ref error) = result {
+                    error!(?error, "Connection error");
+                }
+
+                self.static_channels = StaticChannelSet::new();
+
+                // (M3c) Reset per-connection UDP-multitransport state that is
+                // otherwise only ever SET, never cleared — so a reconnect to
+                // this same persistent RdpServer starts clean. Critically
+                // `egfx_on_udp`: left true from the previous connection, the
+                // next connection routes EGFX over a UDP tunnel that its OWN
+                // Soft-Sync hasn't bound yet → frames are dropped and the
+                // client sees a blank/black desktop on reconnect. Resetting it
+                // keeps EGFX on TCP until the new connection's tunnel binds and
+                // re-fires Soft-Sync (clean migration; and a correct TCP
+                // fallback if the new tunnel never binds). The lossy-audio
+                // counters + the on-lossy handle must likewise restart.
+                // (`multitransport_migration`, `udp_tunnel_bound`, and the
+                // inbound rx ARE refreshed per connection at the offer site, so
+                // only these only-set-never-reset flags need clearing here.)
+                #[cfg(feature = "multitransport")]
+                {
+                    self.egfx_on_udp = false;
+                    self.lossy_audio_block_no = 0;
+                    self.lossy_audio_streaming = false;
+                    if let Some(handle) = &self.egfx_on_lossy_handle {
+                        handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    if let Some(handle) = &self.egfx_on_udp_handle {
+                        handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    // Clear the watchdog's de-migrate request so a fresh
+                    // connection retries UDP instead of instantly routing the
+                    // newly-migrated EGFX straight back to TCP.
+                    if let Some(handle) = &self.demigrate_request {
+                        handle.store(false, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    // Retire this connection's tunnel: lower the shared bound
+                    // flag so the listener's tunnel-death check (which skips
+                    // lowered flags) treats the now-abandoned tunnel as benign
+                    // teardown — it just ages out via the idle GC. Without
+                    // this, every ended session's tunnel "dies" ~30 s later
+                    // and starts the multitransport-offer COOLDOWN, silently
+                    // downgrading the next 10 min of healthy-LAN connections
+                    // to plain TCP (observed live 2026-07-06 after a
+                    // blank-recovery drop). A tunnel that wedges while its
+                    // session is ALIVE still declares death + cooldown exactly
+                    // as before (its flag is still up when the check runs).
+                    if let Some(flag) = &self.udp_tunnel_bound {
+                        flag.store(false, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    // Evict the connection's offer cookie no matter how it
+                    // ended. Eviction used to be keyed off `MigrationState`
+                    // (set only at activation), so a connection dying
+                    // earlier — mstsc's cert-prompt broken pipe, CredSSP
+                    // failures, probes — leaked one registry entry per
+                    // attempt forever, and a LATE tunnel bind (the client's
+                    // UDP handshake outliving a fast session end) could
+                    // still consume the stale cookie and re-raise the
+                    // retired flag → zombie peer → spurious death + a
+                    // 10-min offer cooldown on a healthy setup.
+                    if let Some(cookie) = self.current_offer_cookie.take() {
+                        if let Some(registry) = self.multitransport_cookies.as_ref() {
+                            registry.remove(&cookie);
                         }
                     }
                 }
-                else => break,
+
+                if let Some(ref mut handler) = self.connection_handler {
+                    let action = handler.on_disconnected(
+                        peer,
+                        duration,
+                        result.as_ref().err(),
+                    );
+                    if action == PostConnectionAction::Stop {
+                        debug!(?peer, "Handler requested stop after disconnect");
+                        break;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

When a client is already connected, connecting a second RDP client just hangs — the connection establishes at the TCP layer, but no RDP handshake response ever comes, until the first session ends. Root cause: `RdpServer::run` (vendored `ironrdp-server`) serves one connection at a time — while `run_connection` is awaited for the live client, the accept loop never calls `accept()` again.

macrdp is single-console-session by design (it mirrors/serves one specific desktop), so the right behavior is for a newly-connecting client to **take over**, not queue silently behind a stale/abandoned session.

## Design (updated after CI + review caught real gaps)

The accept loop races the in-flight connection against `listener.accept()`. A candidate is only allowed to preempt the live session once it has **fully authenticated** — real TLS, and CredSSP where the security mode is Hybrid (which macrdp always uses). This replaced an earlier, weaker design (a 2-byte TPKT-header peek) after two rounds of real problems surfaced:

1. **On_accept had to be gated before negotiation, not after winning.** The auth guard's per-source-IP rate-limit/lockout (`AuthGuardHandler::on_accept`) was only checked on the *next* loop iteration, by which point the live session had already been cancelled — so a candidate the guard would reject could still evict the active session before being rejected.
2. **CI caught the deeper issue**: `scripts/test-audit-log.sh` (two sequential connections, correct then wrong password) started failing — the first connection's `event="auth" outcome="success"` never appeared. The TPKT-only gate let a second connection's mere arrival (2 bytes, near-instant) preempt the first connection's *own, still-in-progress* TLS+CredSSP negotiation, purely by winning a timing race. That's not a benign edge case — it means an unauthenticated or even malicious connection attempt could kill the live session without ever proving it's a legitimate client.

Both are now closed by a structural fix rather than a timing patch: a candidate cannot reach the "preempt" outcome without `negotiate_candidate` (new) completing real TLS + CredSSP against the server's actual credentials. Since `RdpServer` serves one connection at a time by design (single `static_channels`, single `gfx_handle`, factories that build real per-connection backends against shared hardware — capture, camera, USB, RDPDR/NFS) and `run_connection` holds `&mut self` for its whole lifetime, the candidate's negotiation runs against a cheaply-cloned `NegotiationContext` snapshot (factories moved from `Box<dyn X>` to `Rc<dyn X>` to make this possible) instead of `self` — a Phase 1 (negotiate + authenticate, concurrency-safe) / Phase 2 (exclusive, resource-driving, winner-only) split. Full design writeup + rationale for every piece is in divergence (23) of `vendor/ironrdp-server/CLAUDE.md`.

Multitransport (the UDP offer + lossy-audio DVC) and RTT sampling are intentionally skipped for a preemption candidate — that state is process-wide and shared with the live connection's own bookkeeping, not safe to touch concurrently. A preemption winner always negotiates plain TCP; a normal (non-racing) connection is unaffected either way.

## Testing

- `second_client_preempts_the_live_session` — drives the real `RdpServer::run` accept loop over real TCP; proves the positive path end-to-end through the new `negotiate_candidate` machinery.
- `preemption_does_not_evict_a_session_the_handler_would_reject` — proves the `on_accept` rate-limit gate blocks a bad actor before negotiation even starts (and before it existed, this failed — verified).
- `a_preempting_candidate_clears_on_accept_exactly_once` — `on_accept` is stateful for the real handler (records toward the rate-limit window, writes an audit line), so a winning candidate must not run it twice for one physical connection.

**Gap, disclosed rather than hidden:** I could not locally test a candidate that reaches CredSSP but fails it (wrong password) — `ironrdp-server` isn't a workspace member here (a `[patch.crates-io]` path override), so `#[cfg(test)]` code inside the vendor crate can't run via any `cargo test` invocation from macrdp (confirmed: `cargo test -p ironrdp-server` refuses — "requires dev-dependencies and is not a member of the workspace"). Building a full NTLM-capable test client from scratch was more risk/effort than the remaining gap warranted, given `scripts/test-audit-log.sh` (real sdl-freerdp, correct AND wrong password) is exactly this scenario and runs in CI — that's the authoritative check for this path, and it's what caught the previous regression in the first place. The property does follow directly from the code structure: a candidate cannot reach `pending` without `negotiate_candidate` returning `Some`, which requires `accept_credssp` to return `Ok`.

`cargo build`, `cargo test` (192 passing), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` are all clean.

## Notes

Filed the equivalent fix upstream as [Devolutions/IronRDP#1476](https://github.com/Devolutions/IronRDP/pull/1476), shaped as an opt-in `preempt_existing_session` builder option — still the TPKT-peek shape as of this writing, since the auth-gating redesign needed the `Box`→`Rc` factory change that isn't obviously desirable as a general-purpose upstream default. Revisiting that PR once this design has had more real-world runway.
