### PR TITLE
fix(ironrdp-server): a silent peer can wedge the accept loop — bound the preemption probe

### DIFF
--- a/src/conn_test.rs
+++ b/src/conn_test.rs
@@ -1005,6 +1005,81 @@ async fn a_just_evicted_peer_cannot_immediately_preempt_back() -> anyhow::Result
         .await
 }
 
+/// A silent candidate MUST NOT be able to wedge the accept loop.
+///
+/// `negotiate_candidate` blocks on socket reads from a peer that has not
+/// authenticated. Before `CANDIDATE_NEGOTIATION_TIMEOUT` /
+/// `CANDIDATE_HANDOFF_GRACE` (vendored divergence 23) the probe was awaited
+/// unbounded: a peer that completed the TCP handshake and then sent NOTHING
+/// parked it forever, and once the live session ended the accept loop blocked
+/// on the handoff await with no `select!` left — no further accepts, no event
+/// drain, so the server stopped answering entirely until restarted. That is an
+/// unauthenticated remote denial of service, and the health watchdog does not
+/// catch it (the tokio runtime stays healthy; only the accept loop is stuck).
+///
+/// Drive exactly that: a live session, a silent candidate, end the session, and
+/// require the server to still accept a fresh client afterwards.
+#[tokio::test]
+async fn a_silent_candidate_cannot_wedge_the_accept_loop() -> anyhow::Result<()> {
+    init_tracing();
+
+    let probe = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+    let addr = probe.local_addr()?;
+    drop(probe);
+
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            let mut server = build_test_server_full(
+                addr.port(),
+                1024,
+                768,
+                true,
+                None,
+                crate::bitmap_codecs(),
+                true,
+            );
+            let server_task = tokio::task::spawn_local(async move {
+                let _ = server.run().await;
+            });
+
+            // A: the live session.
+            let a = connect_with_retry(addr).await?;
+            let (_size_a, framed_a) = connect_client(a, 1280, 800).await?;
+
+            // B: connects and says NOTHING, parking the candidate probe
+            // mid-negotiation.
+            let _silent = connect_with_retry(addr).await?;
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+            // The live session ends. This is the branch that used to await the
+            // probe unbounded and never come back.
+            drop(framed_a);
+
+            // The server must still accept and serve a fresh client. With the
+            // unbounded await this never completes.
+            let c = connect_with_retry(addr).await?;
+            let served = tokio::time::timeout(
+                std::time::Duration::from_secs(15),
+                connect_client(c, 1280, 800),
+            )
+            .await;
+            let outcome = match &served {
+                Ok(Ok(_)) => "served",
+                Ok(Err(e)) => &format!("handshake error: {e}"),
+                Err(_) => "TIMED OUT — the loop never accepted it",
+            };
+            assert!(
+                matches!(served, Ok(Ok(_))),
+                "the accept loop was wedged by an unauthenticated silent peer; a later client got {outcome}"
+            );
+
+            server_task.abort();
+            anyhow::Ok(())
+        })
+        .await
+}
+
 /// The listener needs a moment to bind after `run()` is spawned; retry briefly
 /// so the test isn't racy on a loaded machine.
 async fn connect_with_retry(addr: SocketAddr) -> anyhow::Result<tokio::net::TcpStream> {

--- a/vendor/ironrdp-server/CLAUDE.md
+++ b/vendor/ironrdp-server/CLAUDE.md
@@ -1733,3 +1733,54 @@ AND released — #1276 landing is NOT sufficient. ((7) was HARVESTED at the a5d1
     survives; note every loopback peer is 127.0.0.1, which is exactly the
     source-IP key the net uses). Both verified to fail without their
     respective fix and pass with it.
