### PR TITLE
fix(input): retire divergence (17) — it inflates every scroll-DOWN ~255x since the v0.9.5 pin bump

### DIFF
--- a/src/conn_test.rs
+++ b/src/conn_test.rs
@@ -1016,3 +1016,51 @@ async fn connect_with_retry(addr: SocketAddr) -> anyhow::Result<tokio::net::TcpS
     }
     anyhow::bail!("server never started listening on {addr}")
 }
+
+/// The wheel-rotation delta must survive the PDU round-trip unchanged, and in
+/// particular a DOWNWARD scroll must not be inflated.
+///
+/// History (macrdp issue #113, twice): MS-RDPBCGR's WheelRotationMask (0x01FF)
+/// is a 9-bit TWO'S-COMPLEMENT field, so byte 0xFF with WHEEL_NEGATIVE set
+/// means -1. `ironrdp-pdu` originally decoded it as sign-magnitude (`-(byte)`),
+/// yielding -255, and the vendored server compensated (`-v - 256`). Upstream
+/// then fixed its decode at the a5d1c682 pin — at which point the compensation
+/// DOUBLE-corrected and every gentle downward tick became -255 again, i.e. a
+/// max-speed scroll, while upward (positive, untouched) stayed fine. That
+/// asymmetry is the fingerprint of this bug.
+///
+/// This pins the end-to-end contract instead of either half, so a future pin
+/// bump that changes upstream's decode — in either direction — fails here
+/// rather than in the user's hands.
+#[test]
+fn wheel_rotation_survives_the_pdu_round_trip_in_both_directions() {
+    use ironrdp_pdu::input::mouse::{MousePdu, PointerFlags};
+    use ironrdp_server::MouseEvent;
+
+    for units in [-1_i16, -3, -120, 1, 3, 120] {
+        let mut flags = PointerFlags::VERTICAL_WHEEL;
+        if units < 0 {
+            flags |= PointerFlags::WHEEL_NEGATIVE;
+        }
+        let pdu = MousePdu {
+            flags,
+            number_of_wheel_rotation_units: units,
+            x_position: 0,
+            y_position: 0,
+        };
+
+        let encoded = ironrdp_core::encode_vec(&pdu).expect("encode mouse pdu");
+        let decoded: MousePdu = ironrdp_core::decode(&encoded).expect("decode mouse pdu");
+
+        match MouseEvent::from(decoded) {
+            MouseEvent::VerticalScroll { value } => assert_eq!(
+                value, units,
+                "wheel delta {units} came back as {value}: a scroll-down that is \
+                 inflated while scroll-up is correct means the vendored \
+                 two's-complement compensation is being applied on top of an \
+                 already-correct upstream decode (macrdp #113)"
+            ),
+            other => panic!("expected VerticalScroll for {units}, got {other:?}"),
+        }
+    }
+}

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -3,7 +3,7 @@
 Local fork of ironrdp-server 0.10.0, pulled in via `[patch.crates-io]` in
 `Cargo.toml`. The audio-lag control in the dedicated `dispatch_audio` task
 (carved out of `dispatch_server_events`) is the live divergence. Keep this
-vendor dir until (2)/(3)/(4)/(5)/(6)/(8)/(9)/(10)/(11)/(12)/(13)/(14)/(15)/(16)/(17)/(18)/(19)/(20)/(21)/(22)/(23) below are upstreamed
+vendor dir until (2)/(3)/(4)/(5)/(6)/(8)/(9)/(10)/(11)/(12)/(13)/(14)/(15)/(16)/(18)/(19)/(20)/(21)/(22)/(23) below are upstreamed
 AND released — #1276 landing is NOT sufficient. ((7) was HARVESTED at the a5d1c682 pin bump — see (7).)
 
 (1) The original "keep newest queued waves on per-batch overflow"
@@ -1345,7 +1345,26 @@ AND released — #1276 landing is NOT sufficient. ((7) was HARVESTED at the a5d1
     → per-device channel opened → `ADD_DEVICE` received (GO), session stays up
     (decode error tolerated). Off-path (`--enable-usb-redirection` absent) unchanged.
 
-(17) Wheel-rotation two's-complement decode fix (macrdp issue #113; NOT
+(17) **RETIRED 2026-08-09 — upstream fixed its decode at the a5d1c682 pin, and
+    leaving this compensation in place REGRESSED issue #113 in the opposite
+    direction.** `ironrdp-pdu` now decodes the 9-bit WheelRotationMask as
+    proper two's complement (`byte - 0x100`), so the delta arriving here is
+    already correct; re-applying `-v - 256` on top of it turned a gentle -1
+    into -255 — a max-speed scroll on every DOWNWARD tick — while upward
+    (positive, untouched) stayed correct. That asymmetry (down runs away, up
+    is fine) is the fingerprint. Shipped broken in v0.9.5 (the pin bump moved
+    past the upstream fix but did not delete this divergence, exactly as the
+    original note warned); the compensation is now removed and
+    `From<MousePdu> for MouseEvent` passes `number_of_wheel_rotation_units`
+    through unchanged. Guarded by
+    `src/conn_test.rs::wheel_rotation_survives_the_pdu_round_trip_in_both_directions`,
+    which pins the END-TO-END contract (encode → decode → MouseEvent) rather
+    than either half, so a future pin bump that changes upstream's decode in
+    either direction fails in CI instead of in a user's hands. If upstream
+    ever regresses, fix it in `ironrdp-pdu` — do NOT reintroduce a
+    compensation here. Original note follows for history:
+
+    Wheel-rotation two's-complement decode fix (macrdp issue #113; NOT
     upstreamed, real fix belongs in `ironrdp-pdu`). `From<MousePdu> for
     MouseEvent` in `handler.rs` re-decodes `number_of_wheel_rotation_units`
     as 9-bit two's complement (`WHEEL_NEGATIVE` is the sign bit); upstream's