+
+    **AMENDMENT 2026-08-09 — three bugs in the above, found by the automated
+    reviewer on the upstream PR (Devolutions/IronRDP#1476) and confirmed
+    present here.** The upstream and vendored copies had drifted only
+    cosmetically, so all three applied verbatim:
+
+    (a) **CRITICAL — unauthenticated remote hang of the accept loop.**
+        `negotiate_candidate` blocks on socket reads, and `PreemptRace::Ended`
+        did a bare `pending = probe.await`. A peer that completed the TCP
+        handshake, cleared `on_accept` and then sent NOTHING parked
+        `accept_begin` forever: accepts were already disabled for the rest of
+        the session (the accept arm is gated on `!probing`), and once the live
+        session ended the loop blocked on that await with no `select!` left —
+        no accepts, no event drain, so not even `ServerEvent::Quit` could stop
+        the server. One silent TCP connection wedged the listener until the
+        process was restarted. **The health watchdog does NOT catch this**: the
+        tokio runtime stays healthy and its probe still runs; only the accept
+        loop is stuck, so `src/health.rs` sees nothing wrong. Fixed with TWO
+        deliberately separate bounds — `CANDIDATE_NEGOTIATION_TIMEOUT` (10 s)
+        caps the negotiation itself, and `CANDIDATE_HANDOFF_GRACE` (750 ms)
+        caps the post-session-end wait, which is the window where the loop
+        services nothing at all. Capping only the first is NOT enough (the
+        loop is then deaf for the full negotiation budget). A candidate that
+        can't finish inside the grace is dropped and simply reconnects.
+
+    (b) **The eviction event could kill the WINNER.**
+        `EvictedByOtherConnection` rides the server-global `ev_sender` but is
+        consumed by whichever connection drains it next. An incumbent too
+        wedged to take it within `EVICTION_GRACE` — and being wedged is
+        precisely why it is being evicted — left it queued, and the winner's
+        `client_loop` then drained it and disconnected itself, putting a bogus
+        `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION` on the wire to the client
+        that had just taken over. `RdpServer::discard_stale_eviction_events()`
+        drops leftovers immediately before serving a winner, re-queuing every
+        other event in arrival order (collect-then-resend, so the re-sends
+        don't land back in the queue being drained).
+
+    (c) **The anti-storm cooldown locked out its own headline case.** The
+        re-arm had no cap, so a client whose link dropped could never reclaim
+        its own stale session while auto-reconnecting — exactly the scenario
+        this feature exists for. `REPREEMPT_MAX_LOCKOUT` (30 s) bounds it from
+        the eviction; within the cap the re-arm still throttles a storm, past
+        it the bar lifts even under a continuing storm. The
+        `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION` notice remains the real fix
+        for the loop; this heuristic is only a backstop, so bounding it is the
+        right trade. `recently_evicted` is now `(IpAddr, evicted_at, last_try)`.
+
+    Covered by `src/conn_test.rs::a_silent_candidate_cannot_wedge_the_accept_loop`
+    (live session + a silent candidate + session end → a later client must
+    still be served), verified to fail without the fix — it times out with
+    "the loop never accepted it" — and pass with it.

--- a/vendor/ironrdp-server/src/server.rs
+++ b/vendor/ironrdp-server/src/server.rs
@@ -61,6 +61,37 @@ const EVICTION_GRACE: Duration = Duration::from_millis(750);
 /// so it filters retry storms without blocking a deliberate retake.
 const REPREEMPT_COOLDOWN: Duration = Duration::from_secs(5);
 
+/// (vendored, divergence 23) Absolute cap on that bar, measured from the
+/// eviction itself. The re-arm below is what stops a reconnect storm winning
+/// the session back, but left uncapped it also permanently locks out the
+/// feature's own headline case: a client whose link dropped, whose stale
+/// session is still live, auto-reconnecting to reclaim it. Past this cap the
+/// bar lifts even under a continuing storm — by then the evicted peer has had
+/// its `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION`, which is the real fix.
+const REPREEMPT_MAX_LOCKOUT: Duration = Duration::from_secs(30);
+
+/// (vendored, divergence 23) How long a candidate gets to complete negotiation
+/// and authentication before it is abandoned.
+///
+/// LOAD-BEARING, not tidiness: `negotiate_candidate` blocks on socket reads
+/// from an as-yet-unauthenticated peer. Without this bound, a peer that
+/// completes the TCP handshake and then sends NOTHING parks the probe forever
+/// — which stalls accepts for the rest of the session (the accept arm is gated
+/// on `!probing`) and, once the live session ends, hangs the accept loop on the
+/// handoff await with no way left to observe `ServerEvent::Quit`. Generous for
+/// TLS + CredSSP over a slow link; sub-second on a healthy one.
+const CANDIDATE_NEGOTIATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// (vendored, divergence 23) How long the accept loop waits, AFTER the live
+/// session has ended, for a candidate still mid-negotiation.
+///
+/// Deliberately short and separate from `CANDIDATE_NEGOTIATION_TIMEOUT`: during
+/// this wait the loop services nothing — no accepts, no `ServerEvent`s, not
+/// even `Quit` — so it is the window in which an unauthenticated peer can make
+/// the server look hung. A candidate that cannot finish within it is dropped
+/// and simply reconnects; holding the whole listener for it is the worse trade.
+const CANDIDATE_HANDOFF_GRACE: Duration = Duration::from_millis(750);
+
 /// (vendored, divergence 22) What resolved first while a session was live: the
 /// session itself ending, a new inbound connection, or the verdict on a
 /// previously accepted candidate. The `select!` yields one of these and does
@@ -480,7 +511,7 @@ pub struct RdpServer {
     /// cadence) therefore can never win the session back, while a human who
     /// closes and reconnects — a gap far longer than
     /// [`REPREEMPT_COOLDOWN`] — still can. Cleared once a takeover sticks.
-    recently_evicted: Option<(IpAddr, Instant)>,
+    recently_evicted: Option<(IpAddr, Instant, Instant)>,
     // (vendored, divergence 22) `Rc<RefCell<..>>`, not a bare `Option<Box<..>>`:
     // the preemption race in `run()` needs to call `on_accept` on a candidate
     // while `self` is ALSO mutably borrowed for the whole race by the live
@@ -939,6 +970,32 @@ struct NegotiatedCandidate {
 /// ever sees) and takes `&NegotiationContext` instead, precisely so it can
 /// run alongside a live `&mut self` borrow. Keep the two in sync by hand if
 /// the negotiation sequence ever changes upstream.
+/// (vendored, divergence 23) [`negotiate_candidate`] under a hard deadline.
+///
+/// The negotiation blocks on socket reads from an as-yet-unauthenticated peer,
+/// so it MUST NOT be awaited unbounded anywhere in the accept loop: a peer that
+/// connects and then says nothing would otherwise stall accepts for the rest of
+/// the session and hang the loop outright once the session ended. A timeout is
+/// treated exactly like a failed negotiation — the candidate is dropped and the
+/// live session is untouched.
+async fn negotiate_candidate_bounded(
+    ctx: &NegotiationContext,
+    stream: TcpStream,
+    peer: SocketAddr,
+) -> Option<NegotiatedCandidate> {
+    match tokio::time::timeout(CANDIDATE_NEGOTIATION_TIMEOUT, negotiate_candidate(ctx, stream, peer)).await {
+        Ok(candidate) => candidate,
+        Err(_) => {
+            debug!(
+                ?peer,
+                timeout = ?CANDIDATE_NEGOTIATION_TIMEOUT,
+                "candidate did not finish negotiating in time — abandoning it, the live session is untouched"
+            );
+            None
+        }
+    }
+}
+
 async fn negotiate_candidate(
     ctx: &NegotiationContext,
     stream: TcpStream,
@@ -1419,6 +1476,45 @@ impl RdpServer {
 
     /// (vendored, divergence 23) Build a cheap, `Rc`/`Arc`-cloned snapshot for
     /// a candidate's concurrent negotiation — see [`NegotiationContext`].
+    /// (vendored, divergence 23) Drop any `EvictedByOtherConnection` still
+    /// queued on the server-global event channel, putting every other event
+    /// back in arrival order.
+    ///
+    /// Called immediately before serving a preemption winner. The eviction
+    /// event is addressed to the connection being replaced, but the channel is
+    /// shared across connections and read by whoever drains it next — so an
+    /// event the outgoing session never got around to consuming would be
+    /// delivered to its replacement, which would dutifully disconnect itself.
+    async fn discard_stale_eviction_events(&mut self) {
+        use tokio::sync::mpsc::error::TryRecvError;
+
+        let ev_receiver = Arc::clone(&self.ev_receiver);
+        let mut ev_receiver = ev_receiver.lock().await;
+
+        // Collect first, re-send after: re-sending during the drain would push
+        // events onto the back of the very queue being drained.
+        let mut keep = Vec::new();
+        let mut discarded = 0usize;
+        loop {
+            match ev_receiver.try_recv() {
+                Ok(ServerEvent::EvictedByOtherConnection) => discarded += 1,
+                Ok(other) => keep.push(other),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            }
+        }
+
+        if discarded > 0 {
+            debug!(
+                discarded,
+                "dropped eviction events the replaced session never consumed — they must not reach its replacement"
+            );
+        }
+
+        for event in keep {
+            let _ = self.ev_sender.send(event);
+        }
+    }
+
     fn negotiation_context(&self) -> NegotiationContext {
         NegotiationContext {
             opts: self.opts.clone(),
@@ -1727,7 +1823,18 @@ impl RdpServer {
             }
 
             let entry = match pending.take() {
-                Some((candidate, peer)) => Entry::Negotiated(candidate, peer),
+                Some((candidate, peer)) => {
+                    // The eviction event rides the server-global channel but is
+                    // consumed by whichever connection drains it next. If the
+                    // incumbent was too wedged to take it within
+                    // `EVICTION_GRACE` (being wedged is why it was evicted),
+                    // it is still queued now — and the WINNER's `client_loop`
+                    // would drain it and disconnect itself, reporting a bogus
+                    // `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION` to the client
+                    // that just took over. Drop leftovers; requeue the rest.
+                    self.discard_stale_eviction_events().await;
+                    Entry::Negotiated(candidate, peer)
+                }
                 None => {
                     let ev_receiver = Arc::clone(&self.ev_receiver);
                     let mut ev_receiver = ev_receiver.lock().await;
@@ -1884,7 +1991,20 @@ impl RdpServer {
                                     // anyone) — hand it straight to the next
                                     // iteration.
                                     let peer = probing_peer.expect("probing implies probing_peer is set");
-                                    pending = probe.await.map(|candidate| (candidate, peer));
+                                    // BOUNDED: nothing else is serviced during
+                                    // this await, so a candidate that is not
+                                    // nearly done is dropped rather than
+                                    // allowed to stall the listener.
+                                    pending = match tokio::time::timeout(CANDIDATE_HANDOFF_GRACE, &mut probe).await {
+                                        Ok(candidate) => candidate.map(|c| (c, peer)),
+                                        Err(_) => {
+                                            debug!(
+                                                ?peer,
+                                                "a candidate was still negotiating when the session ended —                                                  dropping it rather than stalling the accept loop; it can reconnect"
+                                            );
+                                            None
+                                        }
+                                    };
                                 }
                                 break (res, None);
                             }
@@ -1908,8 +2028,14 @@ impl RdpServer {
                                 // net under `EvictedByOtherConnection`, which
                                 // is what should normally stop the loop.
                                 let bounced_back = match &mut recently_evicted {
-                                    Some((ip, last_try)) if *ip == next_peer.ip() => {
-                                        let within = last_try.elapsed() < REPREEMPT_COOLDOWN;
+                                    Some((ip, evicted_at, last_try)) if *ip == next_peer.ip() => {
+                                        // Capped: the re-arm throttles a storm,
+                                        // but must not bar a peer forever —
+                                        // that locks out the very case this
+                                        // feature exists for (a dropped client
+                                        // reclaiming its own stale session).
+                                        let within = last_try.elapsed() < REPREEMPT_COOLDOWN
+                                            && evicted_at.elapsed() < REPREEMPT_MAX_LOCKOUT;
                                         if within {
                                             *last_try = Instant::now();
                                         }
@@ -1922,7 +2048,10 @@ impl RdpServer {
                                 if candidate_accepted {
                                     probing = true;
                                     probing_peer = Some(next_peer);
-                                    probe = Box::pin(negotiate_candidate(&ctx, next_stream, next_peer));
+                                    // BOUNDED: see `CANDIDATE_NEGOTIATION_TIMEOUT`.
+                                    // An unbounded probe is a remote hang of
+                                    // the whole accept loop.
+                                    probe = Box::pin(negotiate_candidate_bounded(&ctx, next_stream, next_peer));
                                 } else if bounced_back {
                                     info!(
                                         ?next_peer,
@@ -1964,7 +2093,8 @@ impl RdpServer {
                                         let _ = self_ev_sender.send(ServerEvent::EvictedByOtherConnection);
                                         // Arm the net against this peer
                                         // bouncing straight back in.
-                                        recently_evicted = Some((peer.ip(), Instant::now()));
+                                        let now = Instant::now();
+                                        recently_evicted = Some((peer.ip(), now, now));
                                         // Keep polling the incumbent so it can
                                         // observe the event, write the PDU and
                                         // return on its own. Bounded, because a


### PR DESCRIPTION
## Summary

Three bugs in vendored divergence (23) (second-client preemption), found by the automated reviewer on the upstream PR [Devolutions/IronRDP#1476](https://github.com/Devolutions/IronRDP/pull/1476) and confirmed present here — the upstream and vendored copies had drifted only cosmetically, so all three applied verbatim.

### (a) CRITICAL — unauthenticated remote hang of the accept loop

`negotiate_candidate` blocks on socket reads, and `PreemptRace::Ended` did a bare `pending = probe.await`. A peer that completed the TCP handshake, cleared `on_accept`, and then **sent nothing** parked `accept_begin` forever:

- accepts were already disabled for the rest of the session (the accept arm is gated on `!probing`), and
- once the live session ended, the loop blocked on that await with **no `select!` left** — no accepts, no event drain, so not even `ServerEvent::Quit` could stop the server.

One silent TCP connection to port 3390 wedged the listener until the process was restarted. **The health watchdog does not catch this** — the tokio runtime stays healthy and its probe still runs; only the accept loop is stuck, so `src/health.rs` sees nothing wrong.

Fixed with **two deliberately separate bounds**: `CANDIDATE_NEGOTIATION_TIMEOUT` (10 s) caps the negotiation, and `CANDIDATE_HANDOFF_GRACE` (750 ms) caps the post-session-end wait — the window where the loop services nothing at all. Capping only the negotiation is **not** enough (the loop is then deaf for the full budget; the regression test caught exactly that). A candidate that can't finish inside the grace is dropped and simply reconnects.

### (b) The eviction event could kill the WINNER

`EvictedByOtherConnection` rides the server-global `ev_sender` but is consumed by whichever connection drains it next. An incumbent too wedged to take it within `EVICTION_GRACE` — and being wedged is precisely why it's being evicted — left it queued, and the **winner's** `client_loop` then drained it and disconnected itself, putting a bogus `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION` on the wire to the client that had just taken over.

`discard_stale_eviction_events()` drops leftovers immediately before serving a winner, re-queuing every other event in arrival order (collect-then-resend, so re-sends don't land back in the queue being drained).

### (c) The anti-storm cooldown locked out its own headline case

The re-arm had no cap, so a client whose link dropped could **never** reclaim its own stale session while auto-reconnecting — exactly the scenario the feature exists for. `REPREEMPT_MAX_LOCKOUT` (30 s) bounds it from the eviction; within the cap the re-arm still throttles a storm, past it the bar lifts. The `ERRINFO_DISCONNECTED_BY_OTHERCONNECTION` notice remains the real fix for the loop — this heuristic is only a backstop, so bounding it is the right trade.

## Test

- [x] New `conn_test::a_silent_candidate_cannot_wedge_the_accept_loop` — live session + silent candidate + session end → a later client must still be served
- [x] Verified to **fail without the fix**: times out with *"the loop never accepted it"*
- [x] All 11 existing `conn_test` preemption tests still pass
- [x] Full suite: 204 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- [x] **Live-verified** on the deployed build: a silent connection was accepted and abandoned without disturbing the live session, and subsequent connections were still served

Divergence (23) in the vendored log carries an amendment documenting all three, including the note that the health watchdog would not have caught (a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)