--- a/vendor/ironrdp-server/src/handler.rs
+++ b/vendor/ironrdp-server/src/handler.rs
@@ -161,23 +161,19 @@ impl From<MousePdu> for MouseEvent {
                 MouseEvent::RightReleased
             }
         } else if value.flags.contains(PointerFlags::VERTICAL_WHEEL) {
-            // MS-RDPBCGR's WheelRotationMask (0x01FF) is a 9-bit TWO'S-
-            // COMPLEMENT field — the WHEEL_NEGATIVE 0x0100 bit doubles as its
-            // sign bit (FreeRDP: `if negative: value = -(0x100 - byte)`), so
-            // byte 0xFF with the flag set means -1, not -255. ironrdp-pdu's
-            // MousePdu decode instead computes -(byte), inflating every
-            // negative delta's magnitude (its encode side IS correct two's
-            // complement, so the codec doesn't even round-trip). mstsc masked
-            // this by scrolling in whole ±120 notches (decodes as -136 vs the
-            // true -120 — same result after downstream scaling); the macOS
-            // Windows App sends fine-grained ±1..±3 trackpad deltas, which
-            // arrived here as -255..-253 — a max-speed scroll for every gentle
-            // downward tick (macrdp issue #113). Recover the true value:
-            // decode produced -(byte), so byte = -v, and the 9-bit sign
-            // extension of the byte is byte - 256.
-            let v = value.number_of_wheel_rotation_units;
-            let corrected = if v < 0 { -v - 256 } else { v };
-            MouseEvent::VerticalScroll { value: corrected }
+            // NO correction here — see the retired divergence (17). ironrdp-pdu
+            // used to decode the 9-bit WheelRotationMask as sign-magnitude
+            // (`-(byte)`), so a gentle -1 arrived as -255 and this site had to
+            // undo it. As of the a5d1c682 pin, upstream decodes proper two's
+            // complement (`byte - 0x100`), so the delta is already correct and
+            // re-applying the old compensation would inflate every DOWNWARD
+            // scroll ~255x while leaving upward untouched (macrdp issue #113,
+            // reintroduced by the pin bump in v0.9.5 and fixed here). If a
+            // future pin regresses upstream's decode, fix it in ironrdp-pdu
+            // rather than compensating here.
+            MouseEvent::VerticalScroll {
+                value: value.number_of_wheel_rotation_units,
+            }
         } else {
             MouseEvent::Move {
                 x: value.x_position,


### PR DESCRIPTION
## Summary

**User-visible regression in v0.9.5**, reported live as *"scroll down is scrolling too fast; behaving differently than scrolling up"*. This is macrdp issue #113 coming back, in the opposite direction.

`WheelRotationMask` (0x01FF) is a 9-bit **two's-complement** field, so byte `0xFF` with `WHEEL_NEGATIVE` set means `-1`. `ironrdp-pdu` used to decode it as sign-magnitude (`-(byte)` → `-255`), and vendored divergence (17) in `From<MousePdu> for MouseEvent` compensated with `-v - 256`.

**Upstream fixed its decode** (`byte - 0x100`) at the `a5d1c682` pin. The v0.9.5 pin bump (#178) moved past that fix but did not delete the divergence, so the compensation started **double-correcting**:

| gesture | wire byte | correct | v0.9.5 shipped |
|---|---|---|---|
| Windows App down (−1) | `0xFF` | −1 | **−255** |
| Windows App down (−3) | `0xFD` | −3 | **−253** |
| mstsc down (−120) | `0x88` | −120 | −136 |
| any scroll **up** | — | +N | +N ✓ |

Positive deltas never enter the `v < 0` branch, which is exactly why **scroll-up stayed correct and only scroll-down ran away** — that asymmetry is the fingerprint. mstsc was affected too (~13% too fast down), just far less visibly than the fine-grained ±1..±3 trackpad deltas the macOS Windows App sends.

The original divergence note said to *"delete once ironrdp-pdu's decode is fixed upstream and the pin moves past it"* — this does that. The delta now passes through unchanged.

## Test

New `conn_test::wheel_rotation_survives_the_pdu_round_trip_in_both_directions` deliberately pins the **end-to-end** contract (encode → decode → `MouseEvent`) rather than either half, so a future pin bump that changes upstream's decode **in either direction** fails in CI instead of in a user's hands.

- [x] Verified to **fail against the build that shipped in v0.9.5**: `wheel delta -1 came back as -255`
- [x] Passes with the fix
- [x] Full suite: 204 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- [x] **Live-verified** on a real macOS Windows App session — scroll down now matches scroll up

Divergence (17) is marked RETIRED in the vendored divergence log, with the history and an explicit "if upstream ever regresses, fix it in `ironrdp-pdu` — do NOT reintroduce a compensation here".

🤖 Generated with [Claude Code](https://claude.com/claude-code)